### PR TITLE
Hook up getMarketsAsync to the Flux actions

### DIFF
--- a/app/actions/MarketActions.js
+++ b/app/actions/MarketActions.js
@@ -4,15 +4,17 @@ var constants = require('../libs/constants');
 var MarketActions = {
 
   loadMarkets: function () {
+    this.dispatch(constants.market.LOAD_MARKETS);
+
     var branchState = this.flux.store('branch').getState();
     var configState = this.flux.store('config').getState();
     var account = this.flux.store('network').getAccount();
 
     var branchId = branchState.currentBranch;
     var ethereumClient = configState.ethereumClient;
-    var markets = ethereumClient.getMarkets(branchId);
-
-    this.dispatch(constants.market.LOAD_MARKETS_SUCCESS, {markets: markets});
+    ethereumClient.getMarketsAsync(branchId, (markets) => {
+      this.dispatch(constants.market.LOAD_MARKETS_SUCCESS, {markets: markets});
+    });
   }
 };
 

--- a/app/clients/EthereumClient.js
+++ b/app/clients/EthereumClient.js
@@ -366,7 +366,7 @@ EthereumClient.prototype.getMarketsAsync = function (branchId, callback) {
   }).then((marketIds) => {
     var marketPromises = _.map(marketIds, (marketId) => {
       return new Promise((resolve) => {
-        this.getMarket(branchId, marketId);
+        this.getMarket(branchId, marketId, resolve);
       });
     });
 

--- a/app/clients/EthereumClient.js
+++ b/app/clients/EthereumClient.js
@@ -276,7 +276,7 @@ EthereumClient.prototype.getOutcome = function (marketId, outcomeId, currentPart
     })
   ];
 
-  // Merge all the attributes pass the result to the callback.
+  // Merge all the attributes and pass the result to the callback.
   Promise.all(outcomeAttributePromises).then((attributesList) => {
     callback(_.reduce(attributesList, _.merge));
   });
@@ -344,7 +344,7 @@ EthereumClient.prototype.getMarket = function (branchId, marketId, callback) {
     })
   ];
 
-  // Merge all the attributes pass the result to the callback.
+  // Merge all the attributes and pass the result to the callback.
   Promise.all(marketAttributePromises).then(function (attributesList) {
     var market = _.reduce(attributesList, _.merge);
     market.id = marketId;

--- a/app/libs/constants.js
+++ b/app/libs/constants.js
@@ -34,6 +34,7 @@ module.exports = {
     UPDATE_CURRENT_BRANCH: null
   }),
   market: keyMirror({
+    LOAD_MARKETS: null,
     LOAD_MARKETS_SUCCESS: null
   }),
   event: keyMirror({

--- a/app/stores/MarketStore.js
+++ b/app/stores/MarketStore.js
@@ -2,12 +2,14 @@ var Fluxxor = require('fluxxor');
 var constants = require('../libs/constants');
 
 var state = {
-  markets: {}
+  markets: {},
+  loading: false
 };
 
 var MarketStore = Fluxxor.createStore({
   initialize: function () {
     this.bindActions(
+      constants.market.LOAD_MARKETS, this.handleLoadMarkets,
       constants.market.LOAD_MARKETS_SUCCESS, this.handleLoadMarketsSuccess
     );
   },
@@ -16,7 +18,13 @@ var MarketStore = Fluxxor.createStore({
     return state;
   },
 
+  handleLoadMarkets: function (payload) {
+    state.loading = true;
+    this.emit(constants.CHANGE_EVENT);
+  },
+
   handleLoadMarketsSuccess: function (payload) {
+    state.loading = false;
     state.markets = payload.markets;
     this.emit(constants.CHANGE_EVENT);
   }


### PR DESCRIPTION
This modifies getMarketsAsync to use [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) to make the code more readable, in my opinion. If you guys agree, I hope this is a useful example to work from.

In the market store, I added a `loading` field so the UI can reflect the loading state if we decide to later. Otherwise, the old store would've worked fine with the update to the action that dispatches `LOAD_MARKETS_SUCCESS` in a callback instead of synchronously.

This code hasn't been run. Hopefully geth's invalid block issues will go away tomorrow.