### PR TITLE
market: add a twitter share button

### DIFF
--- a/app/components/Market.jsx
+++ b/app/components/Market.jsx
@@ -93,6 +93,11 @@ var Market = React.createClass({
         </div>
         <div className='row'>
           <div className='col-xs-12'>
+            <Twitter marketName={ market.description } />
+          </div>
+        </div>
+        <div className='row'>
+          <div className='col-xs-12'>
             <Comments comments={ market.comments } account={ this.state.account } />
           </div>
         </div>
@@ -100,6 +105,30 @@ var Market = React.createClass({
     );
   }
 });
+
+class Twitter extends React.Component {
+  componentDidMount() {
+    // load twitter widget js
+    !function(d,s,id){
+      var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';
+      if(!d.getElementById(id)){
+        js=d.createElement(s);
+        js.id=id;
+        js.src=p+'://platform.twitter.com/widgets.js';
+        fjs.parentNode.insertBefore(js,fjs);
+      }
+    }(document, 'script', 'twitter-wjs');
+  }
+
+  render() {
+    let tweet = this.props.marketName;
+    return (
+      <div className="twitter-share-block">
+        <a href="https://twitter.com/share" className="twitter-share-button" data-text={ tweet } data-via="AugurProject" data-hashtags="CashPrediction">Tweet</a>
+      </div>
+    )
+  }
+}
 
 var Comments = React.createClass({
 

--- a/app/css/augur.css
+++ b/app/css/augur.css
@@ -703,6 +703,9 @@ background: linear-gradient(to bottom, rgba(24,55,111,0) 0%,rgba(24,55,111,0.7) 
     top: 5px;
     right: 8px;
 }
+#market .twitter-share-block {
+    margin: 10px;
+}
 
 #account h3 {
     margin-bottom: 0px;


### PR DESCRIPTION
Market names that are longer than 83 characters will be too long to tweet. For now, we just rely on the user to shorten the tweet as needed.

The format of the tweet is currently:
"[market name] \#CashPrediction [market url] via @AugurProject"

Note that when testing on localhost, twitter won't url-shorten, so the tweet will typically be too long. You can modify the domain to anything else to see the real tweet length.