### PR TITLE
grunt watchify notices .js files now

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,7 @@ config.browserify.build = {
   dest: 'app/app.js',
   options: {
     browserifyOptions: {
-      extensions: ['.jsx'],
+      extensions: ['.jsx', '.js'],
       transform: [
         ['babelify', {}],
         ['envify', config.envify.build]

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babelify": "^6.1.1",
     "bignumber.js": "^2.0.7",
     "bootstrap": "^3.3.4",
-    "browserify": "^9.0.8",
+    "browserify": "^10.2.4",
     "envify": "^3.4.0",
     "es6-promise": "^2.0.1",
     "fluxxor": "^1.6.0",


### PR DESCRIPTION
Also, browserify.watch seemed to lose track of files after a while.  There's supposed to be a recent-ish fix, and I haven't seen the issue since upgrading.