### PR TITLE
shouldComponentUpdate must strictly return boolean

### DIFF
--- a/app/components/Markets.jsx
+++ b/app/components/Markets.jsx
@@ -43,7 +43,7 @@ class MarketPane extends React.Component {
       if (this.lastMarket[attr] != nextProps.market[attr])
         return true;
     }
-    return (this.props.currentBranch != nextProps.currentBranch ||
+    return Boolean(this.props.currentBranch != nextProps.currentBranch ||
       (nextProps.currentBranch &&
        this.props.currentBranch.currentPeriod != nextProps.currentBranch.currentPeriod));
   }


### PR DESCRIPTION
This was causing warnings about returning undefined.

I'm away from my dev machine, but this should fix it.