### PR TITLE
Show full author in market on mouse over (issue #174)

### DIFF
--- a/app/components/Market.jsx
+++ b/app/components/Market.jsx
@@ -22,6 +22,12 @@ var Market = React.createClass({
 
   mixins: [FluxMixin, StoreWatchMixin('market', 'asset', 'branch', 'config')],
 
+  getInitialState: function() {
+    return {
+      fullAuthor: false
+    }
+  },
+
   getStateFromFlux: function () {
     var flux = this.getFlux();
 
@@ -48,6 +54,14 @@ var Market = React.createClass({
       blockNumber: flux.store('network').getState().blockNumber,
       commentFilter: (market && market.id) ? augur.comments.initComments(abi.hex(market.id)) : null
     };
+  },
+
+  showFullAuthor: function() {
+    this.setState({fullAuthor: true});
+  },
+
+  truncateAuthor: function() {
+    this.setState({fullAuthor: false});
   },
 
   render: function () {
@@ -174,7 +188,7 @@ var Market = React.createClass({
           <p className='alt'>Outstanding shares: <b>{ outstandingShares }</b></p>
           <p>Fee: <b>{ tradingFee }</b></p>
           <p className='alt'>Traders: <b>{ traderCount }</b></p>
-          <p>Author: <b className='truncate author'>{ author }</b></p>
+          <p onMouseEnter={this.showFullAuthor} onMouseLeave={this.truncateAuthor}>Author: <b className={this.state.fullAuthor ? 'no-truncate author-full' : 'truncate author'}>{ author }</b></p>
           <p className='alt'>Creation date: <b>{ formattedCreationDate }</b></p>
           <p>End date: <b>{ formattedDate }</b></p>
         </div>

--- a/app/css/augur.css
+++ b/app/css/augur.css
@@ -122,6 +122,10 @@ h1, h2, h3, h4, h5 {
     text-overflow: ellipsis;
 }
 
+.no-truncate {
+    word-wrap: break-word;
+}
+
 p.address {
     font-size: 12px;
     background-color: #333;
@@ -712,6 +716,10 @@ background: linear-gradient(to bottom, rgba(24,55,111,0) 0%,rgba(24,55,111,0.7) 
 }
 #market .details .author {
     text-align: right;
+    width: 75%;
+}
+#market .details .author-full {
+    text-align: left;
     width: 75%;
 }
 #market .comments {


### PR DESCRIPTION
For issue #174 - mouse over the author expands the field and shows the full author account, mouse out collapses it back. Also tested on a tablet and clicking in expands it, clicking elsewhere collapses it (as expected).