### PR TITLE
Remove extra `npm install eslint` command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ addons:
 
 before_script:
   - npm install
-  - npm install eslint
 
 script:
   - npm run lint


### PR DESCRIPTION
eslint was [updated to version 3](https://github.com/eslint/eslint/releases/tag/v3.0.0). Since package.json specifies version 2 this command make travis [fail](https://travis-ci.org/AugurProject/augur/builds/141753170#L751)