### PR TITLE
on authoritative lookups of account trades, purge local trade state a…

### DIFF
--- a/src/modules/auth/actions/load-login-account.js
+++ b/src/modules/auth/actions/load-login-account.js
@@ -32,7 +32,7 @@ export function loadLoginAccountDependents() {
 }
 
 export function loadLoginAccountLocalStorage(accountID) {
-	return (dispatch, getState) => {
+	return dispatch => {
 		const localStorageRef = typeof window !== 'undefined' && window.localStorage;
 
 		if (!localStorageRef || !localStorageRef.getItem || !accountID) {
@@ -49,6 +49,7 @@ export function loadLoginAccountLocalStorage(accountID) {
 			dispatch(updateFavorites(localState.favorites));
 		}
 		if (localState.accountTrades) {
+			dispatch(clearAccountTrades());
 			dispatch(updateAccountTradesData(localState.accountTrades));
 		}
 		if (localState.reports && Object.keys(localState.reports).length) {

--- a/src/modules/my-positions/actions/load-account-trades.js
+++ b/src/modules/my-positions/actions/load-account-trades.js
@@ -1,5 +1,6 @@
 import { augur } from '../../../services/augurjs';
 import { updateAccountTradesData } from '../../../modules/my-positions/actions/update-account-trades-data';
+import { clearAccountTrades } from '../../../modules/my-positions/actions/clear-account-trades';
 
 export function loadAccountTrades() {
 	return (dispatch, getState) => {
@@ -8,6 +9,7 @@ export function loadAccountTrades() {
 				if (accountTrades.error) {
 					return console.warn('ERROR loadAccountTrades', accountTrades);
 				}
+				dispatch(clearAccountTrades());
 				dispatch(updateAccountTradesData(accountTrades));
 			}
 		});

--- a/src/modules/my-positions/actions/update-account-trades-data.js
+++ b/src/modules/my-positions/actions/update-account-trades-data.js
@@ -2,7 +2,7 @@ export const UPDATE_ACCOUNT_TRADES_DATA = 'UPDATE_ACCOUNT_TRADES_DATA';
 import { loadMarketsInfo } from '../../markets/actions/load-markets-info';
 
 export function updateAccountTradesData(data) {
-	return (dispatch, getState) => {
+	return dispatch => {
 		const accountTradesMarketIDs = Object.keys(data);
 		dispatch(loadMarketsInfo(accountTradesMarketIDs));
 		dispatch({ type: UPDATE_ACCOUNT_TRADES_DATA, data });


### PR DESCRIPTION
…nd replace with data from contract (has the affect of removing stale trades outside the context of our current listeners) + cleanup