### PR TITLE
Fixes Sign Out Link, changed when fund new account occurs

### DIFF
--- a/src/modules/auth/actions/register.js
+++ b/src/modules/auth/actions/register.js
@@ -31,6 +31,7 @@ export function register(name, password, password2, loginID, rememberMe, loginAc
 			dispatch(loadLoginAccountLocalStorage(loginAccount.id));
 			dispatch(updateLoginAccount(loginAccount));
 			dispatch(loadLoginAccountDependents());
+			setTimeout(() => dispatch(addFundNewAccount(loginAccount.address)), 1500);
 
 			return links.marketsLink.onClick(links.marketsLink.href);
 		}
@@ -49,8 +50,8 @@ export function register(name, password, password2, loginID, rememberMe, loginAc
 				return;
 			}
 
-			dispatch(addFundNewAccount(localLoginAccount.address));
 			dispatch(updateLoginAccount({ loginID: localLoginAccount.loginID }));
+			// dispatch(addFundNewAccount(localLoginAccount.address));
 
 			if (typeof cb === 'function') {
 				cb(localLoginAccount);

--- a/src/modules/auth/actions/register.js
+++ b/src/modules/auth/actions/register.js
@@ -10,6 +10,8 @@ import {
 import { authError } from '../../auth/actions/auth-error';
 import { updateLoginAccount } from '../../auth/actions/update-login-account';
 import { addFundNewAccount } from '../../transactions/actions/add-fund-new-account-transaction';
+import isCurrentLoginMessageRead from '../../login-message/helpers/is-current-login-message-read';
+import isUserLoggedIn from '../../auth/helpers/is-user-logged-in';
 
 export function register(name, password, password2, loginID, rememberMe, loginAccount, cb) {
 	return (dispatch, getState) => {
@@ -27,11 +29,15 @@ export function register(name, password, password2, loginID, rememberMe, loginAc
 				}
 				localStorageRef.setItem('account', JSON.stringify(persistentAccount));
 			}
-
 			dispatch(loadLoginAccountLocalStorage(loginAccount.id));
 			dispatch(updateLoginAccount(loginAccount));
 			dispatch(loadLoginAccountDependents());
 			setTimeout(() => dispatch(addFundNewAccount(loginAccount.address)), 1500);
+			// decide if we need to display the loginMessage
+			const { loginMessage } = getState();
+			if (isUserLoggedIn(loginAccount) && !isCurrentLoginMessageRead(loginMessage)) {
+				return links.loginMessageLink.onClick();
+			}
 
 			return links.marketsLink.onClick(links.marketsLink.href);
 		}

--- a/src/modules/link/selectors/links.js
+++ b/src/modules/link/selectors/links.js
@@ -51,7 +51,7 @@ export const selectPreviousLink = memoizerific(1)((dispatch) => {
 });
 
 export const selectAuthLink = memoizerific(1)((authType, alsoLogout, dispatch) => {
-	const href = makeLocation({ page: authType }).url;
+	const href = alsoLogout ? makeLocation({ page: 'login' }).url : makeLocation({ page: authType }).url;
 	return {
 		href,
 		onClick: () => {

--- a/test/auth/actions/register-test.js
+++ b/test/auth/actions/register-test.js
@@ -29,7 +29,7 @@ describe(`modules/auth/actions/register.js`, () => {
 	const ldLoginAccStub = {};
 	const autoStub = {};
 
-	let action, store;
+	let action, clock, store;
 	let thisTestState = Object.assign({}, testState, {
 		loginAccount: {}
 	});
@@ -74,16 +74,16 @@ describe(`modules/auth/actions/register.js`, () => {
 
 	beforeEach(() => {
 		store.clearActions();
+		clock = sinon.useFakeTimers();
 	});
 
 	afterEach(() => {
 		store.clearActions();
+		clock.restore();
 	});
 
 	it(`should register a new account`, () => {
 		const expectedOutput = [{
-				type: 'FUND_NEW_ACCOUNT'
-			}, {
 				type: 'updateLoginAccount(loginAccount) called.'
 			}, {
 				type: 'loadLoginAccountLocalStorage(id) called.'
@@ -91,11 +91,15 @@ describe(`modules/auth/actions/register.js`, () => {
 				type: 'updateLoginAccount(loginAccount) called.'
 			}, {
 				type: 'loadLoginAccountDependents() called.'
+			},{
+				type: 'FUND_NEW_ACCOUNT'
 		}];
 
 		store.dispatch(action.register('newUser', 'Passw0rd', 'Passw0rd', undefined, false, undefined, fakeCallback));
 		// Call again to simulate someone pasting loginID and then hitting signUp
 		store.dispatch(action.register('newUser', 'Passw0rd', 'Passw0rd', testState.loginAccount.loginID, false, testState.loginAccount, undefined));
+
+		clock.tick(2000);
 
 		assert(fakeCallback.calledOnce, `the callback wasn't triggered 1 time as expected`);
 		assert(fakeFund.addFundNewAccount.calledOnce, `addFundNewAccount wasn't called once as expected`);

--- a/test/auth/actions/register-test.js
+++ b/test/auth/actions/register-test.js
@@ -49,7 +49,10 @@ describe(`modules/auth/actions/register.js`, () => {
 	fakeSelectors.links = {
 		marketsLink: {
 			onClick: () => {}
-		}
+		},
+		loginMessageLink: {
+			onClick: () => {}
+		},
 	};
 	fakeAuthLink.selectAuthLink = (page, bool, dispatch) => {
 		return { onClick: () => {} };


### PR DESCRIPTION
Sign Out link now brings uses back to the login page after signing out. 

the fund new account action won't be triggered until after the user hits "sign in" after registering a new account. 