### PR TITLE
Market Page Links fix, ID's that have 0x or without will both now work.

### DIFF
--- a/src/modules/markets/reducers/selected-market-id.js
+++ b/src/modules/markets/reducers/selected-market-id.js
@@ -4,7 +4,11 @@ export default function (selectedMarketID = null, action) {
 	switch (action.type) {
 	case UPDATE_URL:
 		if (action.parsedURL.searchParams.m) {
-			return action.parsedURL.searchParams.m.split('_').pop();
+			let rawMarketID = action.parsedURL.searchParams.m.split('_').pop();
+			if (rawMarketID.indexOf('0x') !== 0) {
+				rawMarketID = '0x' + rawMarketID;
+			}
+			return rawMarketID;
 		}
 		return null;
 


### PR DESCRIPTION
Story ID 454 (https://app.clubhouse.io/augur/story/454/market-id-should-not-require-0x-prefix-in-url) This should fix that issue.