### PR TITLE
550 disable empty balances link

### DIFF
--- a/src/modules/link/selectors/links.js
+++ b/src/modules/link/selectors/links.js
@@ -30,6 +30,8 @@ export default function () {
 		myPositionsLink: selectMyPositionsLink(store.dispatch),
 		myMarketsLink: selectMyMarketsLink(store.dispatch),
 		myReportsLink: selectMyReportsLink(store.dispatch),
+		// Removed balances link for now, proper value is:
+		// selectBalancesLink(store.dispatch)
 		balancesLink: { href: '/', onClick: () => {} },
 		loginMessageLink: selectLoginMessageLink(loginAccount.id, loginMessage.version, store.dispatch)
 	};

--- a/src/modules/link/selectors/links.js
+++ b/src/modules/link/selectors/links.js
@@ -30,7 +30,7 @@ export default function () {
 		myPositionsLink: selectMyPositionsLink(store.dispatch),
 		myMarketsLink: selectMyMarketsLink(store.dispatch),
 		myReportsLink: selectMyReportsLink(store.dispatch),
-		balancesLink: selectBalancesLink(store.dispatch),
+		balancesLink: { href: '/', onClick: () => {} },
 		loginMessageLink: selectLoginMessageLink(loginAccount.id, loginMessage.version, store.dispatch)
 	};
 }


### PR DESCRIPTION
Simply disables the balances link. It does this by forcing the `balancesLink` object to always return a dummy `onClick` function that does nothing. This disables the UI from switching pages as the `onClick` function no longer changes the url.

https://app.clubhouse.io/augur/story/550/disable-link-to-empty-balances-page