### PR TITLE
Store the private key in an Airbitz wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "partial:index_filename": "[ $NODE_ENV != production ] && echo './build/index.html' || echo \"./build/index-$npm_package_version.html\""
   },
   "dependencies": {
-    "airbitz-core-js-ui": "0.0.10",
+    "airbitz-core-js-ui": "0.0.11",
     "async": "1.5.2",
     "augur-ui-react-components": "3.6.10",
     "augur.js": "3.0.16",

--- a/src/modules/auth/actions/login-with-airbitz.js
+++ b/src/modules/auth/actions/login-with-airbitz.js
@@ -1,3 +1,4 @@
+import secureRandom from 'secure-random';
 import { augur } from '../../../services/augurjs';
 import {
 	loadLoginAccountDependents,
@@ -7,36 +8,52 @@ import { updateLoginAccount } from '../../auth/actions/update-login-account';
 import { authError } from '../../auth/actions/auth-error';
 import { addFundNewAccount } from '../../transactions/actions/add-fund-new-account-transaction';
 
+const walletType = 'wallet:repo:ethereum';
+
+function loginWithEthereumWallet(dispatch, airbitzAccount, ethereumWallet) {
+	const { links } = require('../../../selectors');
+
+	const masterPrivateKey = ethereumWallet.keys.ethereumKey;
+	augur.web.loginWithMasterKey(airbitzAccount.username, masterPrivateKey, (account) => {
+		console.log(account);
+		if (!account) {
+			return dispatch(authError({ code: 0, message: 'failed to login' }));
+		} else if (account.error) {
+			return dispatch(authError({ code: account.error, message: account.message }));
+		}
+		const loginAccount = { ...account, id: account.address, airbitzAccount };
+		if (!loginAccount || !loginAccount.id) {
+			return;
+		}
+		dispatch(loadLoginAccountLocalStorage(loginAccount.id));
+		dispatch(updateLoginAccount(loginAccount));
+		dispatch(loadLoginAccountDependents((err, ether) => {
+			console.log('got:', err, ether);
+			if (err) return console.error('loadLoginAccountDependents:', err);
+			if (ether === 0) {
+				dispatch(addFundNewAccount(loginAccount.id));
+			}
+		}));
+		if (links && links.marketsLink)	{
+			links.marketsLink.onClick(links.marketsLink.href);
+		}
+	});
+}
+
 export function loginWithAirbitz(airbitzAccount) {
 	return (dispatch, getState) => {
-		const { links } = require('../../../selectors');
-
-		// XXX use dataKey for now as the masterPrivateKey. For production, this will need to be a key
-		// created and saved in a wallet repo inside the Augur account. -paul@airbitz.co
-		const masterPrivateKey = airbitzAccount.repoInfo.dataKey;
-		augur.web.loginWithMasterKey(airbitzAccount.username, masterPrivateKey, (account) => {
-			console.log(account);
-			if (!account) {
-				return dispatch(authError({ code: 0, message: 'failed to login' }));
-			} else if (account.error) {
-				return dispatch(authError({ code: account.error, message: account.message }));
-			}
-			const loginAccount = { ...account, id: account.address, airbitzAccount };
-			if (!loginAccount || !loginAccount.id) {
-				return;
-			}
-			dispatch(loadLoginAccountLocalStorage(loginAccount.id));
-			dispatch(updateLoginAccount(loginAccount));
-			dispatch(loadLoginAccountDependents((err, ether) => {
-				console.log('got:', err, ether);
-				if (err) return console.error('loadLoginAccountDependents:', err);
-				if (ether === 0) {
-					dispatch(addFundNewAccount(loginAccount.id));
-				}
-			}));
-			if (links && links.marketsLink)	{
-				links.marketsLink.onClick(links.marketsLink.href);
-			}
-		});
+		const ethereumWallet = airbitzAccount.getFirstWallet(walletType);
+		if (ethereumWallet == null) {
+			// Create an ethereum wallet if one doesn't exist:
+			const keys = {
+				ethereumKey: new Buffer(secureRandom(32)).toString('hex')
+			};
+			airbitzAccount.createWallet(walletType, keys, (err, id) => {
+				if (err) return dispatch(authError({ code: 0, message: 'could not create wallet' }));
+				loginWithEthereumWallet(dispatch, airbitzAccount, airbitzAccount.getWallet(id));
+			});
+		} else {
+			loginWithEthereumWallet(dispatch, airbitzAccount, ethereumWallet);
+		}
 	};
 }


### PR DESCRIPTION
Before, the integration was wrongly using the Airbitz account dataKey
as the Etherium private key. This worked, but was a mis-use of the dataKey.
The proper way to store asset keys is in a wallet, so do that instead.

This change will re-generate the private keys for all accounts logged in with Airbitz. So, those users will need to re-login once this goes in, losing access to assets stored with the previous key (dataKey).

If needed, we could put in a temporary hack that would simply transfer the existing key into the new storage location, giving users time to reclaim their assets, but Augur is still on testnet, so no real value should be lost. It is critically important that we get this code in before things switch to mainnet, though.