### PR TITLE
Add the packaging metadata to build the augur snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: augur-ui
+version: master
+summary: Augur front-end
+description: |
+  Augur is a decentralized prediction market platform built on Ethereum. This
+  is the reference client. It runs locally in your browser and communicates
+  directly with the ethereum network, without going through intermediate
+  servers.
+
+grade: devel
+confinement: strict
+
+apps:
+  server:
+    command: sh -c \"$SNAP/lib/node_modules/augur-ui && npm start\"
+    plugs: [network, network-bind]
+
+parts:
+  augur:
+    source: .
+    plugin: nodejs
+    npm-run: [build]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -21,3 +21,4 @@ parts:
     source: .
     plugin: nodejs
     npm-run: [build]
+    build-packages: [g++, make, python]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,8 +12,9 @@ confinement: strict
 
 apps:
   server:
-    command: sh -c \"$SNAP/lib/node_modules/augur-ui && npm start\"
+    command: sh -c \"cd $SNAP/lib/node_modules/augur-ui && npm start\"
     plugs: [network, network-bind]
+    daemon: simple
 
 parts:
   augur:


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds for adventurous users.