### PR TITLE
#1413 - Added padding to Your Order tooltip

### DIFF
--- a/src/modules/order-book/less/order-book-row-side.less
+++ b/src/modules/order-book/less/order-book-row-side.less
@@ -32,4 +32,8 @@
 			flex: 1;
 		}
 	}
+
+	.tooltip-text {
+		padding: 0.5em;
+	}
 }


### PR DESCRIPTION
With 0.5em padding: 

![screen shot 2017-01-09 at 11 15 54 am](https://cloud.githubusercontent.com/assets/3719333/21779958/a52d5696-d65e-11e6-9ffb-8222c7d60024.png)
