### PR TITLE
#1240 - Added trailing ellipsis for market outcome previews

### DIFF
--- a/src/modules/market/less/market-preview-outcomes.less
+++ b/src/modules/market/less/market-preview-outcomes.less
@@ -22,7 +22,11 @@
 
 		.outcome-name {
 			flex: 3;
+			overflow: hidden;
 			padding-left: 0.5em;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			width: 0;
 		}
 	}
 }


### PR DESCRIPTION
Market outcome name previews will now trail with (...) depending on screen width. I'm not sure why, but the width needs to be set to prevent that right column from expanding its width endlessly on a long name. It scales to always one line.

Example:

![screen shot 2017-01-09 at 12 34 01 pm](https://cloud.githubusercontent.com/assets/3719333/21782339/f1d65f48-d667-11e6-9235-a11bcb5a5f34.png)
