### PR TITLE
#1874 - Added popover for long outcome names

### DIFF
--- a/src/modules/market/components/market-preview-outcomes.jsx
+++ b/src/modules/market/components/market-preview-outcomes.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactTooltip from 'react-tooltip';
 import ValueDenomination from 'modules/common/components/value-denomination';
 
 const MarketOutcomes = p => (
@@ -16,15 +17,39 @@ const MarketOutcomes = p => (
             formattedValue={outcome.lastPricePercent.roundedValue}
           />
         }
-        <span className="outcome-name">{outcome.name}</span>
+        <span
+          data-tip
+          data-for={`outcome-name-tooltip-${outcome.marketID}-${outcome.id}`}
+          data-event="click focus"
+          className="outcome-name"
+        >
+          {outcome.name}
+        </span>
+        {(outcome.name.length > 35) &&
+          <ReactTooltip
+            id={`outcome-name-tooltip-${outcome.marketID}-${outcome.id}`}
+            type="dark"
+            effect="float"
+            place="top"
+            globalEventOff="click"
+          >
+            <span
+              data-tip
+              data-for={`outcome-name-tooltip-${outcome.marketID}-${outcome.id}`}
+              data-event="click focus"
+              className="tooltip-text"
+            >
+              {outcome.name}
+            </span>
+          </ReactTooltip>
+        }
       </div>
     ))}
   </div>
 );
-
 // TODO -- Prop Validations
 // MarketOutcomes.propTypes = {
-// 	outcomes: React.PropTypes.array
+//  outcomes: React.PropTypes.array
 // };
 
 export default MarketOutcomes;

--- a/src/modules/market/components/market-preview-outcomes.jsx
+++ b/src/modules/market/components/market-preview-outcomes.jsx
@@ -25,28 +25,27 @@ const MarketOutcomes = p => (
         >
           {outcome.name}
         </span>
-        {(outcome.name.length > 35) &&
-          <ReactTooltip
-            id={`outcome-name-tooltip-${outcome.marketID}-${outcome.id}`}
-            type="dark"
-            effect="float"
-            place="top"
-            globalEventOff="click"
+        <ReactTooltip
+          id={`outcome-name-tooltip-${outcome.marketID}-${outcome.id}`}
+          type="dark"
+          effect="float"
+          place="top"
+          globalEventOff="click"
+        >
+          <span
+            data-tip
+            data-for={`outcome-name-tooltip-${outcome.marketID}-${outcome.id}`}
+            data-event="click focus"
+            className="tooltip-text"
           >
-            <span
-              data-tip
-              data-for={`outcome-name-tooltip-${outcome.marketID}-${outcome.id}`}
-              data-event="click focus"
-              className="tooltip-text"
-            >
-              {outcome.name}
-            </span>
-          </ReactTooltip>
-        }
+            {outcome.name}
+          </span>
+        </ReactTooltip>
       </div>
     ))}
   </div>
 );
+
 // TODO -- Prop Validations
 // MarketOutcomes.propTypes = {
 //  outcomes: React.PropTypes.array


### PR DESCRIPTION
Added a popup with the full outcome name preview for outcomes that are longer than 35 characters (appx. breakpoint of full screen where truncation starts). 