### PR TITLE
Adds Dockerfile and instructions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM node:6-alpine
+
+ENV PATH /root/.yarn/bin:$PATH
+
+# begin install yarn
+RUN apk update \
+  && apk add git python make g++ bash curl binutils tar \
+  && rm -rf /var/cache/apk/* \
+  && /bin/bash \
+  && touch ~/.bashrc \
+  && curl -o- -L https://yarnpkg.com/install.sh | bash \
+  && apk del curl tar binutils
+# end install yarn
+
+# begin create caching layer
+COPY package.json /augur/package.json
+COPY yarn.lock /augur/yarn.lock
+COPY scripts/lifecycle/post-install.js /augur/scripts/lifecycle/post-install.js
+WORKDIR /augur
+RUN git init \
+  && yarn \
+  && rm -rf .git \
+  && rm package.json \
+  && rm yarn.lock \
+  && rm scripts/lifecycle/post-install.js
+# end create caching layer
+
+COPY . /augur
+
+# workaround a bug when running inside an alpine docker image
+RUN sed -i -e 's/^/# /' /augur/browserslist
+
+RUN yarn build
+WORKDIR /augur
+ENTRYPOINT [ "yarn", "dev" ]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There are several ways to run it:
 
 ## Requirements
 [Git](https://git-scm.com/)  
-[Node](https://nodejs.org/)
+[Node](https://nodejs.org/) or [Docker](https://www.docker.com/)
 
 *A Note to Windows 10 Users:*  
 Turn on `Developer Mode` and also enable `Windows Subsystem For Linux` so that you have access to bash.  
@@ -27,31 +27,41 @@ git clone https://github.com/AugurProject/augur.git
 cd augur
 ```
 
-For those using NPM:
+### NPM
 ```
 npm install
 npm run build
 ```
 
-For those using [Yarn](https://yarnpkg.com/):
+### [Yarn](https://yarnpkg.com/)
 ```
 yarn
 yarn build
 ```
 
-This will create a `build` folder inside of the `augur` directory with all the files necessary to run the client.  
+### [Docker](https://www.docker.com/)
+```
+docker build -t augur .
+```
+
+This will create a `build` folder inside of the `augur` directory with all the files necessary to run the client.
 Simply copy these files to your web server of choice.
 
 ## Develop
 
-For those using npm:
+### NPM
 ```
 npm run dev
 ```
 
-For those using [Yarn](https://yarnpkg.com/):
+### [Yarn](https://yarnpkg.com/)
 ```
 yarn dev
+```
+
+### [Docker](https://www.docker.com/)
+```
+docker run -p 8080:8080 augur
 ```
 
 Visit [http://localhost:8080](http://localhost:8080)


### PR DESCRIPTION
This allows a developer to do development on any OS with minimal requirements.  Node/NPM are notorious for having cross-platform problems so working in Docker can alleviate some of those pain points by running everything in a container.

If the user wants to be able to work with files in their host OS, they can mount a host volume to `/augur/src` and `/augur/test` in the container, letting them edit the files in their host OS in a way that the container will see them.

This Dockerfile is a bit longer than absolutely necessary to help keep build times low.  It does this by having a step that just does dependency resolution early on in the build, which will be cached by Docker.   As long as you don't touch `package.json`, `yarn.lock` or `scripts/lifecycle/post-install.js` Docker will not re-execute the dependency resolution step when you rebuild the image.

## Caveat
I wasn't able to figure out what the issue is with `browserslist` when running inside this docker container.  My best guess is that the Alpine image doesn't have any browser installed which causes this problem, but that could be a red herring as I really don't understand the problem.