### PR TITLE
Changes workaround to removing `yarn.lock`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN apk update \
 
 # begin create caching layer
 COPY package.json /augur/package.json
-COPY yarn.lock /augur/yarn.lock
 COPY scripts/lifecycle/post-install.js /augur/scripts/lifecycle/post-install.js
 WORKDIR /augur
 RUN git init \
@@ -28,7 +27,7 @@ RUN git init \
 COPY . /augur
 
 # workaround a bug when running inside an alpine docker image
-RUN sed -i -e 's/^/# /' /augur/browserslist
+RUN rm /augur/yarn.lock
 
 RUN yarn build
 WORKDIR /augur


### PR DESCRIPTION
This is temporary until we can figure out which dependency is causing the problem or otherwise update the necessary library past this problem.  It could be as simple as getting a new version of the thing throwing the error.