### PR TITLE
2151-bug-url-redirect

### DIFF
--- a/src/modules/auth/actions/import-account.js
+++ b/src/modules/auth/actions/import-account.js
@@ -9,6 +9,6 @@ export const importAccount = (password, rememberMe, keystore) => (dispatch, getS
     }
     const loginID = augur.base58Encode(account);
     if (rememberMe) savePersistentAccountToLocalStorage({ ...account, loginID });
-    dispatch(loadAccountData({ loginID, address: account.address }));
+    dispatch(loadAccountData({ loginID, address: account.address }, true));
   })
 );

--- a/src/modules/auth/actions/load-account-data.js
+++ b/src/modules/auth/actions/load-account-data.js
@@ -6,7 +6,7 @@ import { loadRegisterBlockNumber } from '../../../modules/auth/actions/load-regi
 import { updateAssets } from '../../../modules/auth/actions/update-assets';
 import { updateLoginAccount } from '../../../modules/auth/actions/update-login-account';
 
-export const loadAccountData = account => (dispatch, getState) => {
+export const loadAccountData = (account, redirect) => (dispatch, getState) => {
   if (!account || !account.address) return console.error({ message: 'account address required' });
   dispatch(loadAccountDataFromLocalStorage(account.address));
   dispatch(updateLoginAccount({ address: account.address }));
@@ -15,7 +15,7 @@ export const loadAccountData = account => (dispatch, getState) => {
   if (account.name) dispatch(updateLoginAccount({ name: account.name }));
   if (account.airbitzAccount) dispatch(updateLoginAccount({ airbitzAccount: account.airbitzAccount }));
   if (account.registerBlockNumber) dispatch(updateLoginAccount({ registerBlockNumber: account.registerBlockNumber }));
-  dispatch(displayLoginMessageOrTopics());
+  dispatch(displayLoginMessageOrTopics(redirect));
   dispatch(updateAssets((err, balances) => {
     if (err) return console.error(err);
     if (anyAccountBalancesZero(balances)) {

--- a/src/modules/auth/actions/login.js
+++ b/src/modules/auth/actions/login.js
@@ -17,7 +17,7 @@ export const login = (loginID, password, rememberMe, cb) => (dispatch, getState)
       return callback(account);
     }
     if (rememberMe) savePersistentAccountToLocalStorage({ ...account, loginID });
-    dispatch(loadAccountData({ loginID, address: account.address, name: accountObject.name }));
+    dispatch(loadAccountData({ loginID, address: account.address, name: accountObject.name }, true));
     callback(null);
   });
 };

--- a/src/modules/auth/actions/register.js
+++ b/src/modules/auth/actions/register.js
@@ -21,6 +21,6 @@ export const setupAndFundNewAccount = (password, loginID, rememberMe, cb) => (di
   if (!loginID) return callback({ message: 'loginID is required' });
   if (rememberMe) savePersistentAccountToLocalStorage({ ...augur.accounts.account, loginID });
   dispatch(updateLoginAccount({ loginID, address: augur.accounts.account.address }));
-  dispatch(loadAccountData(getState().loginAccount));
+  dispatch(loadAccountData(getState().loginAccount, true));
   callback(null);
 };

--- a/src/modules/login-message/actions/display-login-message.js
+++ b/src/modules/login-message/actions/display-login-message.js
@@ -2,13 +2,13 @@ import isCurrentLoginMessageRead from '../../login-message/helpers/is-current-lo
 import isUserLoggedIn from '../../auth/helpers/is-user-logged-in';
 
 // decide if we need to display the login message
-export const displayLoginMessageOrTopics = () => (dispatch, getState) => {
+export const displayLoginMessageOrTopics = redirect => (dispatch, getState) => {
   const { links } = require('../../../selectors');
   if (links && links.topicsLink) {
     const { loginAccount, loginMessage } = getState();
     if (isUserLoggedIn(loginAccount) && !isCurrentLoginMessageRead(loginMessage)) {
       links.loginMessageLink.onClick();
-    } else {
+    } else if (redirect) {
       links.topicsLink.onClick();
     }
   }

--- a/test/auth/actions/register-test.js
+++ b/test/auth/actions/register-test.js
@@ -35,10 +35,7 @@ describe(`modules/auth/actions/register.js`, () => {
   const loadAccountDataTestString = 'loadAccountData() called.';
 
   updateLoginAccountStub.updateLoginAccount = sinon.stub().returns({ type: updateTestString });
-  sinon.stub(loadAccountDataStub, 'loadAccountData', (account, cb) => {
-    if (cb) cb(null, 2.5);
-    return { type: loadAccountDataTestString };
-  });
+  sinon.stub(loadAccountDataStub, 'loadAccountData', account => ({ type: loadAccountDataTestString }));
 
   const action = proxyquire('../../../src/modules/auth/actions/register', {
     '../../../services/augurjs': fakeAugurJS,


### PR DESCRIPTION
This bug was due to the method `displayLoginMessageOrTopics` always redirecting a user to the topics view, even when a specific path was present.