### PR TITLE
782-google-translate

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -87,6 +87,12 @@
 
     </script>
 
+    <!-- Google Translate -->
+    <script type="text/javascript">
+      function googleTranslateElementInit() {
+        new google.translate.TranslateElement({pageLanguage: 'en', layout: google.translate.TranslateElement.FloatPosition.TOP_LEFT, multilanguagePage: true}, 'google_translate_element');}</script>
+    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+
     <!-- Google Analytics -->
     <script src="//www.google-analytics.com/analytics.js" defer=""></script>
 

--- a/src/modules/app/components/nav.jsx
+++ b/src/modules/app/components/nav.jsx
@@ -124,10 +124,12 @@ const Nav = (p) => {
           }}
           className={classnames('app-nav-link', AUTHENTICATION, { active: p.activeView === AUTHENTICATION })}
         >
-          <i className="nav-icon">
-            <AugurLogoIcon />
-          </i>
-          Sign Up / Login
+          <div className="nav-icon">
+            <i>
+              <AugurLogoIcon />
+            </i>
+          </div>
+          {`Sign Up / Login`}
         </Link>
       }
     </nav>

--- a/src/modules/app/components/nav.jsx
+++ b/src/modules/app/components/nav.jsx
@@ -124,12 +124,12 @@ const Nav = (p) => {
           }}
           className={classnames('app-nav-link', AUTHENTICATION, { active: p.activeView === AUTHENTICATION })}
         >
-          <div className="nav-icon">
-            <i>
+          <div className="nav-icon-google-translate-fix">
+            <i className="nav-icon">
               <AugurLogoIcon />
             </i>
           </div>
-          {`Sign Up / Login`}
+          Sign Up / Login
         </Link>
       }
     </nav>

--- a/src/modules/app/less/nav.less
+++ b/src/modules/app/less/nav.less
@@ -48,6 +48,10 @@
       display: none;
     }
 
+    .nav-icon-google-translate-fix {
+
+    }
+
     button.app-nav-link {
       i {
 
@@ -159,7 +163,8 @@
       display: none;
     }
 
-    .nav-icon {
+    .nav-icon,
+    .nav-icon-google-translate-fix {
       margin-bottom: 0.2em;
       width: 2em;
     }

--- a/src/modules/app/less/nav.less
+++ b/src/modules/app/less/nav.less
@@ -48,10 +48,6 @@
       display: none;
     }
 
-    .nav-icon-google-translate-fix {
-
-    }
-
     button.app-nav-link {
       i {
 


### PR DESCRIPTION
Added Google simple translate. Small header bug fixed by @stephensprinkle. 

To test: You must change your computers default language. It detects by system language and locale, not browser. In OSX, go to System Preferences --> Languages & Region --> and set a new language as primary. The force close Chrome, and re-open. 