### PR TITLE
Addition of disabled ShapeShift + Coinbase buttons

### DIFF
--- a/src/modules/account/components/account-view.jsx
+++ b/src/modules/account/components/account-view.jsx
@@ -178,6 +178,31 @@ export default class AccountPage extends Component {
           </div>
           <div className={classnames('account-section')}>
             <div className="account-info-item">
+              <h2 className="heading">Deposit & Purchase Funds</h2>
+              <p>
+                You can deposit funds with ShapeShift using any alternative cryptocurrency, or purchase ETH directly with Coinbase. <b>(Disabled during beta)</b>
+              </p>
+              <div className="deposit-funds-section">
+                <button
+                  className="button intigrations"
+                >
+                  Deposit ETH with ShapeShift
+                </button>
+                <button
+                  className="button intigrations"
+                >
+                  Deposit REP with ShapeShift
+                </button>
+                <button
+                  className="button intigrations"
+                >
+                  Purchase ETH with Coinbase
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className={classnames('account-section')}>
+            <div className="account-info-item">
               <h2 className="heading">Transfer Funds</h2>
               <p>
                 You can transfer funds to another address by selecting the type of currency you would like to send and entering the address you would like to send it to. (Note: Always double check the address you intend to send funds to!)
@@ -219,6 +244,14 @@ export default class AccountPage extends Component {
                   onClick={this.handleTransfer}
                 >
                   Send Currency
+                </button>
+                <p>
+                  You can withdraw to any cryptocurrency with ShapeShift. Open ShapeShift with the button below, select your input (ETH or REP) and output currency. Enter your destination address within the ShapeShift modal. Start the transaction, and enter the deposit address ShapeShift gives you into the withdraw feild above. <b>(Disabled during beta)</b>
+                </p>
+                <button
+                  className="button intigrations"
+                >
+                  Transfer funds with ShapeShift
                 </button>
               </div>
             </div>

--- a/src/modules/account/less/account.less
+++ b/src/modules/account/less/account.less
@@ -85,37 +85,37 @@
       }
       // responsive design for mobile display.
       // @media screen and (max-width: @media-mobile-width) {
-      // 	margin-top: 3vmin;
+      //  margin-top: 3vmin;
       //
-      // 	span {
-      // 		margin: 1.5vmin 1.5vmin 1.5vmin 0;
-      // 		width: 12%;
-      // 	}
+      //  span {
+      //    margin: 1.5vmin 1.5vmin 1.5vmin 0;
+      //    width: 12%;
+      //  }
       //
-      // 	span:first-of-type {
-      // 		margin: 1.5vmin 1.5vmin 1.5vmin 0;
-      // 		width: 100%;
-      // 	}
+      //  span:first-of-type {
+      //    margin: 1.5vmin 1.5vmin 1.5vmin 0;
+      //    width: 100%;
+      //  }
       //
-      // 	select {
-      // 		margin: 1.5vmin 0 1.5vmin 0.5vmin;
-      // 		width: 45%;
-      // 	}
+      //  select {
+      //    margin: 1.5vmin 0 1.5vmin 0.5vmin;
+      //    width: 45%;
+      //  }
       //
-      // 	input {
-      // 		margin: 1.5vmin 0;
-      // 		width: 86%;
-      // 	}
+      //  input {
+      //    margin: 1.5vmin 0;
+      //    width: 86%;
+      //  }
       //
-      // 	input:first-of-type {
-      // 		margin: 1.5vmin 0.5vmin 1.5vmin 0;
-      // 		width: 53%;
-      // 	}
+      //  input:first-of-type {
+      //    margin: 1.5vmin 0.5vmin 1.5vmin 0;
+      //    width: 53%;
+      //  }
       //
-      // 	.button {
-      // 		font-size: 0.8em;
-      // 		margin: 0;
-      // 	}
+      //  .button {
+      //    font-size: 0.8em;
+      //    margin: 0;
+      //  }
       // }
     }
 
@@ -194,5 +194,10 @@
       cursor: pointer;
       font-family: 'Font Awesome';
     }
+  }
+
+  .button.intigrations {
+    font-size: 0.8em;
+    margin: 1.5vmin;
   }
 }


### PR DESCRIPTION
Added ShapeShift and Coinbase buttons for depositing and withdrawal of funds. Currently disabled during beta, as we don't want people shifting / depositing real currency. 

ShapeShift for deposits will load a ShapeShift pre-filled transaction screen with their Augur address as the destination address. Users can deposit any currency into ETH or REP. The Coinbase buy widget will open a modal allowing the user to purchase ETH instantly, and will also auto-fill their Augur address as the deposit destination. 

For withdrawals, users will be prompted to open a ShapeShift transaction screen, and enter their destination address. They will then need to get the deposit address from ShapeShift, enter it into our original transfer system - and transfer directly out to ShapeShift. 

Adding a new issue in Clubhouse for post-launch to update the buttons with the links and code needed for all actions to make them live. 