### PR TITLE
Added link for guide on how to get real REP/ETH back from beta

### DIFF
--- a/src/modules/account/components/account-view.jsx
+++ b/src/modules/account/components/account-view.jsx
@@ -262,6 +262,15 @@ export default class AccountPage extends Component {
               <p>
                 Download your account key file. You should always save a backup of your account data somewhere safe! Remember, <b>Augur does not store any user account information and therefore has no ability to restore or recover lost accounts</b>. (Note: running a local Ethereum node? If you download your account data to your keystore folder, you can use your Augur account on your local node.)
               </p>
+              <p>
+                <b>
+                  <a
+                    href="http://blog.augur.net/accidentally-sent-real-rep-eth-augur-beta/"
+                  >
+                    Did you accidentally send real REP or ETH to Augur beta? Learn how to get it back here!
+                  </a>
+                </b>
+              </p>
               <a
                 className="button download-account"
                 href={p.account.downloadAccountDataString}

--- a/src/modules/login-message/components/login-message-view.jsx
+++ b/src/modules/login-message/components/login-message-view.jsx
@@ -53,6 +53,12 @@ const LoginMessagePage = p => (
         </li>
       </ol>
       <h2>Technical updates:</h2>
+      <h3>March 6, 2017</h3>
+      <ol>
+        <li>
+          Added a guide and link on how to recover REP / ETH sent to the beta.
+        </li>
+      </ol>
       <h3>March 5, 2017</h3>
       <ol>
         <li>


### PR DESCRIPTION
Wrote guide for how to get real REP/ETH accidentally sent to the beta back. Get an email about this once every week or two. Added a link to it under the "Download Account Key File" - considering that is what you need to get it back. 