### PR TITLE
Updates to handle node fallback.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,37 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha Tests",
+      "cwd": "${workspaceRoot}",
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/mocha",
+      "windows": { "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/mocha.cmd" },
+      "runtimeArgs": [
+        "-u", "bdd",
+        "--colors",
+        "--no-timeouts",
+        "${workspaceRoot}/test/"
+      ],
+      "env": {
+        "NODE_ENV": "test"
+      },
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:8080",
+      "webRoot": "${workspaceRoot}"
+    },
+    {
+      "type": "chrome",
+      "request": "attach",
+      "name": "Attach to Chrome",
+      "port": 9222,
+      "webRoot": "${workspaceRoot}"
+    }
+  ]
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -34,7 +34,7 @@ const removeBuildDir = new Promise((resolve, reject) => {
 });
 
 const createBuildDir = new Promise((resolve, reject) => {
-  const code = shell.exec(`mkdir -p ${BUILD_DIRECTORY}`).code;
+  const code = shell.exec(`mkdir ${BUILD_DIRECTORY}`).code;
 
   if (code !== 0) {
     reject(new Error());

--- a/src/services/augurjs.js
+++ b/src/services/augurjs.js
@@ -4,19 +4,20 @@ const ex = {};
 
 ex.connect = function connect(env, cb) {
   const options = {
-    http: env.gethHttpURL,
-    ws: env.gethWebsocketsURL,
+    httpAddresses: [],
+    wsAddresses: [],
     contracts: env.contracts,
-    augurNodes: env.augurNodes,
-    noFallback: !env.hostedNodeFallback
+    augurNodes: env.augurNodes
   };
+
   const isHttps = typeof window !== 'undefined' && window.location.protocol === 'https:';
-  if (isHttps) {
-    const isEnvHttps = (env.gethHttpURL && env.gethHttpURL.split('//')[0] === 'https:');
-    const isEnvWss = (env.gethWebsocketsURL && env.gethWebsocketsURL.split('//')[0] === 'wss:');
-    if (!isEnvHttps) options.http = null;
-    if (!isEnvWss) options.ws = null;
-  }
+  const isEnvHttps = (env.gethHttpURL && env.gethHttpURL.split('//')[0] === 'https:');
+  const isEnvWss = (env.gethWebsocketsURL && env.gethWebsocketsURL.split('//')[0] === 'wss:');
+  if (env.gethHttpURL && (!isHttps || isEnvHttps)) options.httpAddresses.push(env.gethHttpURL);
+  if (env.gethWebsocketsURL && (!isHttps || isEnvWss)) options.wsAddresses.push(env.gethWebsocketsURL);
+  if (env.hostedNodeFallback) options.httpAddresses.push("https://eth3.augur.net");
+  if (env.hostedNodeFallback) options.wsAddresses.push("wss://ws.augur.net");
+
   augur.options.debug.trading = env.debug.trading;
   augur.options.debug.reporting = env.debug.reporting;
   augur.options.debug.nonce = false;

--- a/src/services/augurjs.js
+++ b/src/services/augurjs.js
@@ -15,8 +15,8 @@ ex.connect = function connect(env, cb) {
   const isEnvWss = (env.gethWebsocketsURL && env.gethWebsocketsURL.split('//')[0] === 'wss:');
   if (env.gethHttpURL && (!isHttps || isEnvHttps)) options.httpAddresses.push(env.gethHttpURL);
   if (env.gethWebsocketsURL && (!isHttps || isEnvWss)) options.wsAddresses.push(env.gethWebsocketsURL);
-  if (env.hostedNodeFallback) options.httpAddresses.push("https://eth3.augur.net");
-  if (env.hostedNodeFallback) options.wsAddresses.push("wss://ws.augur.net");
+  if (env.hostedNodeFallback) options.httpAddresses.push('https://eth3.augur.net');
+  if (env.hostedNodeFallback) options.wsAddresses.push('wss://ws.augur.net');
 
   augur.options.debug.trading = env.debug.trading;
   augur.options.debug.reporting = env.debug.reporting;

--- a/test/app/actions/listen-to-updates-test.js
+++ b/test/app/actions/listen-to-updates-test.js
@@ -84,9 +84,9 @@ describe(`modules/app/actions/listen-to-updates.js`, () => {
   it(`should listen for new updates`, () => {
     store.dispatch(action.listenToUpdates());
     const out = [{
-      type: 'UPDATE_ASSETS'
-    }, {
       type: 'SYNC_BLOCKCHAIN'
+    }, {
+      type: 'UPDATE_ASSETS'
     }, {
       type: 'SYNC_BRANCH'
     }, {

--- a/test/trade/actions/update-trades-in-progress-test.js
+++ b/test/trade/actions/update-trades-in-progress-test.js
@@ -33,6 +33,7 @@ describe('modules/trade/actions/update-trades-in-progress.js', () => {
 
     beforeEach(() => {
       store.clearActions();
+      augur.rpc.gasPrice = 20000000000;
     });
 
     afterEach(() => {


### PR DESCRIPTION
Previously, ethrpc was doing hosted node fallback.  This code has been moved up to the UI instead, so everything else just operates on an array of possible nodes, the UI provides the list of possible nodes to connect to.

Also adds a launch configuration for debugging tests in VSCode and fixes a minor issue in building on Windows.