### PR TITLE
1968 bug

### DIFF
--- a/src/modules/outcomes/components/outcome-trade.jsx
+++ b/src/modules/outcomes/components/outcome-trade.jsx
@@ -171,7 +171,7 @@ export default class OutcomeTrade extends Component {
               <Input
                 className={classNames({ 'input-error': !s.isSharesValueValid })}
                 placeholder={s.shareInputPlaceholder}
-                value={s.sharesDenominated ? s.sharesDenominated : ''}
+                value={s.sharesDenominated}
                 isIncrementable
                 incrementAmount={s.incrementAmount}
                 updateValue={(value) => {

--- a/src/modules/outcomes/components/outcome-trade.jsx
+++ b/src/modules/outcomes/components/outcome-trade.jsx
@@ -171,7 +171,7 @@ export default class OutcomeTrade extends Component {
               <Input
                 className={classNames({ 'input-error': !s.isSharesValueValid })}
                 placeholder={s.shareInputPlaceholder}
-                value={s.sharesDenominated}
+                value={s.sharesDenominated ? s.sharesDenominated : ''}
                 isIncrementable
                 incrementAmount={s.incrementAmount}
                 updateValue={(value) => {
@@ -185,7 +185,7 @@ export default class OutcomeTrade extends Component {
               <Input
                 className={classNames('trade-price-input', { 'input-error': !s.isLimitPriceValueValid })}
                 placeholder="Price"
-                value={trade.limitPrice}
+                value={trade.limitPrice ? trade.limitPrice : ''}
                 isIncrementable
                 incrementAmount={s.incrementAmount}
                 updateValue={(value) => {


### PR DESCRIPTION
I cannot reliably reproduce this bug each time but I am nearly certain this will prevent this warning in the future.  Basically what happens is `trade.limitPrice` can be null when the user clears the input, so this ternary ensures the value for the input is at least an empty string.