### PR TITLE
2515 create market clear inputs

### DIFF
--- a/src/modules/common/components/input-list.jsx
+++ b/src/modules/common/components/input-list.jsx
@@ -38,12 +38,15 @@ export default class InputList extends Component {
       this.setState({ warnings: nextProps.warnings });
       this.clearWarnings();
     }
+    if (nextProps.list !== this.state.list) {
+      this.setState({ list: this.fillMinElements(nextProps.list, nextProps.listMinElements) });
+    }
   }
 
   componentDidUpdate() {
-    if (this.props.list != this.state.list) {
-      this.setState({ list: this.fillMinElements(this.props.list, this.props.listMinElements) });
-    }
+    // this.onUpdate(function callback() {
+
+    // });
   }
 
   clearWarnings() {
@@ -87,7 +90,7 @@ export default class InputList extends Component {
       list = list.slice();
       list.push('');
     }
-    
+
     return (
       <div className={classNames('input-list', p.className)}>
         {list.map((item, i) => (

--- a/src/modules/common/components/input-list.jsx
+++ b/src/modules/common/components/input-list.jsx
@@ -40,6 +40,12 @@ export default class InputList extends Component {
     }
   }
 
+  componentDidUpdate() {
+    if (this.props.list != this.state.list) {
+      this.setState({ list: this.fillMinElements(this.props.list, this.props.listMinElements) });
+    }
+  }
+
   clearWarnings() {
     this.setState({ warnings: [] });
   }
@@ -81,7 +87,7 @@ export default class InputList extends Component {
       list = list.slice();
       list.push('');
     }
-
+    
     return (
       <div className={classNames('input-list', p.className)}>
         {list.map((item, i) => (

--- a/src/modules/common/components/input-list.jsx
+++ b/src/modules/common/components/input-list.jsx
@@ -43,12 +43,6 @@ export default class InputList extends Component {
     }
   }
 
-  componentDidUpdate() {
-    // this.onUpdate(function callback() {
-
-    // });
-  }
-
   clearWarnings() {
     this.setState({ warnings: [] });
   }

--- a/src/modules/create-market/components/create-market-form-fees.jsx
+++ b/src/modules/create-market/components/create-market-form-fees.jsx
@@ -48,6 +48,10 @@ export default class CreateMarketFormDescription extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.currentStep !== nextProps.currentStep && newMarketCreationOrder[nextProps.currentStep] === NEW_MARKET_FEES) nextProps.updateValidity(true, true);
+    if (nextProps.makerFee !== this.state.makerFee || nextProps.takerFee !== this.state.takerFee) {
+      // when clearMarket button is pressed and user navigates back here the state will still be the old fee values. this call makes sure to reset them if they don't line up with props passed.
+      this.setState({ makerFee: nextProps.makerFee, takerFee: nextProps.takerFee });
+    }
   }
 
   componentDidUpdate(prevProps) {
@@ -55,10 +59,6 @@ export default class CreateMarketFormDescription extends Component {
       this.props.currentStep === newMarketCreationOrder.indexOf(NEW_MARKET_FEES)
     ) {
       this.defaultFormToFocus.getElementsByTagName('input')[0].focus();
-    }
-    if (this.props.makerFee != this.state.makerFee || this.props.takerFee != this.state.takerFee) {
-      // when clearMarket button is pressed and user navigates back here the state will still be the old fee values. this call makes sure to reset them if they don't line up with props passed.
-      this.setState({ makerFee: this.props.makerFee, takerFee: this.props.takerFee });
     }
   }
 

--- a/src/modules/create-market/components/create-market-form-fees.jsx
+++ b/src/modules/create-market/components/create-market-form-fees.jsx
@@ -56,6 +56,10 @@ export default class CreateMarketFormDescription extends Component {
     ) {
       this.defaultFormToFocus.getElementsByTagName('input')[0].focus();
     }
+    if (this.props.makerFee != this.state.makerFee || this.props.takerFee != this.state.takerFee) {
+      // when clearMarket button is pressed and user navigates back here the state will still be the old fee values. this call makes sure to reset them if they don't line up with props passed.
+      this.setState({ makerFee: this.props.makerFee, takerFee: this.props.takerFee });
+    }
   }
 
   validateForm(takerFeeRaw, makerFeeRaw, init) {

--- a/src/modules/create-market/components/create-market-form-order-book.jsx
+++ b/src/modules/create-market/components/create-market-form-order-book.jsx
@@ -405,8 +405,8 @@ export default class CreateMarketFormOrderBook extends Component {
     // Validate Quantity
     if (orderQuantity !== '' && orderPrice !== '' && orderPrice.times(orderQuantity).plus(this.props.initialLiquidityEth).greaterThan(new BigNumber(this.props.availableEth))) {
       // Done this way so both inputs are in err
-      errors.quantity.push('Issufficient funds');
-      errors.price.push('Issufficient funds');
+      errors.quantity.push('Insufficient funds');
+      errors.price.push('Insufficient funds');
     } else if (orderQuantity !== '' && orderQuantity.lessThanOrEqualTo(new BigNumber(0))) {
       errors.quantity.push('Quantity must be positive');
     } else if (orderPrice !== '') {

--- a/src/modules/create-market/components/create-market-form.jsx
+++ b/src/modules/create-market/components/create-market-form.jsx
@@ -144,7 +144,6 @@ export default class CreateMarketForm extends Component {
             'display-form-part': s.currentStep === newMarketCreationOrder.indexOf(NEW_MARKET_EXPIRY_SOURCE),
             'hide-form-part': s.currentStep !== newMarketCreationOrder.indexOf(NEW_MARKET_EXPIRY_SOURCE) && s.lastStep === newMarketCreationOrder.indexOf(NEW_MARKET_EXPIRY_SOURCE)
           })}
-          key={p.newMarket.endDate}
           currentStep={p.newMarket.currentStep}
           expirySourceType={p.newMarket.expirySourceType}
           expirySource={p.newMarket.expirySource}
@@ -152,18 +151,19 @@ export default class CreateMarketForm extends Component {
           updateNewMarket={p.updateNewMarket}
         />
         {
-          s.currentStep === newMarketCreationOrder.indexOf(NEW_MARKET_END_DATE) && <CreateMarketFormEndDate
-            className={classNames({
-              'display-form-part': s.currentStep === newMarketCreationOrder.indexOf(NEW_MARKET_END_DATE),
-              'hide-form-part': s.currentStep !== newMarketCreationOrder.indexOf(NEW_MARKET_END_DATE) && s.lastStep === newMarketCreationOrder.indexOf(NEW_MARKET_END_DATE)
-            })}
-            currentStep={p.newMarket.currentStep}
-            isValid={p.newMarket.isValid}
-            endDate={p.newMarket.endDate}
-            updateFormHeight={this.updateFormHeight}
-            updateValidity={this.updateValidity}
-            updateNewMarket={p.updateNewMarket}
-          />
+          s.currentStep === newMarketCreationOrder.indexOf(NEW_MARKET_END_DATE) &&
+            <CreateMarketFormEndDate
+              className={classNames({
+                'display-form-part': s.currentStep === newMarketCreationOrder.indexOf(NEW_MARKET_END_DATE),
+                'hide-form-part': s.currentStep !== newMarketCreationOrder.indexOf(NEW_MARKET_END_DATE) && s.lastStep === newMarketCreationOrder.indexOf(NEW_MARKET_END_DATE)
+              })}
+              currentStep={p.newMarket.currentStep}
+              isValid={p.newMarket.isValid}
+              endDate={p.newMarket.endDate}
+              updateFormHeight={this.updateFormHeight}
+              updateValidity={this.updateValidity}
+              updateNewMarket={p.updateNewMarket}
+            />
         }
         <CreateMarketFormDetails
           className={classNames({

--- a/src/modules/create-market/components/create-market-form.jsx
+++ b/src/modules/create-market/components/create-market-form.jsx
@@ -144,24 +144,27 @@ export default class CreateMarketForm extends Component {
             'display-form-part': s.currentStep === newMarketCreationOrder.indexOf(NEW_MARKET_EXPIRY_SOURCE),
             'hide-form-part': s.currentStep !== newMarketCreationOrder.indexOf(NEW_MARKET_EXPIRY_SOURCE) && s.lastStep === newMarketCreationOrder.indexOf(NEW_MARKET_EXPIRY_SOURCE)
           })}
+          key={p.newMarket.endDate}
           currentStep={p.newMarket.currentStep}
           expirySourceType={p.newMarket.expirySourceType}
           expirySource={p.newMarket.expirySource}
           updateValidity={this.updateValidity}
           updateNewMarket={p.updateNewMarket}
         />
-        <CreateMarketFormEndDate
-          className={classNames({
-            'display-form-part': s.currentStep === newMarketCreationOrder.indexOf(NEW_MARKET_END_DATE),
-            'hide-form-part': s.currentStep !== newMarketCreationOrder.indexOf(NEW_MARKET_END_DATE) && s.lastStep === newMarketCreationOrder.indexOf(NEW_MARKET_END_DATE)
-          })}
-          currentStep={p.newMarket.currentStep}
-          isValid={p.newMarket.isValid}
-          endDate={p.newMarket.endDate}
-          updateFormHeight={this.updateFormHeight}
-          updateValidity={this.updateValidity}
-          updateNewMarket={p.updateNewMarket}
-        />
+        {
+          s.currentStep === newMarketCreationOrder.indexOf(NEW_MARKET_END_DATE) && <CreateMarketFormEndDate
+            className={classNames({
+              'display-form-part': s.currentStep === newMarketCreationOrder.indexOf(NEW_MARKET_END_DATE),
+              'hide-form-part': s.currentStep !== newMarketCreationOrder.indexOf(NEW_MARKET_END_DATE) && s.lastStep === newMarketCreationOrder.indexOf(NEW_MARKET_END_DATE)
+            })}
+            currentStep={p.newMarket.currentStep}
+            isValid={p.newMarket.isValid}
+            endDate={p.newMarket.endDate}
+            updateFormHeight={this.updateFormHeight}
+            updateValidity={this.updateValidity}
+            updateNewMarket={p.updateNewMarket}
+          />
+        }
         <CreateMarketFormDetails
           className={classNames({
             'display-form-part': s.currentStep === newMarketCreationOrder.indexOf(NEW_MARKET_DETAILS),

--- a/src/modules/create-market/container.js
+++ b/src/modules/create-market/container.js
@@ -14,7 +14,7 @@ import getValue from 'utils/get-value';
 
 const mapStateToProps = state => ({
   branch: state.branch,
-  availableEth: getValue(state, 'loginAccount.ether'),
+  availableEth: getValue(state, 'loginAccount.ethTokens'),
   newMarket: state.newMarket,
   footerHeight: state.footerHeight
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5119,9 +5119,9 @@ keythereum@0.5.1:
     sjcl "1.0.6"
     uuid "3.0.0"
 
-keythereum@0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/keythereum/-/keythereum-0.5.2.tgz#73a15f0232efc2c98f258492157a2d684ead5205"
+keythereum@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/keythereum/-/keythereum-1.0.0.tgz#4ebe7f59b4b5e600349ca8db45a308abd7f7115a"
   dependencies:
     keccak "1.2.0"
     secp256k1 "3.2.5"


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/2515/date-ui-keywords-not-resetting-on-clear-market
Fixed keywords, fees, date/time picker. 
Fixed an issue where you couldn't add orders to the orderBook during market creation
Unable to reproduce described issue of orders remaining after clearing a new Market creation.