### PR TITLE
2833-unmounted-ReactToolTip

### DIFF
--- a/src/modules/common/components/checkbox.jsx
+++ b/src/modules/common/components/checkbox.jsx
@@ -44,7 +44,7 @@ export default class Checkbox extends Component {
       } else {
         this.setState({
           isLabelTruncated: false,
-          dataTip: this.props.title
+          dataTip: this.props.title || this.props.text
         });
       }
     }


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/2833/console-error-for-unmounted-reacttooltips-when-setstate-is-being-called
This fixes the issue described in the clubhouse issue linked above. 

It seems that the `checkbox` common component was attempting to set `dataTip` (which is used by reactToolTip) to `this.props.title` however on the sidebar `this.props.title` is `undefined`. I added an or statement to use `this.props.text` if `this.props.title` is `undefined`. 

The reason this was causing an issue when you resized on the markets page is because this function was being called on a window `resize` event . The sidebar is only shown on the markets page which is why this issue seemed to only be present on that page and appeared hard to reproduce.