### PR TITLE
fix CreateMarketPreview setState error

### DIFF
--- a/src/modules/create-market/components/create-market-preview.jsx
+++ b/src/modules/create-market/components/create-market-preview.jsx
@@ -131,7 +131,9 @@ export default class CreateMarketPreview extends Component {
         this.marketPreview.style.height = `${newHeight}px`;
       } else {
         setTimeout(() => {
-          this.marketPreview.style.height = `${newHeight}px`;
+          if (this.marketPreview) {
+            this.marketPreview.style.height = `${newHeight}px`;
+          }
         }, 1500);
       }
     }
@@ -173,7 +175,9 @@ export default class CreateMarketPreview extends Component {
   }
 
   shouldUpdateHeight(shouldUpdateHeight) {
-    this.setState({ shouldUpdateHeight });
+    if (this.marketPreview) {
+      this.setState({ shouldUpdateHeight });
+    }
   }
 
   render() {

--- a/src/modules/create-market/components/create-market-preview.jsx
+++ b/src/modules/create-market/components/create-market-preview.jsx
@@ -89,9 +89,9 @@ export default class CreateMarketPreview extends Component {
       }
     });
 
-    window.addEventListener('resize', () => {
-      this.shouldUpdateHeight(true);
-    });
+    this.shouldUpdateHeight(true);
+
+    window.addEventListener('resize', this.updatePreviewHeight);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/modules/create-market/components/create-market-review.jsx
+++ b/src/modules/create-market/components/create-market-review.jsx
@@ -46,6 +46,10 @@ export default class CreateMarketReview extends Component {
     };
   }
 
+  componentWillMount() {
+    this.calculateMarketCreationCosts();
+  }
+
   componentWillReceiveProps(nextProps) {
     if (this.props.currentStep !== nextProps.currentStep &&
       newMarketCreationOrder[nextProps.currentStep] === NEW_MARKET_REVIEW


### PR DESCRIPTION
Because of the way setState was being called, sometimes it would get triggered after createMarketPreview had been unmounted which resulted in an error. Attempting to set the state of an unmounted component. This now checks to make sure the component is mounted, also corrects a similar situation that was more rare where a style was being applied to an unmounted component because of a timeout. 