### PR TITLE
2011-fix-pending-markets-hidden

### DIFF
--- a/src/modules/markets/selectors/markets-filtered.js
+++ b/src/modules/markets/selectors/markets-filtered.js
@@ -80,7 +80,7 @@ export const isMarketFiltersMatch = (market, keywords, selectedFilterSort, selec
   }
 
   function isDisplayable(market) {
-    if (!market.isMalFormed && !market.isRequiredToReportByAccount) {
+    if (!market.isMalFormed) {
       return true;
     }
   }


### PR DESCRIPTION
Clubhouse Story: https://app.clubhouse.io/augur/story/2011/when-markets-are-marked-as-having-pending-reports-they-should-not-be-removed-from-the-main-markets-listing

Change: removed part of the check for a displayable filter that was hiding all markets that are either malFormed or are required to be reported on by the logged in account. I removed the check for required to be reported on by logged in account and left only the malFormed check.