### PR TITLE
Simple prop validation fix

### DIFF
--- a/src/modules/app/components/inner-nav.jsx
+++ b/src/modules/app/components/inner-nav.jsx
@@ -9,7 +9,7 @@ class InnerNav extends Component {
     keywords: PropTypes.array.isRequired,
     isMobile: PropTypes.bool.isRequired,
     mobileMenuState: PropTypes.number.isRequired,
-    selectedCategory: PropTypes.string.isRequired,
+    selectedCategory: PropTypes.string,
     onSelectCategory: PropTypes.func.isRequired,
     subMenuScalar: PropTypes.number.isRequired
   };


### PR DESCRIPTION
`selectedCategory` prop is not actually required by `InnerNav` - it defaults to `null` in the Redux state, which is expected and accounted for.