### PR TITLE
Fix (non-hardware-accelerated) graph BG regression

### DIFF
--- a/src/modules/common/components/graph-background.jsx
+++ b/src/modules/common/components/graph-background.jsx
@@ -118,6 +118,7 @@ export default class GraphBG extends Component {
     p.background(35, 26, 58);
     const scaledTime = p.millis() / 2500;
 
+    p.noStroke();
     p.fill(83, 76, 101);
     this.circles.forEach((circle) => {
       const { x, y } = circle.origin;
@@ -137,6 +138,7 @@ export default class GraphBG extends Component {
       }
     });
 
+    p.stroke(83, 76, 101);
     Object.keys(this.lines).forEach((linekey) => {
       const line = this.lines[linekey];
       const circleA = this.circles[line.circleIndices[0]];


### PR DESCRIPTION
Fixes a visual regression that resulted in black lines and borders for the 2d version of the animated graph BG 🌟