### PR TITLE
Removed outcomes/constants/trade-types.js moved all references to BUY…

### DIFF
--- a/src/modules/app/actions/listen-to-updates.js
+++ b/src/modules/app/actions/listen-to-updates.js
@@ -9,7 +9,6 @@ import { updateOutcomePrice } from 'modules/markets/actions/update-outcome-price
 import { claimProceeds } from 'modules/my-positions/actions/claim-proceeds';
 import { convertLogsToTransactions } from 'modules/transactions/actions/convert-logs-to-transactions';
 import { updateMarketTopicPopularity } from 'modules/topics/actions/update-topics';
-import { SELL } from 'modules/outcomes/constants/trade-types';
 import * as TYPES from 'modules/transactions/constants/types';
 import { updateAccountBidsAsksData, updateAccountCancelsData, updateAccountTradesData } from 'modules/my-positions/actions/update-account-trades-data';
 
@@ -120,7 +119,7 @@ export function listenToUpdates() {
           dispatch(updateMarketTopicPopularity(msg.market, msg.amount));
 
           const { address } = getState().loginAccount;
-          if (msg.sender !== address) dispatch(fillOrder({ ...msg, type: SELL }));
+          if (msg.sender !== address) dispatch(fillOrder({ ...msg, type: TYPES.SELL }));
 
           // if the user is either the maker or taker, add it to the transaction display
           if (msg.sender === address || msg.owner === address) {
@@ -185,7 +184,7 @@ export function listenToUpdates() {
         if (msg) {
           console.log('completeSets_logReturn:', msg);
           let amount = new BigNumber(msg.amount, 10).times(msg.numOutcomes);
-          if (msg.type === SELL) amount = amount.neg();
+          if (msg.type === TYPES.SELL) amount = amount.neg();
           dispatch(updateMarketTopicPopularity(msg.market, amount.toFixed()));
         }
       },

--- a/src/modules/market/components/market-active.jsx
+++ b/src/modules/market/components/market-active.jsx
@@ -8,8 +8,7 @@ import OutcomeTrade from 'modules/outcomes/components/outcome-trade';
 
 import { SHARE, MILLI_SHARE, MICRO_SHARE } from 'modules/market/constants/share-denominations';
 import { PRICE } from 'modules/order-book/constants/order-book-value-types';
-import { BUY, SELL } from 'modules/outcomes/constants/trade-types';
-import { BID } from 'modules/transactions/constants/types';
+import { BID, BUY, SELL } from 'modules/transactions/constants/types';
 import { BIDS, ASKS } from 'modules/order-book/constants/order-book-order-types';
 import { SCALAR } from 'modules/markets/constants/market-types';
 

--- a/src/modules/order-book/components/order-book-row-side.jsx
+++ b/src/modules/order-book/components/order-book-row-side.jsx
@@ -8,8 +8,7 @@ import NullStateMessage from 'modules/common/components/null-state-message';
 import getValue from 'utils/get-value';
 import setShareDenomination from 'utils/set-share-denomination';
 
-import { BUY, SELL } from 'modules/outcomes/constants/trade-types';
-import { BID, ASK } from 'modules/transactions/constants/types';
+import { BID, ASK, BUY, SELL } from 'modules/transactions/constants/types';
 import { PRICE, SHARE } from 'modules/order-book/constants/order-book-value-types';
 
 const OrderBookRowSide = (p) => {

--- a/src/modules/outcomes/components/outcome-trade.jsx
+++ b/src/modules/outcomes/components/outcome-trade.jsx
@@ -9,7 +9,7 @@ import ComponentNav from 'modules/common/components/component-nav';
 import EmDash from 'modules/common/components/em-dash';
 
 import { SHARE, MICRO_SHARE, MILLI_SHARE } from 'modules/market/constants/share-denominations';
-import { BUY } from 'modules/outcomes/constants/trade-types';
+import { BUY } from 'modules/transactions/constants/types';
 import { BIDS, ASKS } from 'modules/order-book/constants/order-book-order-types';
 import { SCALAR } from 'modules/markets/constants/market-types';
 

--- a/src/modules/outcomes/constants/trade-types.js
+++ b/src/modules/outcomes/constants/trade-types.js
@@ -1,2 +1,0 @@
-export const BUY = 'buy';
-export const SELL = 'sell';


### PR DESCRIPTION
… and SELL to transactions/constants/types.js

I removed trade-types.js and 3 references to it. Moved to use transactions/constants/types.js. In types.js file I didn't see redundant 'buy' strings so I didn't change anything in this file.