### PR TITLE
Add a loading spinner to the topics view

### DIFF
--- a/src/modules/markets/reducers/event-markets-map.js
+++ b/src/modules/markets/reducers/event-markets-map.js
@@ -4,12 +4,19 @@ export default function (eventMarketsMap = {}, action) {
   switch (action.type) {
     case UPDATE_EVENT_MARKETS_MAP: {
       if (eventMarketsMap[action.eventID]) {
-        const isUnique = {};
+
+        const elements = (eventMarketsMap[action.eventID].concat(action.marketIDs))
+        .reduce((agg, el) => {
+          if (!agg.isUnique.hasOwnProperty(el)) {
+            agg.isUnique[el] = true;
+            agg.values.push(el);
+          }
+          return agg;
+        }, { values: [], isUnique: {} });
+
         return {
           ...eventMarketsMap,
-          [action.eventID]: (eventMarketsMap[action.eventID].concat(action.marketIDs)).filter(el => (
-            isUnique.hasOwnProperty(el) ? false : (isUnique[el] = true))
-          )
+          [action.eventID]: elements.values
         };
       }
       return {

--- a/src/modules/topics/components/topics-view.jsx
+++ b/src/modules/topics/components/topics-view.jsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 import NullStateMessage from 'modules/common/components/null-state-message';
 import TopicRows from 'modules/topics/components/topic-rows';
 import Paginator from 'modules/common/components/paginator';
+import Spinner from 'modules/common/components/spinner';
 import Branch from 'modules/branch/components/branch';
 import FilterSort from 'modules/filter-sort/container';
 
@@ -47,6 +48,7 @@ export default class TopicsView extends Component {
       filteredTopics: [],
       filteredTopicsLength: 0,
       hasKeywords: false,
+      loaded: false,
       paginatedTopics: [],
       pagination: {},
       fontAwesomeClasses: [],
@@ -149,6 +151,7 @@ export default class TopicsView extends Component {
 
   updateFilteredItems(filteredTopics) {
     this.setState({
+      loaded: true,
       filteredTopics,
       filteredTopicsLength: filteredTopics.length,
       hasKeywords: filteredTopics.length !== getValue(this.props, 'topics.length') // Inferred
@@ -156,8 +159,10 @@ export default class TopicsView extends Component {
   }
 
   render() {
+
     const p = this.props;
     const s = this.state;
+
 
     return (
       <section id="topics_view">
@@ -185,7 +190,16 @@ export default class TopicsView extends Component {
               </Link>
             }
           </div>
-          {s.filteredTopicsLength && s.boundedLength ?
+          {!s.loaded ?
+            <section id="topics_view">
+              <div id="topics_container">
+                <div className="loading-spinner" >
+                  <Spinner />
+                </div>
+              </div>
+            </section> : ''
+          }
+          {s.loaded && s.filteredTopicsLength && s.boundedLength ?
             <div className="topics">
               <TopicRows
                 topics={p.topics}
@@ -203,7 +217,7 @@ export default class TopicsView extends Component {
             </div> :
             <NullStateMessage message={'No Topics Available'} />
           }
-          {!!s.filteredTopicsLength &&
+          {s.loaded && !!s.filteredTopicsLength &&
             <Paginator
               itemsLength={s.filteredTopicsLength}
               itemsPerPage={s.itemsPerPage}


### PR DESCRIPTION
I would like to add this loading spinner to the topics page to help with the User Experience. When the code is loading, the UI says "No Topics Available", which is pretty confusing to me since there may be topics, but they just haven't loaded yet. A user may see "No Topics Available" while having a slow connection, and assume there really are no topics available. Adding a spinner is better UX since at least the User knows something is happening in the background, and they should wait.

Also, 1ca4616 allows me to pass linter checks on pull. When I run npm lint, this error shows: 
```bash
/Users/jalil/Programs/augur/src/modules/markets/reducers/event-markets-map.js
  10:95  error  Arrow function should not return assignment  no-return-assign
```
This commit is a fix for that, where I just use a reduce statement to aggregate the unique items instead of a stateful filter.