### PR TITLE
Fix background sizing bug

### DIFF
--- a/src/modules/common/components/graph-background/graph-background.jsx
+++ b/src/modules/common/components/graph-background/graph-background.jsx
@@ -172,9 +172,8 @@ export default class GraphBG extends Component {
 
 
   handleWindowResize(p) {
-    const { offsetWidth, offsetHeight } = this.refs.canvascontainer
-    const width = offsetWidth
-    const height = offsetHeight
+    const width = document.body.offsetWidth
+    const height = this.refs.canvascontaineroffsetHeight
 
     this.setupScreen(p, width, height)
     this.readjustScene()
@@ -183,9 +182,8 @@ export default class GraphBG extends Component {
 
   sketch(p) {
     p.setup = () => {
-      const { offsetWidth, offsetHeight } = this.refs.canvascontainer
-      const width = offsetWidth
-      const height = offsetHeight
+      const width = document.body.offsetWidth
+      const height = this.refs.canvascontainer.offsetHeight
 
       if (this.hasWebGL) {
         p.createCanvas(width, height, P5.prototype.WEBGL)

--- a/src/modules/common/components/graph-background/graph-background.jsx
+++ b/src/modules/common/components/graph-background/graph-background.jsx
@@ -173,7 +173,7 @@ export default class GraphBG extends Component {
 
   handleWindowResize(p) {
     const width = document.body.offsetWidth
-    const height = this.refs.canvascontaineroffsetHeight
+    const height = this.refs.canvascontainer.offsetHeight
 
     this.setupScreen(p, width, height)
     this.readjustScene()

--- a/src/modules/common/components/graph-background/graph-background.styles.less
+++ b/src/modules/common/components/graph-background/graph-background.styles.less
@@ -7,4 +7,9 @@
   right: 0;
   top: 0;
   z-index: @default-z-index;
+
+  canvas {
+    margin-left: 50%;
+    transform: translateX(-50%);
+  }
 }


### PR DESCRIPTION
Wanted to fix this w/o relying on polling for element resizes, so it's just CSS minus setting the canvas size to the `<body>` width in JS.
The issue was that there was no screen resize event, though the container effectively resized because of the sidebar animation.