### PR TITLE
Fixes for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk update \
   && rm -rf /var/cache/apk/* \
   && /bin/bash \
   && touch ~/.bashrc \
-  && curl -o- -L https://yarnpkg.com/install.sh | bash \
+  && curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --nightly \
   && apk del curl tar binutils
 # end install yarn
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,12 @@ RUN apk update \
 
 # begin create caching layer
 COPY package.json /augur/package.json
-COPY scripts/lifecycle/post-install.js /augur/scripts/lifecycle/post-install.js
 WORKDIR /augur
 RUN git init \
   && yarn \
   && rm -rf .git \
   && rm package.json \
-  && rm yarn.lock \
-  && rm scripts/lifecycle/post-install.js
+  && rm yarn.lock
 # end create caching layer
 
 COPY . /augur

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:6-alpine
 ENV PATH /root/.yarn/bin:$PATH
 
 # begin install yarn
+# Using --nightly yarn due to this bug: https://github.com/yarnpkg/yarn/issues/4363
 RUN apk update \
   && apk add git python make g++ bash curl binutils tar \
   && rm -rf /var/cache/apk/* \

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "The Augur Developers <team@augur.net>",
   "license": "AAL",
   "engines": {
-    "node": "6.5.0"
+    "node": "6.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I've eased the node version requirement from 6.5.0 to 6.x, but if we want to keep a version pinned, we would need to mirror a node:6-alpine Docker image.