### PR TITLE
fixed core stat label color on the top bar

### DIFF
--- a/src/modules/app/components/top-bar/top-bar.styles.less
+++ b/src/modules/app/components/top-bar/top-bar.styles.less
@@ -30,7 +30,7 @@
   width: @font-size-rather-large;
 }
 
-.TopBar__stat_label {
+.TopBar__stat-label {
   color: rgba(255, 255, 255, 0.25);
   margin-right: 0.62rem;
 }


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/4467/core-stats-number-colors-wrong

Fixes the color of the labels on the top-bar to match the mocks. turns out a classname was flubbed.