### PR TITLE
Fixed search bar Magnifying glass space and search bar spacing on header

### DIFF
--- a/src/modules/filter-sort/components/filter-search/filter-search.styles.less
+++ b/src/modules/filter-sort/components/filter-search/filter-search.styles.less
@@ -13,7 +13,6 @@
 
   > svg {
     height: 0.75rem;
-    margin: 1px 0 0;
     width: 0.75rem;
   }
 
@@ -23,7 +22,7 @@
     color: inherit;
     font-size: inherit;
     line-height: inherit;
-    padding-left: 0.5rem;
+    padding: 0 0 0 0.5rem;
     text-transform: none;
 
     &::placeholder {

--- a/src/modules/filter-sort/components/filter-search/filter-search.styles.less
+++ b/src/modules/filter-sort/components/filter-search/filter-search.styles.less
@@ -13,7 +13,7 @@
 
   > svg {
     height: 0.75rem;
-    margin: 1px 0.75rem 0 0;
+    margin: 1px 0 0;
     width: 0.75rem;
   }
 
@@ -23,6 +23,7 @@
     color: inherit;
     font-size: inherit;
     line-height: inherit;
+    padding-left: 0.5rem;
     text-transform: none;
 
     &::placeholder {


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/4473/too-much-spacing-between-search-input-view-header

Moved the magnifying glass closer to the word "search" to closer match the mocks, also removed some of the padding so that the search bar is more inline with the first word of the sub-menu as in the mocks. This also decreases the space between the search bar and the title of the markets page.