### PR TITLE
4494 chart title fix

### DIFF
--- a/src/env.json
+++ b/src/env.json
@@ -3,7 +3,7 @@
   "gethWebsocketsURL": "ws://127.0.0.1:8546",
   "augurNodeUrl": "ws://127.0.0.1:9001",
   "networkID": null,
-  "autoLogin": false,
+  "autoLogin": true,
   "universe": null,
   "debug": {
     "connect": true,

--- a/src/env.json
+++ b/src/env.json
@@ -3,7 +3,7 @@
   "gethWebsocketsURL": "ws://127.0.0.1:8546",
   "augurNodeUrl": "ws://127.0.0.1:9001",
   "networkID": null,
-  "autoLogin": true,
+  "autoLogin": false,
   "universe": null,
   "debug": {
     "connect": true,

--- a/src/modules/account/components/account-header/account-header.jsx
+++ b/src/modules/account/components/account-header/account-header.jsx
@@ -43,13 +43,13 @@ class AccountHeader extends Component {
     // on mobile we want to reduce scaling by roughly 30%, otherwise fitText default
     containerWidth = this.props.isMobile ? containerWidth - (containerWidth * 0.3) : containerWidth
     // @params: container, target, scaleUp, maxScale
-    fitText({ clientWidth: containerWidth }, ethTarget, true, 10)
+    fitText({ clientWidth: containerWidth }, ethTarget, true, 7)
 
     if (repValue > 0) {
       const repContainer = this.repCurrencyContainer
       const repTarget = this.repCurrencyValue
       // @params: container, target, scaleUp, maxScale
-      fitText({ clientWidth: repContainer.clientWidth }, repTarget, true, 10)
+      fitText({ clientWidth: repContainer.clientWidth }, repTarget, true, 7)
     }
   }
 

--- a/src/modules/account/components/account-header/account-header.styles.less
+++ b/src/modules/account/components/account-header/account-header.styles.less
@@ -9,8 +9,8 @@
   margin: 3rem 4rem;
 
   @media @breakpoint-mobile {
-    margin: 0;
     flex: 1 0 auto;
+    margin: 0;
   }
 }
 

--- a/src/modules/account/components/account-header/account-header.styles.less
+++ b/src/modules/account/components/account-header/account-header.styles.less
@@ -10,6 +10,7 @@
 
   @media @breakpoint-mobile {
     margin: 0;
+    flex: 1 0 auto;
   }
 }
 

--- a/src/modules/account/components/account-view/account-view.styles.less
+++ b/src/modules/account/components/account-view/account-view.styles.less
@@ -6,5 +6,5 @@
 
 .AccountView__content {
   display: flex;
-  flex: 1;
+  flex: 1 0 auto;
 }

--- a/src/modules/account/components/profit-loss-chart/profit-loss-chart.styles.less
+++ b/src/modules/account/components/profit-loss-chart/profit-loss-chart.styles.less
@@ -7,9 +7,9 @@
 }
 
 .ProfitLossChart__Title {
+  margin-top: 1.25rem;
   text-align: center;
   width: 100%;
-  margin-top: 1.25rem;
 }
 
 .ProfitLossChart__Title-label {
@@ -34,9 +34,9 @@
 
   .ProfitLossChart__Title {
     font-size: @font-size-rather-large;
+    margin: 0;
     position: fixed;
     text-align: center;
-    margin: 0;
     width: 100%;
   }
 

--- a/src/modules/account/components/profit-loss-chart/profit-loss-chart.styles.less
+++ b/src/modules/account/components/profit-loss-chart/profit-loss-chart.styles.less
@@ -2,7 +2,6 @@
 
 .ProfitLossChart {
   flex: 1;
-  height: 170px;
   max-width: 23rem;
   text-align: center;
 }
@@ -10,6 +9,7 @@
 .ProfitLossChart__Title {
   text-align: center;
   width: 100%;
+  margin-top: 1.25rem;
 }
 
 .ProfitLossChart__Title-label {
@@ -23,8 +23,7 @@
 @media @breakpoint-mobile {
   .ProfitLossChart {
     display: flex;
-    flex-flow: column nowrap;
-    height: 100%;
+    flex-flow: column-reverse nowrap;
     max-width: 100%;
     width: 100%;
 
@@ -37,7 +36,7 @@
     font-size: @font-size-rather-large;
     position: fixed;
     text-align: center;
-    top: 17rem;
+    margin: 0;
     width: 100%;
   }
 

--- a/src/modules/app/components/terms-and-conditions/terms-and-conditions.styles.less
+++ b/src/modules/app/components/terms-and-conditions/terms-and-conditions.styles.less
@@ -2,11 +2,11 @@
 
 .TermsAndConditions {
   color: @color-text-light;
+  flex: 0 0 auto;
   font-size: @font-size-large;
   margin: 1em 0;
   text-align: center;
   white-space: nowrap;
-  flex: 0 0 auto;
 
   a {
     flex: none;

--- a/src/modules/app/components/terms-and-conditions/terms-and-conditions.styles.less
+++ b/src/modules/app/components/terms-and-conditions/terms-and-conditions.styles.less
@@ -6,6 +6,7 @@
   margin: 1em 0;
   text-align: center;
   white-space: nowrap;
+  flex: 0 0 auto;
 
   a {
     flex: none;


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/4494/additional-padding-between-chart-titles-account-header
https://app.clubhouse.io/augur/story/4492/establish-reasonable-max-size-of-eth-amount-in-account-header

Adds padding to the title below the charts in account header.
Adds a max scale size for the ETH/REP to 7 from 10. This seems to be more reasonable. 

I want to make note that the Account Header page is still not congruent to the docs in my opinion, and more works needs to be done, however I'm struggling with it at the moment and i don't want to waste too much time on one thing. My plan is to re-approach the account header to complete the final CH issue (https://app.clubhouse.io/augur/story/4493/graph-should-be-bottom-aligned-account-header) in order to more closely fit the mocks. I believe there is still a layout issue, I think part of the problem is the highcharts works but I haven't been able to find a workable solution so far.