### PR TITLE
fixed a clipping issue

### DIFF
--- a/src/modules/account/components/account-header/account-header.styles.less
+++ b/src/modules/account/components/account-header/account-header.styles.less
@@ -24,7 +24,6 @@
   font-size: @font-size-rather-large;
   justify-content: center;
   margin: 0 0 1.5rem;
-  overflow: hidden;
 }
 
 .AccountHeader__Currency-value {
@@ -67,7 +66,6 @@
     display: flex;
     flex-flow: row nowrap;
     margin: 0;
-    overflow: visible;
     padding-bottom: 5rem;
     position: absolute;
     width: 100vw;


### PR DESCRIPTION
fixed a edge case where navigating from certain views was causing `eth` to be clipped due to overflow. with the updated scaling styling in place this overflow isn't really needed anymore so I removed it to fix the clipping of the label when the sidebar moved after rendering/scaling the header.