### PR TITLE
4261-market-icons

### DIFF
--- a/src/env.json
+++ b/src/env.json
@@ -3,7 +3,7 @@
   "gethWebsocketsURL": "ws://127.0.0.1:8546",
   "augurNodeUrl": "ws://127.0.0.1:9001",
   "networkID": null,
-  "autoLogin": true,
+  "autoLogin": false,
   "universe": null,
   "debug": {
     "connect": true,

--- a/src/modules/market/components/market-portfolio-card/market-portfolio-card.jsx
+++ b/src/modules/market/components/market-portfolio-card/market-portfolio-card.jsx
@@ -81,7 +81,7 @@ export default class MarketPortfolioCard extends React.Component {
                 {this.props.market.description}
               </h1>
             </div>
-            <MarketStatusIcon className={Styles.MarketCard__statusicon} isOpen isReported />
+            <MarketStatusIcon className={Styles.MarketCard__statusicon} isOpen={p.market.isOpen} isReported={p.market.isReported} />
           </div>
           <div className={Styles.MarketCard__topstats}>
             <div className={Styles.MarketCard__leftstats}>
@@ -187,7 +187,7 @@ export default class MarketPortfolioCard extends React.Component {
               }
             />
           }
-          {this.props.market.outcomes[0].userOpenOrders.length !== 0 &&
+          {this.props.market.outcomes[0] && this.props.market.outcomes[0].userOpenOrders && this.props.market.outcomes[0].userOpenOrders.length !== 0 &&
             <div className={Styles.MarketCard__headingcontainer}>
               <h1 className={Styles.MarketCard__tableheading}>
                 Open Orders

--- a/src/modules/portfolio/components/markets/markets.jsx
+++ b/src/modules/portfolio/components/markets/markets.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import { Helmet } from 'react-helmet'
 
 import Dropdown from 'modules/common/components/dropdown/dropdown'
-// import MarketCard from 'modules/market/components/market-card/market-card'
 import MarketsList from 'modules/markets/components/markets-list'
 import Styles from 'modules/portfolio/components/markets/markets.styles'
 import { TYPE_REPORT } from 'modules/market/constants/link-types'

--- a/src/modules/portfolio/components/positions-markets-list/positions-markets-list.jsx
+++ b/src/modules/portfolio/components/positions-markets-list/positions-markets-list.jsx
@@ -82,27 +82,19 @@ class PositionsMarketsList extends Component {
           </div>
         </div>
         {p.markets.length ?
-          p.markets.map((market) => {
-            // TODO: REMOVE and simply return the MarketPortfolioCard.
-            // This is temporary so the page doesn't error out due to bad data during the wiring up of v3
-            if (market.outcomes.length === 0) {
-              return (<NullStateMessage message={'Market Data Malformed'} />)
-            }
-
-            return (
-              <MarketPortfolioCard
-                key={market.id}
-                market={market}
-                closePositionStatus={p.closePositionStatus}
-                scalarShareDenomination={p.scalarShareDenomination}
-                orderCancellation={p.orderCancellation}
-                location={p.location}
-                history={p.history}
-                linkType={p.linkType}
-                positionsDefault={p.positionsDefault}
-              />
-            )
-          }):
+          p.markets.map(market =>
+            (<MarketPortfolioCard
+              key={market.id}
+              market={market}
+              closePositionStatus={p.closePositionStatus}
+              scalarShareDenomination={p.scalarShareDenomination}
+              orderCancellation={p.orderCancellation}
+              location={p.location}
+              history={p.history}
+              linkType={p.linkType}
+              positionsDefault={p.positionsDefault}
+            />)
+          ):
           <NullStateMessage message={'No Markets Available'} />}
       </div>
     )


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/4261/double-check-all-market-basics-icon-states-update-if-any-are-missing

Ensured all icons would show properly depending on markets stats. Currently `isOpen` is one of the values but as we have discussed before `closed` is a bad term as is `open` as the market is never ever closed for trading. We should consider a Move to Open, Reporting, In Dispute, and Finalized instead of Open, Reporting, Dispute, Closed. Also corrected Sprinkle shame in env.json...for shame indeed.... :) 

-- Oh and removed that 'mal formed market data' message in positions portfolio and simple hide open orders if the market doesn't have any...