### PR TITLE
4485-sort-reporting-outcomes

### DIFF
--- a/src/modules/reporting/components/reporting-report-form/reporting-report-form.jsx
+++ b/src/modules/reporting/components/reporting-report-form/reporting-report-form.jsx
@@ -123,7 +123,7 @@ const ReportingReportForm = p => (
           <span>Outcome</span>
         </label>
         <ul className={FormStyles['Form__radio-buttons--per-line']}>
-          { p.market.outcomes && p.market.outcomes.map(outcome => (
+          { p.market.outcomes && p.market.outcomes.sort((a, b) => b.stake - a.stake).map(outcome => (
             <li key={outcome.id}>
               <button
                 className={classNames({ [`${FormStyles.active}`]: p.selectedOutcome === outcome.name })}


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/4485/reporting-outcomes-should-be-sorted-by-staking

Updates the reporting outcomes to be sorted by stake from highest stake to lowest.