### PR TITLE
4917 augur node listeners

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -594,18 +594,13 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
-    "augur-contracts": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/augur-contracts/-/augur-contracts-3.3.8.tgz",
-      "integrity": "sha512-57mrNjHP61uLmey+ln94pJAyt9QVyfNSfebTRTEbUSX1JvoLlqVga3ngzZUXrJo7YFdsH2fXZ4VR3YejtirTRg=="
-    },
     "augur.js": {
-      "version": "4.6.20",
-      "resolved": "https://registry.npmjs.org/augur.js/-/augur.js-4.6.20.tgz",
-      "integrity": "sha512-aDuoTKZRDqWAp3G4abvRL/vfwp7upO3bhKbclfOuajAvtZViPoZZgouvM0Xk+4SOv4yr2JTIjLPTFDl/e5BbZw==",
+      "version": "4.6.21",
+      "resolved": "https://registry.npmjs.org/augur.js/-/augur.js-4.6.21.tgz",
+      "integrity": "sha512-aJP0KugtjUh2Y1S+sldWEs8uNXmUy6xpaFAuUnuMabxTL1NR2PMuDFbiB8PyqDEGBM3UUVdwHb2JpCODT1oCDw==",
       "requires": {
         "async": "1.5.2",
-        "augur-contracts": "3.3.8",
+        "augur-contracts": "3.3.10",
         "bignumber.js": "2.3.0",
         "clone": "1.0.2",
         "ethereumjs-connect": "4.4.1",
@@ -624,6 +619,11 @@
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "augur-contracts": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/augur-contracts/-/augur-contracts-3.3.10.tgz",
+          "integrity": "sha512-IVjpgURvXfS7pw8nwP/BnP66Rgr+KaNRqDE7yLt+hcqnCGsahv/kFiQ9cbj43T46D07Kx3G9pTPZTd2W+VuFkw=="
         },
         "bignumber.js": {
           "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -594,10 +594,15 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "augur-contracts": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/augur-contracts/-/augur-contracts-3.3.10.tgz",
+      "integrity": "sha512-IVjpgURvXfS7pw8nwP/BnP66Rgr+KaNRqDE7yLt+hcqnCGsahv/kFiQ9cbj43T46D07Kx3G9pTPZTd2W+VuFkw=="
+    },
     "augur.js": {
-      "version": "4.6.21",
-      "resolved": "https://registry.npmjs.org/augur.js/-/augur.js-4.6.21.tgz",
-      "integrity": "sha512-aJP0KugtjUh2Y1S+sldWEs8uNXmUy6xpaFAuUnuMabxTL1NR2PMuDFbiB8PyqDEGBM3UUVdwHb2JpCODT1oCDw==",
+      "version": "4.6.22",
+      "resolved": "https://registry.npmjs.org/augur.js/-/augur.js-4.6.22.tgz",
+      "integrity": "sha512-V0IBI2Gsfawkyik+EqctYzvU3ZFiIBBoF2j0tr5/yFsonolo9edWBRKMeou37PjLD72WuSDCaoVcLoUJbci6yQ==",
       "requires": {
         "async": "1.5.2",
         "augur-contracts": "3.3.10",
@@ -619,11 +624,6 @@
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "augur-contracts": {
-          "version": "3.3.10",
-          "resolved": "https://registry.npmjs.org/augur-contracts/-/augur-contracts-3.3.10.tgz",
-          "integrity": "sha512-IVjpgURvXfS7pw8nwP/BnP66Rgr+KaNRqDE7yLt+hcqnCGsahv/kFiQ9cbj43T46D07Kx3G9pTPZTd2W+VuFkw=="
         },
         "bignumber.js": {
           "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "airbitz-core-js-ui": "0.1.7",
     "async": "2.4.1",
-    "augur.js": "4.6.21",
+    "augur.js": "4.6.22",
     "bignumber.js": "4.0.2",
     "bs58": "4.0.1",
     "classnames": "2.2.5",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "airbitz-core-js-ui": "0.1.7",
     "async": "2.4.1",
-    "augur.js": "4.6.20",
+    "augur.js": "4.6.21",
     "bignumber.js": "4.0.2",
     "bs58": "4.0.1",
     "classnames": "2.2.5",

--- a/src/modules/app/actions/listen-to-updates.js
+++ b/src/modules/app/actions/listen-to-updates.js
@@ -1,5 +1,155 @@
+import { augur } from 'services/augurjs'
+
 export function listenToUpdates() {
   return (dispatch, getState) => {
-    // TODO subscribe to augur-node updates
+    augur.events.startBlockListeners({
+      onAdded: (block) => {
+        console.log('block added:', block)
+        // dispatch(syncBlockchain())
+        // dispatch(updateAssets())
+        // dispatch(syncUniverse())
+      },
+      onRemoved: (block) => {
+        console.log('block removed:', block)
+        // dispatch(syncBlockchain())
+        // dispatch(updateAssets())
+        // dispatch(syncUniverse())
+      }
+    })
+    augur.events.startAugurNodeEventListeners({
+      MarketCreated: (err, log) => {
+        if (err) return console.error('MarketCreated:', err)
+        if (log) {
+          console.log('MarketCreated:', log)
+          // dispatch(loadMarketsInfo([log.marketID]))
+          // if (log.sender === getState().loginAccount.address) {
+          //   dispatch(updateAssets())
+          //   dispatch(convertLogsToTransactions(TYPES.CREATE_MARKET, [log]))
+          // }
+        }
+      },
+      TokensTransferred: (err, log) => {
+        if (err) return console.error('TokensTransferred:', err)
+        if (log) {
+          console.log('TokensTransferred:', log)
+          // const { address } = getState().loginAccount
+          // if (log._from === address || log._to === address) {
+          //   dispatch(updateAssets())
+          //   dispatch(convertLogsToTransactions(TYPES.TRANSFER, [log]))
+          // }
+        }
+      },
+      OrderCanceled: (err, log) => {
+        if (err) return console.error('OrderCanceled:', err)
+        if (log) {
+          console.log('OrderCanceled:', log)
+          // // if this is the user's order, then add it to the transaction display
+          // if (log.sender === getState().loginAccount.address) {
+          //   dispatch(updateAccountCancelsData({
+          //     [log.market]: { [log.outcome]: [log] }
+          //   }))
+          //   dispatch(updateAssets())
+          // }
+        }
+      },
+      OrderCreated: (err, log) => {
+        if (err) return console.error('OrderCreated:', err)
+        if (log) {
+          console.log('OrderCreated:', log)
+          // // if this is the user's order, then add it to the transaction display
+          // if (log.sender === getState().loginAccount.address) {
+          //   dispatch(updateAccountBidsAsksData({
+          //     [log.market]: {
+          //       [log.outcome]: [log]
+          //     }
+          //   }))
+          //   dispatch(updateAssets())
+          // }
+        }
+      },
+      OrderFilled: (err, log) => {
+        if (err) return console.error('OrderFilled:', err)
+        if (log) {
+          console.log('OrderFilled:', log)
+          // dispatch(updateOutcomePrice(log.market, log.outcome, new BigNumber(log.price, 10)))
+          // dispatch(updateMarketTopicPopularity(log.market, log.amount))
+          // const { address } = getState().loginAccount
+          // if (log.sender !== address) dispatch(fillOrder(log))
+          // if (log.sender === address || log.owner === address) {
+          //   dispatch(updateAccountTradesData({
+          //     [log.market]: { [log.outcome]: [{
+          //       ...log,
+          //       maker: log.owner === address
+          //     }] }
+          //   }))
+          //   dispatch(updateAssets())
+          //   dispatch(loadMarketsInfo([log.market]))
+          //   console.log('MSG -- ', log)
+          // }
+        }
+      },
+      TradingProceedsClaimed: (err, log) => {
+        if (err) return console.error('TradingProceedsClaimed:', err)
+        if (log) {
+          console.log('TradingProceedsClaimed:', log)
+          // if (log && log.sender === getState().loginAccount.address) {
+          //   dispatch(updateAssets())
+          //   dispatch(convertLogsToTransactions(TYPES.PAYOUT, [log]))
+          // }
+        }
+      },
+      DesignatedReportSubmitted: (err, log) => {
+        if (err) return console.error('DesignatedReportSubmitted:', err)
+        if (log) {
+          console.log('DesignatedReportSubmitted:', log)
+        }
+      },
+      ReportSubmitted: (err, log) => {
+        if (err) return console.error('ReportSubmitted:', err)
+        if (log) {
+          console.log('ReportSubmitted:', log)
+          // if (log && log.sender === getState().loginAccount.address) {
+          //   dispatch(updateAssets())
+          //   dispatch(convertLogsToTransactions(TYPES.SUBMIT_REPORT, [log]))
+          // }
+        }
+      },
+      WinningTokensRedeemed: (err, log) => {
+        if (err) return console.error('WinningTokensRedeemed:', err)
+        if (log) {
+          console.log('WinningTokensRedeemed:', log)
+          // if (log && log.reporter === getState().loginAccount.address) {
+          //   dispatch(updateAssets())
+          //   dispatch(convertLogsToTransactions(TYPES.REDEEM_WINNING_TOKENS, [log]))
+          // }
+        }
+      },
+      ReportsDisputed: (err, log) => {
+        if (err) return console.error('ReportsDisputed:', err)
+        if (log) {
+          console.log('ReportsDisputed:', log)
+        }
+      },
+      MarketFinalized: (err, log) => {
+        if (err) return console.error('MarketFinalized:', err)
+        if (log) {
+          console.log('MarketFinalized:', log)
+          // const { universe, loginAccount } = getState()
+          // if (universe.id === log.universe) {
+          //   dispatch(loadMarketsInfo([log.market], () => {
+          //     const { volume } = getState().marketsData[log.market]
+          //     dispatch(updateMarketTopicPopularity(log.market, new BigNumber(volume, 10).neg().toNumber()))
+          //     if (loginAccount.address) dispatch(claimProceeds())
+          //   }))
+          // }
+        }
+      },
+      UniverseForked: (err, log) => {
+        if (err) return console.error('UniverseForked:', err)
+        if (log) {
+          console.log('UniverseForked:', log)
+        }
+      },
+    }, err => console.log(err || 'Listening for events'))
   }
 }


### PR DESCRIPTION
Sets up scaffolding for augur-node listeners.  Important note: the callback bodies in listen-to-updates are just placeholders that print the logs out to the console when they come in.  I included as commented-out code the old (pre-augur-node) callback bodies; hopefully at least some of this code can be re-used.

I verified against a live setup (local augur-node and geth connected to Rinkeby) that the listeners for new blocks, TokensTransferred, MarketCreated, OrderCreated, and OrderFilled receive notifications when they are supposed to, and the notifications appear to be structured correctly.

Tagging @JohnDanz and @stephensprinkle to make sure you guys see this PR and are aware that the callbacks still need to be filled in! :grin: 