### PR TITLE
fixed issue with onClick being set to false in create-market-form

### DIFF
--- a/src/modules/create-market/components/create-market-form/create-market-form.jsx
+++ b/src/modules/create-market/components/create-market-form/create-market-form.jsx
@@ -187,7 +187,7 @@ export default class CreateMarketForm extends Component {
                   <button
                     className={classNames(Styles.CreateMarketForm__next, { [`${Styles['hide-button']}`]: p.newMarket.currentStep === s.pages.length - 1 })}
                     disabled={!p.newMarket.isValid}
-                    onClick={p.newMarket.isValid && this.nextPage}
+                    onClick={p.newMarket.isValid ? this.nextPage : null}
                   >Next: {s.pages[p.newMarket.currentStep + 1]}
                   </button>
                 }


### PR DESCRIPTION
fixes that warning we keep seeing in the create-market-form. Basically we were doing `boolean && Function` but if the `boolean` was `false`, it would pass `onClick` as `false` which caused the error.