### PR TITLE
Top bar tweaks

### DIFF
--- a/src/modules/app/components/app/app.jsx
+++ b/src/modules/app/components/app/app.jsx
@@ -373,7 +373,7 @@ export default class AppView extends Component {
           />
         </section>
         <section className={Styles.Main}>
-          <section>
+          <section className={Styles.TopBar}>
             <TopBar
               isMobile={p.isMobile}
               isLogged={p.isLogged}

--- a/src/modules/app/components/app/app.styles.less
+++ b/src/modules/app/components/app/app.styles.less
@@ -118,3 +118,7 @@ svg.SideBar__mobile-bars-unseen {
   position: relative;
   right: 0.35rem;
 }
+
+.TopBar {
+  z-index: @above-all-content;
+}

--- a/src/modules/app/components/top-bar/top-bar.jsx
+++ b/src/modules/app/components/top-bar/top-bar.jsx
@@ -29,19 +29,21 @@ const TopBar = props => (
           <div className={Styles.TopBar__stat}>
             <div
               className={Styles['TopBar__stat-label']}
-              dangerouslySetInnerHTML={{ __html: `<span>30 Day P/L</span>` }}
-            />
+            >
+              <span>{props.stats[1].totalPLMonth.label}</span>
+            </div>
             <span className={Styles['TopBar__stat-value']}>
-              123
+              {props.stats[1].totalPLMonth.value.formatted}
             </span>
           </div>
           <div className={Styles.TopBar__stat}>
             <div
               className={Styles['TopBar__stat-label']}
-              dangerouslySetInnerHTML={{ __html: `<span>1 Day P/L</span>` }}
-            />
+            >
+              <span>{props.stats[1].totalPLDay.label}</span>
+            </div>
             <span className={Styles['TopBar__stat-value']}>
-              123
+              {props.stats[1].totalPLDay.value.formatted}
             </span>
           </div>
         </div>

--- a/src/modules/app/components/top-bar/top-bar.styles.less
+++ b/src/modules/app/components/top-bar/top-bar.styles.less
@@ -23,19 +23,17 @@
   display: flex;
   letter-spacing: 0.05em;
   line-height: 2.6rem;
-  margin-right: 2.5rem;
-  width: 6.8rem;
+  width: 7.85rem;
 }
 
 .TopBar__notifications {
   color: @color-white;
   display: inline-block;
-  float: right;
   font-size: @font-size-rather-large;
   letter-spacing: 0.05em;
   line-height: 2.6rem;
   text-align: center;
-  width: 3rem;
+  width: 2.25rem;
 }
 
 .TopBar__notification-icon {
@@ -46,12 +44,11 @@
 .TopBar__stat-label {
   color: rgba(255, 255, 255, 0.25);
   display: inline;
-  margin-right: 0.62rem;
+  margin-right: 0.25rem;
 }
 
 .TopBar__stat-value {
   color: @color-white;
-  padding-left: 0.5em;
 }
 
 .TopBar__logo-text {

--- a/src/modules/notifications/components/notification.jsx
+++ b/src/modules/notifications/components/notification.jsx
@@ -98,9 +98,10 @@ export default class Notification extends Component {
       >
         <Link
           className={Styles.Notification__link}
-          to={p.linkPath}
+          to={p.linkPath ? p.linkPath : ''}
           onClick={(e) => {
             e.stopPropagation()
+            if (!p.linkPath) e.preventDefault()
             if (p.linkPath && p.onClick) p.toggleNotifications()
           }}
         >
@@ -110,6 +111,7 @@ export default class Notification extends Component {
             className={Styles.Notification__close}
             onClick={(e) => {
               e.stopPropagation()
+              e.preventDefault()
               p.removeNotification()
             }}
           >

--- a/src/modules/notifications/components/notifications-view.jsx
+++ b/src/modules/notifications/components/notifications-view.jsx
@@ -90,7 +90,7 @@ export default class NotificationsView extends Component {
               />
             ))}
           </div> :
-          <NullStateMessage message="No Notifications" />
+          <NullStateMessage className={Styles.NullStateMessage} message="No Notifications" />
         }
       </section>
     )

--- a/src/modules/notifications/components/notifications-view.styles.less
+++ b/src/modules/notifications/components/notifications-view.styles.less
@@ -26,7 +26,7 @@
   margin-left: -10px;
   pointer-events: none;
   position: absolute;
-  right: 0.5rem;
+  right: 0.2rem;
   width: 0;
 }
 
@@ -40,6 +40,11 @@
   cursor: pointer;
   display: none;
   width: @font-size-rather-large;
+}
+
+.NullStateMessage {
+  color: @color-text-dark;
+  width: 100%;
 }
 
 @media @breakpoint-mobile {

--- a/src/modules/notifications/components/notifications-view.styles.less
+++ b/src/modules/notifications/components/notifications-view.styles.less
@@ -44,6 +44,7 @@
 
 .NullStateMessage {
   color: @color-text-dark;
+  text-align: center;
   width: 100%;
 }
 

--- a/src/modules/topics/components/topics-view/topics-view.styles.less
+++ b/src/modules/topics/components/topics-view/topics-view.styles.less
@@ -11,7 +11,7 @@
   .standard-view-padding();
 
   position: relative;
-  z-index: @above-all-content;
+  z-index: @default-z-index;
 }
 
 .TopicsHeading {
@@ -53,5 +53,5 @@
 
 .Topics__paginator {
   position: relative;
-  z-index: 10;
+  z-index: @default-z-index;
 }


### PR DESCRIPTION
fixed some visual issues with the top-bar so that it actually displays the full label text for P/L. also tried to do more to allow the full topbar to fit on a 900 px display before the mobile collapse occurs. Fixed an issue that was placing the z-index of the background and categories above the topbar/notifications center making it impossible to click on notifications on the category page. 

Also wired up the 30 day/1 day PL values in the topbar to the actual coreStats data from the state and removed a `DangerouslySetInnerHTML` call.