### PR TITLE
Fix PrivateKey warning

### DIFF
--- a/src/modules/app/components/inner-nav/account-inner-nav.jsx
+++ b/src/modules/app/components/inner-nav/account-inner-nav.jsx
@@ -7,7 +7,7 @@ import { ACCOUNT_DEPOSIT, ACCOUNT_WITHDRAW, ACCOUNT_EXPORT } from 'modules/route
 export default class AccountInnerNav extends BaseInnerNav {
   static propTypes = {
     ...BaseInnerNav.propTypes,
-    privateKey: PropTypes.string.isRequired
+    privateKey: PropTypes.string
   }
 
   getMainMenuData() {


### PR DESCRIPTION
fixes issue with account Inner Nav complaining about privateKey when there will never be one for unlocked Geth Accounts, so privateKey cannot be required.