### PR TITLE
Fix airbitz transactions

### DIFF
--- a/src/modules/auth/actions/login-with-airbitz.js
+++ b/src/modules/auth/actions/login-with-airbitz.js
@@ -15,7 +15,7 @@ export const loginWithAirbitzEthereumWallet = (airbitzAccount, ethereumWallet, h
     ...account,
     meta: {
       address: account.address,
-      signer: typeof privateKey === 'string' ? Buffer.from(privateKey, 'hex') : privateKey,
+      signer: Buffer.from(privateKey, 'hex'),
       accountType: augur.rpc.constants.ACCOUNT_TYPES.PRIVATE_KEY
     },
     name: airbitzAccount.username,

--- a/src/modules/auth/actions/login-with-airbitz.js
+++ b/src/modules/auth/actions/login-with-airbitz.js
@@ -15,7 +15,7 @@ export const loginWithAirbitzEthereumWallet = (airbitzAccount, ethereumWallet, h
     ...account,
     meta: {
       address: account.address,
-      signer: privateKey,
+      signer: typeof privateKey === 'string' ? Buffer.from(privateKey, "hex") : privateKey,
       accountType: augur.rpc.constants.ACCOUNT_TYPES.PRIVATE_KEY
     },
     name: airbitzAccount.username,

--- a/src/modules/auth/actions/login-with-airbitz.js
+++ b/src/modules/auth/actions/login-with-airbitz.js
@@ -15,7 +15,7 @@ export const loginWithAirbitzEthereumWallet = (airbitzAccount, ethereumWallet, h
     ...account,
     meta: {
       address: account.address,
-      signer: typeof privateKey === 'string' ? Buffer.from(privateKey, "hex") : privateKey,
+      signer: typeof privateKey === 'string' ? Buffer.from(privateKey, 'hex') : privateKey,
       accountType: augur.rpc.constants.ACCOUNT_TYPES.PRIVATE_KEY
     },
     name: airbitzAccount.username,


### PR DESCRIPTION
found an issue with airbitz not actually able to sign anything through augur.js, turns out we were saving/sending a privateKey in a hex string form, but augur.js was expecting a buffer. this should clear that up.