### PR TITLE
5531-update-collectFees

### DIFF
--- a/src/modules/market/components/market-outstanding-returns/market-outstanding-returns.jsx
+++ b/src/modules/market/components/market-outstanding-returns/market-outstanding-returns.jsx
@@ -1,9 +1,21 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import Styles from 'modules/market/components/market-outstanding-returns/market-outstanding-returns.styles'
+
 const OutstandingReturns = p => (
-  <div>
-      Outstanding Returns {p.unclaimedCreatorFees.full}
+  <div className={Styles.MarketOutstandingReturns}>
+    Outstanding Returns {p.unclaimedCreatorFees.full}
+    <div className={Styles.MarketOutstandingReturns__actions}>
+      <button
+        className={Styles.MarketOutstandingReturns__collect}
+        onClick={() => {
+          p.collectMarketCreatorFees(p.id)
+        }}
+      >
+        Collect Returns
+      </button>
+    </div>
   </div>
 )
 

--- a/src/modules/market/components/market-outstanding-returns/market-outstanding-returns.jsx
+++ b/src/modules/market/components/market-outstanding-returns/market-outstanding-returns.jsx
@@ -19,8 +19,11 @@ const OutstandingReturns = p => (
   </div>
 )
 
+
 OutstandingReturns.propTypes = {
-  unclaimedCreatorFees: PropTypes.object.isRequired
+  id: PropTypes.string.isRequired,
+  unclaimedCreatorFees: PropTypes.object.isRequired,
+  collectMarketCreatorFees: PropTypes.func.isRequired,
 }
 
 export default OutstandingReturns

--- a/src/modules/market/components/market-outstanding-returns/market-outstanding-returns.styles.less
+++ b/src/modules/market/components/market-outstanding-returns/market-outstanding-returns.styles.less
@@ -1,0 +1,26 @@
+@import (reference) '~assets/styles/shared';
+
+.MarketOutstandingReturns {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.MarketOutstandingReturns__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.MarketOutstandingReturns__collect {
+  &:extend(.button--purple all);
+}
+
+@media @breakpoint-mobile-medium {
+  .MarketOutstandingReturns {
+    display: block;
+  }
+
+  .MarketOutstandingReturns__actions {
+    margin-top: 1.5rem;
+  }
+}

--- a/src/modules/market/components/market-preview/market-preview.jsx
+++ b/src/modules/market/components/market-preview/market-preview.jsx
@@ -17,7 +17,11 @@ const MarketPreview = p => (
     </div>
     {p.outstandingReturns && p.unclaimedCreatorFees.value > 0 &&
       <div className={classNames(Styles.MarketPreview__footer, { [`${Styles['single-card']}`]: p.cardStyle === 'single-card' })}>
-        <OutstandingReturns {...p} />
+        <OutstandingReturns
+          id={p.id}
+          unclaimedCreatorFees={p.unclaimedCreatorFees}
+          collectMarketCreatorFees={p.collectMarketCreatorFees}
+        />
       </div>
     }
   </article>

--- a/src/modules/market/components/market-preview/market-preview.jsx
+++ b/src/modules/market/components/market-preview/market-preview.jsx
@@ -15,9 +15,9 @@ const MarketPreview = p => (
     <div className={classNames(Styles.MarketPreview__footer, { [`${Styles['single-card']}`]: p.cardStyle === 'single-card' })}>
       <MarketProperties {...p} />
     </div>
-    {p.outstandingReturns &&
+    {p.outstandingReturns && p.unclaimedCreatorFees.value > 0 &&
       <div className={classNames(Styles.MarketPreview__footer, { [`${Styles['single-card']}`]: p.cardStyle === 'single-card' })}>
-        <OutstandingReturns unclaimedCreatorFees={p.unclaimedCreatorFees} />
+        <OutstandingReturns {...p} />
       </div>
     }
   </article>

--- a/src/modules/market/components/market-properties/market-properties.jsx
+++ b/src/modules/market/components/market-properties/market-properties.jsx
@@ -51,7 +51,10 @@ const MarketProperties = (p) => {
         {p.linkType && p.linkType === TYPE_COLLECT_FEES &&
           <li>
             <span>Collected Returns</span>
-            <ValueDenomination formatted={p.marketCreatorFeesCollected.rounded} denomination={p.marketCreatorFeesCollected.denomination} />
+            <ValueDenomination
+              formatted={p.marketCreatorFeesCollected.rounded}
+              denomination={p.marketCreatorFeesCollected.denomination}
+            />
           </li>
         }
       </ul>

--- a/src/modules/market/components/market-properties/market-properties.jsx
+++ b/src/modules/market/components/market-properties/market-properties.jsx
@@ -29,9 +29,6 @@ const MarketProperties = (p) => {
     case TYPE_TRADE:
       buttonText = 'Trade'
       break
-    case TYPE_COLLECT_FEES:
-      buttonText = 'Collect Fees'
-      break
     default:
       buttonText = 'View'
   }
@@ -51,6 +48,12 @@ const MarketProperties = (p) => {
           <span>Expires</span>
           <span>{ p.endDate.formatted }</span>
         </li>
+        {p.linkType && p.linkType === TYPE_COLLECT_FEES &&
+          <li>
+            <span>Collected Returns</span>
+            <ValueDenomination formatted={p.marketCreatorFeesCollected.rounded} denomination={p.marketCreatorFeesCollected.denomination} />
+          </li>
+        }
       </ul>
       <div className={Styles.MarketProperties__actions}>
         { p.isLogged && p.toggleFavorite &&
@@ -80,17 +83,6 @@ const MarketProperties = (p) => {
             onClick={e => console.log('call to finalize market')}
           >
             Finalize
-          </button>
-        }
-        { p.linkType && p.linkType === TYPE_COLLECT_FEES &&
-          <button
-            className={Styles.MarketProperties__trade}
-            disabled={(p.unclaimedCreatorFees.formattedValue === 0)}
-            onClick={() => {
-              p.collectMarketCreatorFees(p.id)
-            }}
-          >
-            { p.buttonText || buttonText }
           </button>
         }
       </div>

--- a/src/modules/market/selectors/market.js
+++ b/src/modules/market/selectors/market.js
@@ -270,6 +270,8 @@ export function assembleMarket(
 
       market.unclaimedCreatorFees = formatEther(marketData.unclaimedCreatorFees)
 
+      market.marketCreatorFeesCollected = formatEther(marketData.marketCreatorFeesCollected || 0)
+
       // market.priceTimeSeries = selectPriceTimeSeries(market.outcomes, marketPriceHistory)
 
       market.reportableOutcomes = selectReportableOutcomes(market.type, market.outcomes)

--- a/src/modules/portfolio/components/markets/markets.jsx
+++ b/src/modules/portfolio/components/markets/markets.jsx
@@ -294,6 +294,7 @@ class MyMarkets extends Component {
             linkType={TYPE_COLLECT_FEES}
             outstandingReturns
             paginationPageParam="reporting"
+            collectMarketCreatorFees={p.collectMarketCreatorFees}
           />
         }
         {haveMarkets && s.filteredMarketsReporting.length === 0 && <div className={Styles['Markets__nullState--spacer']} />}
@@ -331,6 +332,7 @@ class MyMarkets extends Component {
             linkType={TYPE_COLLECT_FEES}
             outstandingReturns
             paginationPageParam="final"
+            collectMarketCreatorFees={p.collectMarketCreatorFees}
           />
         }
         {haveMarkets && s.filteredMarketsFinal.length === 0 && <div className={Styles['Markets__nullState--spacer']} />}


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/5531/update-collect-fees-layout-on-portfolio-my-markets

moved collect fees to the outstanding returns bar. hide outstanding returns if we don't have any to collect, added collected returns to the market properties bar but only in my markets view.