### PR TITLE
5484-liquidity-data-bug

### DIFF
--- a/src/modules/market/components/market-basics/market-basics.jsx
+++ b/src/modules/market/components/market-basics/market-basics.jsx
@@ -43,11 +43,11 @@ const MarketBasics = p => (
         </MarketLink>
       </h1>
 
-      {(p.type === BINARY || p.type === SCALAR) &&
-        <MarketOutcomesBinaryScalar outcomes={p.outcomes} min={p.minValue} max={p.maxValue} type={p.type} />
+      {(p.marketType === BINARY || p.marketType === SCALAR) &&
+        <MarketOutcomesBinaryScalar outcomes={p.outcomes} min={p.minValue} max={p.maxValue} type={p.marketType} />
       }
 
-      {p.type === 'categorical' &&
+      {p.marketType === 'categorical' &&
         <MarketOutcomesCategorical outcomes={p.outcomes} />
       }
     </div>


### PR DESCRIPTION
fixed a bug that was causing the market outcome liquidity info to not display on the market cards.

https://app.clubhouse.io/augur/story/5484/markets-page-debug-why-liquidity-data-isn-t-display-on-market-cards
