### PR TITLE
5547 notification updates

### DIFF
--- a/src/assets/styles/_box-shadow.less
+++ b/src/assets/styles/_box-shadow.less
@@ -1,3 +1,3 @@
 // TODO -- there are a few occurances of box shadow
 // 	For consistency, need to build up a mixin
-@box-shadow-notifications: 0 2px 4px 0 rgba(0,0,0,0.50);
+@box-shadow-notifications: 0 2px 4px 0 rgba(0, 0, 0, 0.5);

--- a/src/assets/styles/_box-shadow.less
+++ b/src/assets/styles/_box-shadow.less
@@ -1,2 +1,3 @@
 // TODO -- there are a few occurances of box shadow
 // 	For consistency, need to build up a mixin
+@box-shadow-notifications: 0 2px 4px 0 rgba(0,0,0,0.50);

--- a/src/assets/styles/shared.less
+++ b/src/assets/styles/shared.less
@@ -7,6 +7,7 @@
 @import '_animations';
 @import '_arrangement';
 @import '_borders';
+@import '_box-shadow';
 @import '_buttons';
 @import '_responsive';
 @import '_inputs';

--- a/src/modules/account/components/account-header/account-header.styles.less
+++ b/src/modules/account/components/account-header/account-header.styles.less
@@ -67,7 +67,7 @@
     padding-bottom: 5rem;
     position: absolute;
     width: 100vw;
-    z-index: 1000; // TOOD - clean this up
+    z-index: @above-all-content;
   }
 
   .AccountHeader__Currency-value {

--- a/src/modules/app/components/app/app.jsx
+++ b/src/modules/app/components/app/app.jsx
@@ -23,6 +23,7 @@ import SideNav from 'modules/app/components/side-nav/side-nav'
 import Origami from 'modules/app/components/origami-svg/origami-svg'
 import Logo from 'modules/app/components/logo/logo'
 import Routes from 'modules/routes/components/routes/routes'
+import NotificationsContainer from 'modules/notifications/container'
 
 import MobileNavHamburgerIcon from 'modules/common/components/mobile-nav-hamburger-icon'
 import MobileNavCloseIcon from 'modules/common/components/mobile-nav-close-icon'
@@ -338,8 +339,21 @@ export default class AppView extends Component {
     let origamiScalar = 0
 
     const mainSectionClickHandler = () => {
+      const stateUpdate = {}
+      let updateState = false
+
       if (this.props.isMobile && this.state.mobileMenuState !== mobileMenuStates.CLOSED) {
-        this.setState({ mobileMenuState: mobileMenuStates.CLOSED })
+        stateUpdate.mobileMenuState = mobileMenuStates.CLOSED
+        updateState = true
+      }
+
+      if (this.state.isNotificationsVisible) {
+        stateUpdate.isNotificationsVisible = false
+        updateState = true
+      }
+
+      if (updateState) {
+        this.setState(stateUpdate)
       }
     }
 
@@ -355,7 +369,7 @@ export default class AppView extends Component {
       // ensure origami fold-out moves perfectly with submenu
       origamiScalar = Math.max(0, (subMenu.scalar + mainMenu.scalar) - 1)
     }
-
+    // console.log('rendering app', p)
     return (
       <main>
         <Helmet
@@ -400,11 +414,14 @@ export default class AppView extends Component {
                 isLogged={p.isLogged}
                 stats={p.coreStats}
                 unseenCount={unseenCount}
-                isNotificationsVisible={s.isNotificationsVisible}
                 toggleNotifications={this.toggleNotifications}
-                notifications={p.notifications}
               />
             </section>
+            {p.isLogged && s.isNotificationsVisible &&
+              <NotificationsContainer
+                toggleNotifications={() => this.toggleNotifications()}
+              />
+            }
             <section
               className={Styles.Main__wrap}
               style={{ marginLeft: categoriesMargin }}

--- a/src/modules/app/components/app/app.jsx
+++ b/src/modules/app/components/app/app.jsx
@@ -369,7 +369,7 @@ export default class AppView extends Component {
       // ensure origami fold-out moves perfectly with submenu
       origamiScalar = Math.max(0, (subMenu.scalar + mainMenu.scalar) - 1)
     }
-    // console.log('rendering app', p)
+
     return (
       <main>
         <Helmet

--- a/src/modules/app/components/top-bar/top-bar.jsx
+++ b/src/modules/app/components/top-bar/top-bar.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
 import { Notifications } from 'modules/common/components/icons/icons'
-import NotificationsContainer from 'modules/notifications/container'
 
 import Styles from 'modules/app/components/top-bar/top-bar.styles'
 
@@ -58,11 +57,6 @@ const TopBar = props => (
           >
             {Notifications(props.unseenCount)}
           </button>
-          {props.isLogged && props.isNotificationsVisible &&
-            <NotificationsContainer
-              toggleNotifications={() => props.toggleNotifications()}
-            />
-          }
         </div>
       </section>
     }
@@ -74,9 +68,7 @@ TopBar.propTypes = {
   isLogged: PropTypes.bool.isRequired,
   stats: PropTypes.array.isRequired,
   unseenCount: PropTypes.number.isRequired,
-  isNotificationsVisible: PropTypes.bool.isRequired,
   toggleNotifications: PropTypes.func.isRequired,
-  notifications: PropTypes.object
 }
 
 export default TopBar

--- a/src/modules/app/components/top-bar/top-bar.styles.less
+++ b/src/modules/app/components/top-bar/top-bar.styles.less
@@ -36,9 +36,9 @@
 }
 
 .TopBar__notification-icon {
+  margin-right: 2rem;
   vertical-align: middle;
   width: @font-size-rather-large;
-  margin-right: 2rem;
 }
 
 .TopBar__stat-label {

--- a/src/modules/app/components/top-bar/top-bar.styles.less
+++ b/src/modules/app/components/top-bar/top-bar.styles.less
@@ -24,7 +24,6 @@
   letter-spacing: 0.05em;
   line-height: 2.6rem;
   margin: 0 0.5rem;
-  // width: 7.85rem;
 }
 
 .TopBar__notifications {
@@ -34,12 +33,12 @@
   letter-spacing: 0.05em;
   line-height: 2.6rem;
   text-align: center;
-  width: 2.25rem;
 }
 
 .TopBar__notification-icon {
   vertical-align: middle;
   width: @font-size-rather-large;
+  margin-right: 2rem;
 }
 
 .TopBar__stat-label {

--- a/src/modules/notifications/components/notifications-view.styles.less
+++ b/src/modules/notifications/components/notifications-view.styles.less
@@ -4,7 +4,7 @@
   background: @color-lightergray;
   box-shadow: @box-shadow-notifications;
   color: @color-text-dark;
-  display: block;
+  display: flex;
   height: 30.25rem;
   max-height: 80%;
   padding: 0.25em;
@@ -39,7 +39,11 @@
 .Notification__close {
   cursor: pointer;
   display: none;
-  width: @font-size-rather-large;
+  height: @font-size-normal;
+  left: @font-size-normal;
+  position: absolute;
+  top: @font-size-normal;
+  width: @font-size-normal;
 }
 
 .NullStateMessage {
@@ -85,5 +89,9 @@
 
   .Notification__close {
     display: block;
+  }
+
+  .NullStateMessage {
+    margin: auto 0;
   }
 }

--- a/src/modules/notifications/components/notifications-view.styles.less
+++ b/src/modules/notifications/components/notifications-view.styles.less
@@ -92,6 +92,6 @@
   }
 
   .NullStateMessage {
-    margin: auto 0;
+    margin-top: 0.5rem;
   }
 }

--- a/src/modules/notifications/components/notifications-view.styles.less
+++ b/src/modules/notifications/components/notifications-view.styles.less
@@ -2,18 +2,18 @@
 
 .NotificationsView {
   background: @color-lightergray;
-  box-shadow: 0.1rem 0.2rem 0.5rem @color-almostblack;
+  box-shadow: @box-shadow-notifications;
   color: @color-text-dark;
   display: block;
   height: 30.25rem;
   max-height: 80%;
   padding: 0.25em;
   position: absolute;
-  right: 0.25rem;
+  right: 1.8rem;
   text-align: left;
   top: 3rem;
-  width: 20em;
-  z-index: 1000;
+  width: 22.75rem;
+  z-index: @mask-modal;
 }
 
 .NotificationsView::after {
@@ -43,7 +43,10 @@
 }
 
 .NullStateMessage {
-  color: @color-text-dark;
+  align-self: center;
+  color: @color-lightgray;
+  font-size: 1rem;
+  font-weight: 400;
   text-align: center;
   width: 100%;
 }
@@ -52,7 +55,6 @@
   .NotificationsView {
     background: @color-lightergray;
     bottom: 0;
-    box-shadow: 0.1rem 0.2rem 0.5rem @color-almostblack;
     color: @color-text-dark;
     display: flex;
     flex-flow: column nowrap;
@@ -65,7 +67,7 @@
     text-align: left;
     top: 0;
     width: 100%;
-    z-index: 1000;
+    z-index: @mask-modal;
   }
 
   .NotificationsView::after {

--- a/src/modules/notifications/components/notifications-view.styles.less
+++ b/src/modules/notifications/components/notifications-view.styles.less
@@ -13,7 +13,7 @@
   text-align: left;
   top: 3rem;
   width: 22.75rem;
-  z-index: @mask-modal;
+  z-index: @mask-above;
 }
 
 .NotificationsView::after {

--- a/src/modules/notifications/components/notifications-view.styles.less
+++ b/src/modules/notifications/components/notifications-view.styles.less
@@ -71,7 +71,7 @@
     text-align: left;
     top: 0;
     width: 100%;
-    z-index: @mask-modal;
+    z-index: @mask-above;
   }
 
   .NotificationsView::after {


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/5547/notifications-style-and-functionality-fixes

Don't actually merge this until @sharkcrayon has weighed in on the position of the mobile null state message. Otherwise this should be good to go. One thing i added that wasn't explicitly in the ticket was a resize/position of the mobile close notification X that appears in the top left corner. I made it match it's position and size to the close X that appears when the side nav is open in mobile. this makes it feel more consistent and doesn't feel as jarring.