### PR TITLE
6614-market-create-date

### DIFF
--- a/src/modules/auth/actions/transfer-funds.js
+++ b/src/modules/auth/actions/transfer-funds.js
@@ -31,7 +31,7 @@ export function transferFunds(amount, currency, toAddress) {
               id: `onSent-${tx.hash}`,
               title: `Transfer Ether -- Pending`,
               description: `${amount} ETH -> ${trimString(to)}`,
-              timestamp: parseInt(getCurrentDateTimestamp(), 10),
+              timestamp: getCurrentDateTimestamp(),
             }))
           },
           onSuccess: (tx) => {
@@ -39,7 +39,7 @@ export function transferFunds(amount, currency, toAddress) {
               id: `onSent-${tx.hash}`,
               title: `Transfer Ether -- Success`,
               description: `${amount} ETH -> ${trimString(to)}`,
-              timestamp: parseInt(getCurrentDateTimestamp(), 10),
+              timestamp: getCurrentDateTimestamp(),
             }))
             dispatch(updateAssets)
           },
@@ -48,7 +48,7 @@ export function transferFunds(amount, currency, toAddress) {
               id: `onSent-${tx.hash}`,
               title: `Transfer Ether -- Failed`,
               description: `${amount} ETH -> ${trimString(to)}`,
-              timestamp: parseInt(getCurrentDateTimestamp(), 10),
+              timestamp: getCurrentDateTimestamp(),
             }))
           }
         })

--- a/src/modules/auth/actions/transfer-funds.js
+++ b/src/modules/auth/actions/transfer-funds.js
@@ -2,6 +2,7 @@ import speedomatic from 'speedomatic'
 import { augur } from 'services/augurjs'
 import { updateAssets } from 'modules/auth/actions/update-assets'
 import { addNotification } from 'modules/notifications/actions/update-notifications'
+import { getCurrentDateTimestamp } from 'utils/format-date'
 
 import trimString from 'utils/trim-string'
 
@@ -30,7 +31,7 @@ export function transferFunds(amount, currency, toAddress) {
               id: `onSent-${tx.hash}`,
               title: `Transfer Ether -- Pending`,
               description: `${amount} ETH -> ${trimString(to)}`,
-              timestamp: parseInt(Date.now() / 1000, 10),
+              timestamp: parseInt(getCurrentDateTimestamp(), 10),
             }))
           },
           onSuccess: (tx) => {
@@ -38,7 +39,7 @@ export function transferFunds(amount, currency, toAddress) {
               id: `onSent-${tx.hash}`,
               title: `Transfer Ether -- Success`,
               description: `${amount} ETH -> ${trimString(to)}`,
-              timestamp: parseInt(Date.now() / 1000, 10),
+              timestamp: parseInt(getCurrentDateTimestamp(), 10),
             }))
             dispatch(updateAssets)
           },
@@ -47,7 +48,7 @@ export function transferFunds(amount, currency, toAddress) {
               id: `onSent-${tx.hash}`,
               title: `Transfer Ether -- Failed`,
               description: `${amount} ETH -> ${trimString(to)}`,
-              timestamp: parseInt(Date.now() / 1000, 10),
+              timestamp: parseInt(getCurrentDateTimestamp(), 10),
             }))
           }
         })

--- a/src/modules/create-market/actions/submit-new-market.js
+++ b/src/modules/create-market/actions/submit-new-market.js
@@ -22,7 +22,7 @@ export function submitNewMarket(newMarket, history) {
     // General Properties
     const formattedNewMarket = {
       universe: universe.id,
-      _endTime: parseInt(newMarket.endDate.timestamp / 1000, 10),
+      _endTime: parseInt(newMarket.endDate.timestamp, 10),
       _feePerEthInWei: speedomatic.fix(newMarket.settlementFee / 100, 'hex'),
       _denominationToken: contractAddresses.Cash,
       _description: newMarket.description,

--- a/src/modules/create-market/components/create-market-form-resolution/create-market-form-resolution.jsx
+++ b/src/modules/create-market/components/create-market-form-resolution/create-market-form-resolution.jsx
@@ -48,7 +48,7 @@ export default class CreateMarketResolution extends Component {
 
     this.state = {
       // expirySourceType: false,
-      date: Object.keys(this.props.newMarket.endDate).length ? moment(this.props.newMarket.endDate.timestamp) : null,
+      date: Object.keys(this.props.newMarket.endDate).length ? moment(this.props.newMarket.endDate.timestamp * 1000) : null,
       focused: false,
     }
 

--- a/src/modules/create-market/components/create-market-preview/create-market-preview.jsx
+++ b/src/modules/create-market/components/create-market-preview/create-market-preview.jsx
@@ -25,7 +25,7 @@ export default class CreateMarketPreview extends Component {
       return '-'
     }
 
-    const endDate = moment(p.newMarket.endDate.timestamp)
+    const endDate = moment(p.newMarket.endDate.timestamp * 1000)
     endDate.set({
       hour: p.newMarket.hour,
       minute: p.newMarket.minute,

--- a/src/modules/create-market/components/create-market-review.jsx
+++ b/src/modules/create-market/components/create-market-review.jsx
@@ -64,7 +64,7 @@ export default class CreateMarketReview extends Component {
     const self = this
     augur.createMarket.getMarketCreationCostBreakdown({
       universe: this.props.universe.id,
-      _endTime: this.props.endDate.timestamp / 1000
+      _endTime: this.props.endDate.timestamp
     }, (err, marketCreationCostBreakdown) => {
       if (err) return console.error(err)
       self.setState({

--- a/src/modules/market/selectors/market.js
+++ b/src/modules/market/selectors/market.js
@@ -23,7 +23,7 @@ This is true for all selectors, but especially important for this one.
 import BigNumber from 'bignumber.js'
 import memoize from 'memoizee'
 import { formatShares, formatEtherTokens, formatEther, formatPercent, formatNumber } from 'utils/format-number'
-import { formatDate } from 'utils/format-date'
+import { formatDate, getCurrentDateTimestamp, convertUnix } from 'utils/format-date'
 import { isMarketDataOpen, isMarketDataExpired } from 'utils/is-market-data-open'
 
 import { UNIVERSE_ID } from 'modules/app/constants/network'
@@ -69,7 +69,7 @@ export const selectMarket = (marketID) => {
     return {}
   }
 
-  const endDate = new Date((marketsData[marketID].endDate * 1000) || 0)
+  const endDate = convertUnix(marketsData[marketID].endDate)
 
   return assembleMarket(
     marketID,
@@ -77,7 +77,7 @@ export const selectMarket = (marketID) => {
     marketLoading.indexOf(marketID) !== -1,
     priceHistory[marketID],
     isMarketDataOpen(marketsData[marketID]),
-    isMarketDataExpired(marketsData[marketID], new Date().getTime()),
+    isMarketDataExpired(marketsData[marketID], getCurrentDateTimestamp()),
 
     !!favorites[marketID],
     outcomesData[marketID],
@@ -88,9 +88,9 @@ export const selectMarket = (marketID) => {
     tradesInProgress[marketID],
 
     // the reason we pass in the date parts broken up like this, is because date objects are never equal, thereby always triggering re-assembly, and never hitting the memoization cache
-    endDate.getFullYear(),
-    endDate.getMonth(),
-    endDate.getDate(),
+    endDate.value.getFullYear(),
+    endDate.value.getMonth(),
+    endDate.value.getDate(),
 
     universe && universe.currentReportingWindowAddress,
 

--- a/src/modules/market/selectors/market.js
+++ b/src/modules/market/selectors/market.js
@@ -23,7 +23,7 @@ This is true for all selectors, but especially important for this one.
 import BigNumber from 'bignumber.js'
 import memoize from 'memoizee'
 import { formatShares, formatEtherTokens, formatEther, formatPercent, formatNumber } from 'utils/format-number'
-import { formatDate, getCurrentDateTimestamp, convertUnix } from 'utils/format-date'
+import { formatDate, getCurrentDateTimestamp, convertUnixToFormattedDate } from 'utils/format-date'
 import { isMarketDataOpen, isMarketDataExpired } from 'utils/is-market-data-open'
 
 import { UNIVERSE_ID } from 'modules/app/constants/network'
@@ -69,7 +69,7 @@ export const selectMarket = (marketID) => {
     return {}
   }
 
-  const endDate = convertUnix(marketsData[marketID].endDate)
+  const endDate = convertUnixToFormattedDate(marketsData[marketID].endDate)
 
   return assembleMarket(
     marketID,

--- a/src/modules/transactions/actions/add-transactions.js
+++ b/src/modules/transactions/actions/add-transactions.js
@@ -2,7 +2,7 @@ import { MARKET_CREATION, TRANSFER, REPORTING, TRADE, OPEN_ORDER, BUY, SELL } fr
 import { SUCCESS } from 'modules/transactions/constants/statuses'
 import { updateTransactionsData } from 'modules/transactions/actions/update-transactions-data'
 import { eachOf, each, groupBy } from 'async'
-import { convertUnix } from 'src/utils/format-date'
+import { convertUnixToFormattedDate } from 'src/utils/format-date'
 
 export function addTransactions(transactionsArray) {
   return (dispatch, getState) => {
@@ -176,7 +176,7 @@ export function addOpenOrderTransactions(openOrders) {
             transaction.id = transaction.transactionHash + transaction.logIndex
             transaction.message = `${transaction.orderState} - ${type} ${transaction.amount} Shares @ ${transaction.price} ETH`
             const meta = {}
-            creationTime = convertUnix(transaction.creationTime)
+            creationTime = convertUnixToFormattedDate(transaction.creationTime)
             meta.txhash = transaction.transactionHash
             meta.timestamp = creationTime.full
             meta.outcome = outcomeID // need to get payNumerators ?
@@ -243,7 +243,7 @@ function buildHeader(item, type, status) {
   header.status = status
   header.hash = item.id
   // TODO: need to sort by datetime in render
-  header.timestamp = convertUnix(item.timestamp ? item.timestamp : item.creationTime)
+  header.timestamp = convertUnixToFormattedDate(item.timestamp ? item.timestamp : item.creationTime)
   header.sortOrder = getSortOrder(type)
   return header
 }

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -35,7 +35,7 @@ export function formatDate(d) {
     formattedLocal: `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} ${localTimeTwelve.join(':')} ${localAMPM} (UTC ${localOffset})`, // local time
     formattedLocalShort: `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} (UTC ${localOffset})`, // local time
     full: date.toUTCString(),
-    timestamp: date.getTime() / 1000
+    timestamp: date.getTime()
   }
 }
 

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -35,7 +35,7 @@ export function formatDate(d) {
     formattedLocal: `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} ${localTimeTwelve.join(':')} ${localAMPM} (UTC ${localOffset})`, // local time
     formattedLocalShort: `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} (UTC ${localOffset})`, // local time
     full: date.toUTCString(),
-    timestamp: date.getTime()
+    timestamp: date.getTime() / 1000
   }
 }
 
@@ -51,7 +51,7 @@ function getTwelveHour(time) {
   return time
 }
 
-export function convertUnix(integer) {
+export function convertUnix(integer = 0) {
   return formatDate(moment.unix(integer).toDate())
 }
 
@@ -73,4 +73,9 @@ export function getBeginDate(periodString) {
 export function dateHasPassed(unixTimestamp) {
   const date = moment().utc()
   return (date.unix() >= unixTimestamp)
+}
+
+/** timestamps are always in seconds */
+export function getCurrentDateTimestamp() {
+  return Date.now() / 1000
 }

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -51,7 +51,7 @@ function getTwelveHour(time) {
   return time
 }
 
-export function convertUnix(integer = 0) {
+export function convertUnixToFormattedDate(integer = 0) {
   return formatDate(moment.unix(integer).toDate())
 }
 

--- a/src/utils/is-market-data-open.js
+++ b/src/utils/is-market-data-open.js
@@ -6,7 +6,7 @@ export function isMarketDataExpired(marketData, currentTime) {
   if (!marketData || !marketData.endDate || !currentTime) {
     return false
   }
-  return marketData.endDate < parseInt(currentTime / 1000, 10)
+  return marketData.endDate < parseInt(currentTime, 10)
 }
 
 export function isMarketDataPreviousReportPeriod(marketData, currentPeriod, reportingPeriodDurationInSeconds) {

--- a/test/create-market/actions/submit-new-market-test.js
+++ b/test/create-market/actions/submit-new-market-test.js
@@ -76,7 +76,7 @@ describe('modules/create-market/actions/submit-new-market', () => {
         },
         _designatedReporterAddress: '0x1233',
         universe: '1010101',
-        _endTime: 1234567890,
+        _endTime: 1234567890000,
         _denominationToken: 'domnination',
         _description: 'test description',
         _extraInfo: {
@@ -153,7 +153,7 @@ describe('modules/create-market/actions/submit-new-market', () => {
           test: 'object'
         },
         universe: '1010101',
-        _endTime: 1234567890,
+        _endTime: 1234567890000,
         _denominationToken: 'domnination',
         _description: 'test description',
         _extraInfo: {
@@ -230,7 +230,7 @@ describe('modules/create-market/actions/submit-new-market', () => {
         },
         _designatedReporterAddress: '0x01234abcd',
         universe: '1010101',
-        _endTime: 1234567890,
+        _endTime: 1234567890000,
         _denominationToken: 'domnination',
         _description: 'test description',
         _extraInfo: {


### PR DESCRIPTION
timestamp needs to be in seconds unix timestamp. This looks like format-date thought it was in  milliseconds format. The Create market UI was showing year 1970 and causing market creates to fail. At least that is 1 reason the fail.

https://app.clubhouse.io/augur/story/6614/market-create-date-control-not-setting-date-in-state-correctly
currently in unscheduled, I thought this was a priority so made the code change based on input from @epheph and @justinbarry 


pushed as much date stuff as I could into format-date. 2 instances of using moment() which needed * 1000 to render the correct date, event though timestamp should have been in seconds. 