### PR TITLE
5782-norm-trans-market

### DIFF
--- a/src/modules/app/actions/listen-to-updates.js
+++ b/src/modules/app/actions/listen-to-updates.js
@@ -42,7 +42,8 @@ export function listenToUpdates(history) {
         if (err) return console.error('MarketCreated:', err)
         if (log) {
           console.log('MarketCreated:', log)
-          dispatch(loadMarketsInfo([log.marketID]))
+          // augur-node emitting log.market from raw contract logs.
+          dispatch(loadMarketsInfo([log.market]))
           if (log.sender === getState().loginAccount.address) {
             dispatch(updateAssets())
             dispatch(convertLogsToTransactions(TYPES.CREATE_MARKET, [log]))

--- a/src/modules/create-market/actions/submit-new-market.js
+++ b/src/modules/create-market/actions/submit-new-market.js
@@ -5,6 +5,7 @@ import { augur, constants } from 'services/augurjs'
 import { invalidateMarketCreation, clearNewMarket } from 'modules/create-market/actions/update-new-market'
 import { updateTradesInProgress } from 'modules/trade/actions/update-trades-in-progress'
 import { placeTrade } from 'modules/trade/actions/place-trade'
+import { addNewMarketCreationTransactions } from 'modules/transactions/actions/add-transactions'
 
 import makePath from 'modules/routes/helpers/make-path'
 
@@ -58,6 +59,7 @@ export function submitNewMarket(newMarket, history) {
       ...formattedNewMarket,
       meta: loginAccount.meta,
       onSent: (res) => {
+        dispatch(addNewMarketCreationTransactions({ ...formattedNewMarket, ...res }))
         history.push(makePath(TRANSACTIONS))
         dispatch(clearNewMarket())
       },

--- a/src/modules/transactions/actions/add-transactions.js
+++ b/src/modules/transactions/actions/add-transactions.js
@@ -128,7 +128,7 @@ export function addNewMarketCreationTransactions(market) {
     }
     const meta = {
       market: market.hash,
-      'designated reporter ': market._designatedReporterAddress,
+      'designated reporter': market._designatedReporterAddress,
       'creation fee': 0,
       'gas fees': 0,
     }

--- a/src/modules/transactions/actions/add-transactions.js
+++ b/src/modules/transactions/actions/add-transactions.js
@@ -1,5 +1,5 @@
 import { MARKET_CREATION, TRANSFER, REPORTING, TRADE, OPEN_ORDER, BUY, SELL } from 'modules/transactions/constants/types'
-import { SUCCESS } from 'modules/transactions/constants/statuses'
+import { SUCCESS, PENDING } from 'modules/transactions/constants/statuses'
 import { updateTransactionsData } from 'modules/transactions/actions/update-transactions-data'
 import { eachOf, each, groupBy } from 'async'
 import { convertUnixToFormattedDate } from 'src/utils/format-date'
@@ -113,6 +113,36 @@ export function addTransferTransactions(transfers) {
       transactions[transaction.id] = header
     })
     dispatch(updateTransactionsData(transactions))
+  }
+}
+
+export function addNewMarketCreationTransactions(market) {
+  return (dispatch, getState) => {
+    const marketCreationData = {}
+    const { loginAccount } = getState()
+    const transaction = {
+      market,
+      timestamp: market._endTime,
+      createdBy: loginAccount.address,
+      id: market.hash
+    }
+    const meta = {
+      market: market.hash,
+      'designated reporter ': market._designatedReporterAddress,
+      'creation fee': 0,
+      'gas fees': 0,
+    }
+    transaction.meta = meta
+
+    const header = {
+      ...buildHeader(transaction, MARKET_CREATION, PENDING),
+      message: 'Market Creation',
+      description: market._description,
+      transactions: [transaction]
+    }
+
+    marketCreationData[transaction.id] = header
+    dispatch(updateTransactionsData(marketCreationData))
   }
 }
 

--- a/src/modules/transactions/reducers/transactions-data.js
+++ b/src/modules/transactions/reducers/transactions-data.js
@@ -2,6 +2,7 @@ import { UPDATE_TRANSACTIONS_DATA } from 'modules/transactions/actions/update-tr
 import { DELETE_TRANSACTION, CLEAR_TRANSACTION_DATA } from 'modules/transactions/actions/delete-transaction'
 import { CLEAR_LOGIN_ACCOUNT } from 'modules/auth/actions/update-login-account'
 import { RESET_STATE } from 'modules/app/actions/reset-state'
+import { PENDING } from 'modules/transactions/constants/statuses'
 
 const DEFAULT_STATE = {}
 
@@ -24,6 +25,12 @@ export default function (transactionsData = DEFAULT_STATE, action) {
         return p
       }, {})
     case CLEAR_TRANSACTION_DATA:
+      return Object.keys(transactionsData).reduce((p, transactionID) => {
+        if (transactionsData[transactionID].status === PENDING) {
+          p[transactionID] = transactionsData[transactionID]
+        }
+        return p
+      }, {})
     case RESET_STATE:
     case CLEAR_LOGIN_ACCOUNT:
       return DEFAULT_STATE

--- a/test/create-market/actions/submit-new-market-test.js
+++ b/test/create-market/actions/submit-new-market-test.js
@@ -11,6 +11,10 @@ import { DESIGNATED_REPORTER_SELF, DESIGNATED_REPORTER_SPECIFIC } from 'modules/
 
 describe('modules/create-market/actions/submit-new-market', () => {
   const mockStore = configureMockStore([thunk])
+  const addNewMarketCreationTransactions =
+    function addTransaction() {
+      return { type: 'addPendingTransaction' }
+    }
 
   const test = t => it(t.description, () => {
     const store = mockStore(t.state || {})
@@ -67,6 +71,7 @@ describe('modules/create-market/actions/submit-new-market', () => {
       })
 
       __RewireAPI__.__Rewire__('augur', mockAugur)
+      __RewireAPI__.__Rewire__('addNewMarketCreationTransactions', addNewMarketCreationTransactions)
 
       store.dispatch(submitNewMarket(store.getState().newMarket))
 
@@ -310,8 +315,12 @@ describe('modules/create-market/actions/submit-new-market', () => {
 
       const expected = [
         {
+          type: 'addPendingTransaction'
+        },
+        {
           type: 'createNewMarket'
-        }
+        },
+
       ]
 
       assert.deepEqual(actual, expected, `Didn't dispatch the expected actions`)


### PR DESCRIPTION
fixed issue where bad transaction formatted blank create market entries gets added to users transaction from convert log to transaction when market is created. 
fixed unit test. 
saw that augur-node sends log.market we were expecting log.marketId, so changed and added comment