### PR TITLE
Create Tooltip Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-modal-dialog": "4.0.7",
     "react-redux": "5.0.6",
     "react-router-dom": "4.2.2",
+    "react-tooltip": "^3.4.0",
     "react-transition-group": "2.2.1",
     "redux": "3.7.2",
     "redux-devtools-extension": "2.13.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react-modal-dialog": "4.0.7",
     "react-redux": "5.0.6",
     "react-router-dom": "4.2.2",
-    "react-tooltip": "^3.4.0",
+    "react-tooltip": "3.4.0",
     "react-transition-group": "2.2.1",
     "redux": "3.7.2",
     "redux-devtools-extension": "2.13.2",

--- a/src/modules/common/less/tooltip.less
+++ b/src/modules/common/less/tooltip.less
@@ -1,3 +1,5 @@
+
+/* stylelint-disable declaration-no-important  */
 @import (reference) '~assets/styles/shared';
 
 .Tooltip {

--- a/src/modules/common/less/tooltip.less
+++ b/src/modules/common/less/tooltip.less
@@ -1,0 +1,52 @@
+@import (reference) '~assets/styles/shared';
+
+.Tooltip {
+  background-color: @color-lightergray !important;
+  border-radius: 0 !important;
+  box-shadow: 0 -2px 4px 0 rgba(0, 0, 0, 0.5);
+  color: @color-darkpurple !important;
+  font-size: @font-size-small !important;
+  line-height: 0.9375rem;
+  max-width: 13.7rem;
+  padding: 1rem 1.5rem !important;
+
+  &::after {
+    border-left-color: @color-lightergray !important;
+  }
+
+  > h4 {
+    font-weight: 500;
+    margin-bottom: 0.75rem;
+  }
+
+  > p {
+    margin: 0 0 0.75rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+:global {
+  .__react_component_tooltip {
+    &.show {
+      opacity: 1 !important;
+    }
+
+    &.place-left {
+      margin-left: -14px;
+      margin-top: -5px;
+
+      &::after {
+        right: -10px !important;
+      }
+
+      &.type-light::after {
+        border-bottom-width: 10px;
+        border-left-width: 10px !important;
+        border-top-width: 10px;
+      }
+    }
+  }
+}

--- a/src/modules/create-market/components/create-market-form-define/create-market-form-define.styles.less
+++ b/src/modules/create-market/components/create-market-form-define/create-market-form-define.styles.less
@@ -38,8 +38,8 @@
   }
 }
 
-.CreateMarketDefine__question {
-  margin-bottom: 2rem !important;
+li.CreateMarketDefine__question {
+  margin-bottom: 2rem;
 }
 
 .CreateMarketDefine__question-disclaimer {

--- a/src/modules/market/less/market-header.less
+++ b/src/modules/market/less/market-header.less
@@ -8,7 +8,7 @@
   }
 
   h3 {
-    margin: 0 !important;
+    margin: 0;
   }
 
   .market-header-actions {

--- a/src/modules/market/less/market-trade-close-dialog.less
+++ b/src/modules/market/less/market-trade-close-dialog.less
@@ -2,7 +2,7 @@
   align-items: center;
   display: flex;
   justify-content: center;
-  padding: 0 !important;
+  padding: 0;
 
   &.action-failed {
     background-color: @color-red-light;

--- a/src/modules/portfolio/components/performance-graph/performance-graph.styles.less
+++ b/src/modules/portfolio/components/performance-graph/performance-graph.styles.less
@@ -3,7 +3,7 @@
 .PerformanceGraph {
   :global {
     .highcharts-container {
-      width: 100% !important;
+      min-width: 100%;
 
       > svg {
         width: 100%;

--- a/src/modules/reporting/components/reporting-dispute/reporting-dispute.jsx
+++ b/src/modules/reporting/components/reporting-dispute/reporting-dispute.jsx
@@ -29,8 +29,6 @@ export default class ReportingDispute extends Component {
         </Helmet>
         <ReportingHeader
           heading="Dispute"
-          showReportingEndDate
-          showParticipationTokens
         />
         {this.props.doesUserHaveRep || <ReportDisputeNoRepState
           btnText="Add Funds"

--- a/src/modules/reporting/components/reporting-dispute/reporting-dispute.jsx
+++ b/src/modules/reporting/components/reporting-dispute/reporting-dispute.jsx
@@ -30,6 +30,7 @@ export default class ReportingDispute extends Component {
         <ReportingHeader
           heading="Dispute"
           showReportingEndDate
+          showParticipationTokens
         />
         {this.props.doesUserHaveRep || <ReportDisputeNoRepState
           btnText="Add Funds"

--- a/src/modules/reporting/components/reporting-header/reporting-header.jsx
+++ b/src/modules/reporting/components/reporting-header/reporting-header.jsx
@@ -1,9 +1,11 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import ReactTooltip from 'react-tooltip'
 
 import { formatDate } from 'utils/format-date'
 
 import Styles from 'modules/reporting/components/reporting-header/reporting-header.styles'
+import TooltipStyles from 'modules/common/less/tooltip'
 
 export default class ReportingHeader extends Component {
   static propTypes = {
@@ -40,7 +42,22 @@ export default class ReportingHeader extends Component {
                     <span className={Styles.ReportingHeader__endDate}>Reporting cycle ends { formattedDate.formattedLocal }</span>
                     <span className={Styles.ReportingHeader__stake}> | </span><span className={Styles.ReportingHeader__stake}>{ p.reportingWindowStats.stake } REP Staked</span>
                   </div>
-                  <span className={Styles.ReportingHeader__participationTokens}>Example Tooltip</span>
+                  <span
+                    className={Styles.ReportingHeader__participationTokens}
+                    data-tip
+                    data-for="tooltip--participation-tokens"
+                  >Example Tooltip
+                  </span>
+                  <ReactTooltip
+                    id="tooltip--participation-tokens"
+                    className={TooltipStyles.Tooltip}
+                    effect="solid"
+                    place="left"
+                    type="light"
+                  >
+                    <h4>Don&apos;t see any markets that need to be disputed?</h4>
+                    <p>Purchase participation tokens to earn a share of the reporting fees collected during this dispute window.</p>
+                  </ReactTooltip>
                 </div>
                 <div className={Styles['ReportingHeader__dispute-graph']}>
                   <div className={Styles.ReportingHeader__graph}>

--- a/src/modules/reporting/components/reporting-header/reporting-header.jsx
+++ b/src/modules/reporting/components/reporting-header/reporting-header.jsx
@@ -33,30 +33,32 @@ export default class ReportingHeader extends Component {
       <article className={Styles.ReportingHeader}>
         <div className={Styles.ReportingHeader__header}>
           <div>
-            { p.heading === 'Reporting' &&
-              <h1 className={Styles.ReportingHeader__heading}>{p.heading}</h1>
-            }
-            { p.heading !== 'Reporting' &&
-              <h1 className={Styles.ReportingHeader__heading}>Reporting: {p.heading}</h1>
-            }
-            { p.showReportingEndDate &&
-              <span className={Styles.ReportingHeader__endDate}>Reporting cycle ends { formattedDate.formattedLocal }</span>
-            }
-            <span className={Styles.ReportingHeader__stake}> | </span><span className={Styles.ReportingHeader__stake}>{ p.reportingWindowStats.stake } REP Staked</span>
-          </div>
-        </div>
-        <div className={Styles['ReportingHeader__graph-wrapper']}>
-          <div className={Styles.ReportingHeader__graph}>
-            <div className={Styles['ReportingHeader__graph-current']}>
-              <div style={currentPeriodStyle}>
-                <span>{ Math.floor(daysLeft) } days left</span>
+            <h1 className={Styles.ReportingHeader__heading}>Reporting: {p.heading}</h1>
+            { p.heading === 'Dispute' &&
+              <div className={Styles['ReportingHeader__dispute-wrapper']}>
+                <div className={Styles['ReportingHeader__dispute-header']}>
+                  <div className={Styles['ReportingHeader__meta-wrapper']}>
+                    <span className={Styles.ReportingHeader__endDate}>Reporting cycle ends { formattedDate.formattedLocal }</span>
+                    <span className={Styles.ReportingHeader__stake}> | </span><span className={Styles.ReportingHeader__stake}>{ p.reportingWindowStats.stake } REP Staked</span>
+                  </div>
+                  <span className={Styles.ReportingHeader__participationTokens}>Example Tooltip</span>
+                </div>
+                <div className={Styles['ReportingHeader__dispute-graph']}>
+                  <div className={Styles.ReportingHeader__graph}>
+                    <div className={Styles['ReportingHeader__graph-current']}>
+                      <div style={currentPeriodStyle}>
+                        <span>{ Math.floor(daysLeft) } days left</span>
+                      </div>
+                    </div>
+                    <div className={Styles['ReportingHeader__graph-dispute']} />
+                  </div>
+                  <div className={Styles.ReportingHeader__labels}>
+                    <span>Current Cycle</span>
+                    <span>Dispute</span>
+                  </div>
+                </div>
               </div>
-            </div>
-            <div className={Styles['ReportingHeader__graph-dispute']} />
-          </div>
-          <div className={Styles.ReportingHeader__labels}>
-            <span>Current Cycle</span>
-            <span>Dispute</span>
+            }
           </div>
         </div>
       </article>

--- a/src/modules/reporting/components/reporting-header/reporting-header.jsx
+++ b/src/modules/reporting/components/reporting-header/reporting-header.jsx
@@ -8,7 +8,6 @@ import Styles from 'modules/reporting/components/reporting-header/reporting-head
 export default class ReportingHeader extends Component {
   static propTypes = {
     heading: PropTypes.string.isRequired,
-    showReportingEndDate: PropTypes.bool.isRequired,
     loadReportingWindowBounds: PropTypes.func.isRequired,
     reportingWindowStats: PropTypes.object.isRequired,
   }

--- a/src/modules/reporting/components/reporting-header/reporting-header.styles.less
+++ b/src/modules/reporting/components/reporting-header/reporting-header.styles.less
@@ -6,6 +6,16 @@
   padding-top: 6em;
 }
 
+.ReportingHeader__dispute-graph {
+  margin-top: 0.25rem;
+}
+
+.ReportingHeader__dispute-header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.875rem;
+}
+
 .ReportingHeader__endDate {
   &:extend(.caps--small);
 
@@ -48,19 +58,11 @@
   width: 22%;
 }
 
-.ReportingHeader__graph-wrapper {
-  margin-top: 0.25rem;
-}
-
-.ReportingHeader__header {
-  align-items: center;
-  display: flex;
-  justify-content: space-between;
-}
-
 .ReportingHeader__heading {
   margin: 1rem 0;
   text-transform: uppercase;
+
+  &:extend(.h1--heavy);
 }
 
 .ReportingHeader__labels {
@@ -75,6 +77,14 @@
   > span:last-child {
     width: 22%;
   }
+}
+
+.ReportingHeader__participationTokens {
+  &:extend(.caps);
+
+  border-bottom: 1px solid @color-lightgray;
+  color: @color-lightgray;
+
 }
 
 .ReportingHeader__stake {
@@ -92,10 +102,6 @@
 }
 
 @media @breakpoint-mobile-small {
-  .ReportingHeader__header {
-    display: block;
-  }
-
   .ReportingHeader__stake {
     font-weight: 500;
   }

--- a/src/modules/reporting/components/reporting-header/reporting-header.styles.less
+++ b/src/modules/reporting/components/reporting-header/reporting-header.styles.less
@@ -82,9 +82,8 @@
 .ReportingHeader__participationTokens {
   &:extend(.caps);
 
-  border-bottom: 1px solid @color-lightgray;
-  color: @color-lightgray;
-
+  border-bottom: 1px solid @color-white;
+  padding-bottom: 2px;
 }
 
 .ReportingHeader__stake {

--- a/src/modules/reporting/components/reporting-open/reporting-open.jsx
+++ b/src/modules/reporting/components/reporting-open/reporting-open.jsx
@@ -41,7 +41,6 @@ export default class ReportingOpen extends Component {
         </Helmet>
         <ReportingHeader
           heading="Reporting"
-          showReportingEndDate
         />
         { s.filteredMarketsDispute.length &&
           <h2 className={Styles.ReportingOpen__heading}>In Dispute</h2>

--- a/src/utils/toggle-height/toggle-height.styles.less
+++ b/src/utils/toggle-height/toggle-height.styles.less
@@ -12,6 +12,6 @@
 
 @media @breakpoint-mobile {
   .toggle-height-target.open-on-mobile {
-    height: auto !important;
+    height: auto;
   }
 }


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/6459/create-tooltip-component

I added an example tooltip. You can view it on the Reporting: Dispute view by hovering over "Example Text" (which will be changed to "Participate" in a future story).

One difference from the mock: this center of this tooltip aligns with its corresponding text, rather than being bottom aligned. I don't think this is something we want to fool with since we're using a plugin for positioning, so I'm happy with letting that visual constraint go.

Note: I adjusted some of the structure and styles within `reporting-header.jsx` when adding "Example Text". The content here (the Dispute Window progress bar, etc) hasn't been updated to the newest mocks. As a result, my updates may cause a merge conflict if work on those updates has already started. (The related story for bringing that content in line with the new mocks is "Ready for Deploy", but I could not find the matching PR in either Open or Closed PRs. https://app.clubhouse.io/augur/story/5838/dispute-view-header)