### PR TITLE
Portfolio View Desktop Style Updates

### DIFF
--- a/src/assets/styles/_typography.less
+++ b/src/assets/styles/_typography.less
@@ -5,21 +5,6 @@
 
 @import '_type_font-face';
 
-// TYPOGRAPHY
-// site-wide typographic rules + values
-
-h1 {
-  font-size: 1.875rem; // 30px
-  font-weight: 400;
-  line-height: 2.1875rem;
-  margin-bottom: 1.25rem;
-}
-
-.h1--heavy {
-  font-weight: 500;
-  text-transform: uppercase;
-}
-
 //  VARS
 @din-pro: 'DINPro', sans-serif;
 
@@ -115,3 +100,23 @@ h1 {
   font-size: @font-size-rather-large;
   line-height: @font-size-rather-large;
 }
+
+// TYPOGRAPHY
+// site-wide typographic rules + values
+
+h1 {
+  font-size: @font-size-extra-large;
+  font-weight: 400;
+  line-height: 2.1875rem;
+  margin-bottom: 1.25rem;
+
+  @media @breakpoint-mobile-small {
+    font-size: @font-size-rather-large;
+    line-height: @font-size-extra-large;
+  }
+}
+
+.h1--heavy {
+  .caps;
+}
+

--- a/src/modules/app/components/app/app.jsx
+++ b/src/modules/app/components/app/app.jsx
@@ -41,7 +41,7 @@ import parseQuery from 'modules/routes/helpers/parse-query'
 
 import getValue from 'utils/get-value'
 
-import { MARKETS, ACCOUNT_DEPOSIT, ACCOUNT_WITHDRAW, MY_MARKETS, MY_POSITIONS, WATCHLIST, PORTFOLIO_TRANSACTIONS, PORTFOLIO_REPORTS, CREATE_MARKET, CATEGORIES, REPORTING_DISPUTE, REPORTING_REPORTING, AUTHENTICATION } from 'modules/routes/constants/views'
+import { MARKETS, ACCOUNT_DEPOSIT, ACCOUNT_WITHDRAW, MY_MARKETS, MY_POSITIONS, FAVORITES, PORTFOLIO_TRANSACTIONS, PORTFOLIO_REPORTS, CREATE_MARKET, CATEGORIES, REPORTING_DISPUTE, REPORTING_REPORTING, AUTHENTICATION } from 'modules/routes/constants/views'
 import { CATEGORY_PARAM_NAME } from 'modules/filter-sort/constants/param-names'
 
 import Styles from 'modules/app/components/app/app.styles'
@@ -60,7 +60,7 @@ const navTypes = {
   [MARKETS]: MarketsInnerNav,
   [MY_MARKETS]: PortfolioInnerNav,
   [MY_POSITIONS]: PortfolioInnerNav,
-  [WATCHLIST]: PortfolioInnerNav,
+  [FAVORITES]: PortfolioInnerNav,
   [PORTFOLIO_TRANSACTIONS]: PortfolioInnerNav,
   [PORTFOLIO_REPORTS]: PortfolioInnerNav,
   [ACCOUNT_DEPOSIT]: AccountInnerNav,
@@ -217,7 +217,7 @@ export default class AppView extends Component {
         case MARKETS:
         case MY_MARKETS:
         case MY_POSITIONS:
-        case WATCHLIST:
+        case FAVORITES:
         case ACCOUNT_DEPOSIT:
         case ACCOUNT_WITHDRAW:
         case REPORTING_DISPUTE:

--- a/src/modules/app/components/inner-nav/portfolio-inner-nav.jsx
+++ b/src/modules/app/components/inner-nav/portfolio-inner-nav.jsx
@@ -1,5 +1,5 @@
 import BaseInnerNav from 'modules/app/components/inner-nav/base-inner-nav'
-import { MY_POSITIONS, MY_MARKETS, WATCHLIST, PORTFOLIO_TRANSACTIONS, PORTFOLIO_REPORTS } from 'modules/routes/constants/views'
+import { MY_POSITIONS, MY_MARKETS, FAVORITES, PORTFOLIO_TRANSACTIONS, PORTFOLIO_REPORTS } from 'modules/routes/constants/views'
 
 export default class PorfolioInnerNav extends BaseInnerNav {
   getMainMenuData() {
@@ -21,11 +21,11 @@ export default class PorfolioInnerNav extends BaseInnerNav {
         }
       },
       {
-        label: 'Watching',
+        label: 'Favorites',
         visible: true,
-        isSelected: (this.props.currentBasePath === WATCHLIST),
+        isSelected: (this.props.currentBasePath === FAVORITES),
         link: {
-          pathname: WATCHLIST
+          pathname: FAVORITES
         }
       },
       {

--- a/src/modules/common/components/dropdown/dropdown.styles.less
+++ b/src/modules/common/components/dropdown/dropdown.styles.less
@@ -7,6 +7,10 @@
   margin-right: 1em;
   position: relative;
   z-index: 1;
+
+  &:last-child {
+    margin-right: 0;
+  }
 }
 
 .Dropdown__angle-down {

--- a/src/modules/markets/components/markets-header/markets-header.styles.less
+++ b/src/modules/markets/components/markets-header/markets-header.styles.less
@@ -2,7 +2,7 @@
 
 .MarketsHeader {
   font-size: 1rem;
-  padding: 2.5rem 2rem 2rem;
+  padding: 2.5rem 2rem 1.5rem;
 }
 
 .MarketsHeader__heading {
@@ -46,9 +46,5 @@
 @media @breakpoint-mobile-small {
   .MarketsHeader__wrapper {
     display: block;
-  }
-
-  .MarketsHeader__heading {
-    margin-bottom: 1rem;
   }
 }

--- a/src/modules/portfolio/components/favorites/favorites.jsx
+++ b/src/modules/portfolio/components/favorites/favorites.jsx
@@ -4,10 +4,10 @@ import { Helmet } from 'react-helmet'
 
 import Dropdown from 'modules/common/components/dropdown/dropdown'
 import MarketsList from 'modules/markets/components/markets-list'
-import Styles from 'modules/portfolio/components/watchlist/watchlist.styles'
+import Styles from 'modules/portfolio/components/favorites/favorites.styles'
 import { TYPE_TRADE } from 'modules/market/constants/link-types'
 
-class WatchList extends Component {
+class Favorites extends Component {
   static propTypes = {
     markets: PropTypes.array.isRequired,
     filteredMarkets: PropTypes.array.isRequired,
@@ -70,25 +70,25 @@ class WatchList extends Component {
     const s = this.state
 
     return (
-      <section className={Styles.WatchList}>
+      <section className={Styles.Favorites}>
         <Helmet>
-          <title>Watching</title>
+          <title>Favorites</title>
         </Helmet>
         <div
-          className={Styles.WatchList__SortBar}
+          className={Styles.Favorites__SortBar}
         >
           <div
-            className={Styles['WatchList__SortBar-title']}
+            className={Styles['Favorites__SortBar-title']}
           >
-            Watching
+            Favorites
           </div>
           <div
-            className={Styles['WatchList__SortBar-sort']}
+            className={Styles['Favorites__SortBar-sort']}
           >
             <Dropdown default={s.sortDefault} options={s.sortOptions} onChange={this.changeDropdown} />
           </div>
           <div
-            className={Styles['WatchList__SortBar-filter']}
+            className={Styles['Favorites__SortBar-filter']}
           >
             <Dropdown default={s.filterDefault} options={s.filterOptions} onChange={this.changeDropdown} />
           </div>
@@ -109,4 +109,4 @@ class WatchList extends Component {
   }
 }
 
-export default WatchList
+export default Favorites

--- a/src/modules/portfolio/components/favorites/favorites.styles.less
+++ b/src/modules/portfolio/components/favorites/favorites.styles.less
@@ -15,8 +15,9 @@
 }
 
 .Favorites__SortBar-title {
+  &:extend(.caps--large);
+
   color: @color-white;
-  font-size: @font-size-extra-large;
 }
 
 .Favorites__SortBar-sort {

--- a/src/modules/portfolio/components/favorites/favorites.styles.less
+++ b/src/modules/portfolio/components/favorites/favorites.styles.less
@@ -1,12 +1,12 @@
 @import (reference) '~assets/styles/shared';
 
-.WatchList {
+.Favorites {
   align-items: center;
   text-align: left;
   width: 100%;
 }
 
-.WatchList__SortBar {
+.Favorites__SortBar {
   align-items: baseline;
   display: flex;
   flex-flow: row nowrap;
@@ -14,27 +14,27 @@
   width: 100%;
 }
 
-.WatchList__SortBar-title {
+.Favorites__SortBar-title {
   color: @color-white;
   font-size: @font-size-extra-large;
 }
 
-.WatchList__SortBar-sort {
+.Favorites__SortBar-sort {
   display: flex;
   flex: 1;
   margin-left: 1rem;
 }
 
-.WatchList__SortBar-filter {
+.Favorites__SortBar-filter {
   display: flex;
 }
 
 @media @breakpoint-mobile {
-  .WatchList__SortBar {
+  .Favorites__SortBar {
     padding: 0 1rem;
   }
 
-  .WatchList__SortBar-title {
+  .Favorites__SortBar-title {
     font-size: @font-size-large;
   }
 }

--- a/src/modules/portfolio/components/markets/markets.jsx
+++ b/src/modules/portfolio/components/markets/markets.jsx
@@ -226,11 +226,7 @@ class MyMarkets extends Component {
           <div
             className={Styles.Markets__SortBar}
           >
-            <div
-              className={Styles['Markets__SortBar-title']}
-            >
-              Open
-            </div>
+            <h2 className={Styles['Markets__SortBar-title']}>Open</h2>
             <div
               className={Styles['Markets__SortBar-sort']}
             >

--- a/src/modules/portfolio/components/markets/markets.styles.less
+++ b/src/modules/portfolio/components/markets/markets.styles.less
@@ -15,8 +15,9 @@
 }
 
 .Markets__SortBar-title {
+  &:extend(.caps--large);
+
   color: @color-white;
-  font-size: @font-size-extra-large;
 }
 
 .Markets__SortBar-sort {

--- a/src/modules/portfolio/components/performance-graph/performance-graph.jsx
+++ b/src/modules/portfolio/components/performance-graph/performance-graph.jsx
@@ -58,7 +58,8 @@ class PerformanceGraph extends Component {
         text: null
       },
       chart: {
-        backgroundColor: '#1e1a31',
+        backgroundColor: 'transparent',
+        height: '220px',
         spacingLeft: 0,
         spacingRight: 0,
       },
@@ -92,16 +93,20 @@ class PerformanceGraph extends Component {
       xAxis: {
         visible: true,
         type: 'datetime',
+        lineColor: '#686177',
         crosshair: {
           width: 4,
+          color: '#6f697e',
         },
         labels: {
           formatter() {
             return formatDate(new Date(this.value)).simpleDate
           },
           style: {
-            color: '#ffffff',
-            fontSize: '0.875rem',
+            color: '#a7a2b2',
+            fontSize: '0.625rem',
+            textTransform: 'uppercase',
+            fontWeight: '500',
           }
         },
         tickLength: 6,
@@ -116,6 +121,7 @@ class PerformanceGraph extends Component {
         visible: true,
         showFirstLabel: false,
         showLastLabel: true,
+        gridLineColor: '#686177',
         title: {
           text: null,
         },
@@ -129,8 +135,10 @@ class PerformanceGraph extends Component {
             return formatEther(this.value).full
           },
           style: {
-            color: '#ffffff',
-            fontSize: '0.875rem'
+            color: '#a7a2b2',
+            fontSize: '0.625rem',
+            textTransform: 'uppercase',
+            fontWeight: '500',
           },
         },
         tickPositioner() {
@@ -172,7 +180,9 @@ class PerformanceGraph extends Component {
         borderWidth: 0,
         headerFormat: '',
         style: {
-          fontSize: '1rem'
+          fontSize: '0.625rem',
+          color: 'white',
+          fontWeight: '700',
         },
         shadow: false,
         shape: 'none',

--- a/src/modules/portfolio/components/performance-graph/performance-graph.styles.less
+++ b/src/modules/portfolio/components/performance-graph/performance-graph.styles.less
@@ -38,9 +38,3 @@
     font-weight: 500;
   }
 }
-
-@media @breakpoint-mobile {
-  .PerformanceGraph {
-    padding: 0 1rem;
-  }
-}

--- a/src/modules/portfolio/components/performance-graph/performance-graph.styles.less
+++ b/src/modules/portfolio/components/performance-graph/performance-graph.styles.less
@@ -4,6 +4,8 @@
   :global {
     .highcharts-container {
       min-width: 100%;
+      position: relative;
+      top: -0.65rem;
 
       > svg {
         width: 100%;
@@ -20,11 +22,21 @@
 }
 
 .PerformanceGraph__SortBar-title {
+  &:extend(.caps--small);
+
   flex: 1;
+  font-weight: 500;
 }
 
 .PerformanceGraph__SortBar-dropdowns {
   display: flex;
+
+  > div > button:first-child {
+    &:extend(.caps--small);
+
+    color: @color-white;
+    font-weight: 500;
+  }
 }
 
 @media @breakpoint-mobile {

--- a/src/modules/portfolio/components/portfolio-header/portfolio-header.jsx
+++ b/src/modules/portfolio/components/portfolio-header/portfolio-header.jsx
@@ -6,7 +6,7 @@ import PerformanceGraph from 'modules/portfolio/containers/performance-graph'
 import { ExportIcon } from 'modules/common/components/icons'
 
 import parsePath from 'modules/routes/helpers/parse-path'
-import { MY_POSITIONS, MY_MARKETS, WATCHLIST, TRANSACTIONS, PORTFOLIO_REPORTS } from 'modules/routes/constants/views'
+import { MY_POSITIONS, MY_MARKETS, FAVORITES, TRANSACTIONS, PORTFOLIO_REPORTS } from 'modules/routes/constants/views'
 
 import Styles from 'modules/portfolio/components/portfolio-header/portfolio-header.styles'
 
@@ -37,8 +37,8 @@ function getTitle(path) {
   switch (view) {
     case MY_MARKETS:
       return 'my markets'
-    case WATCHLIST:
-      return 'watching'
+    case FAVORITES:
+      return 'favorites'
     case TRANSACTIONS:
       return 'transactions'
     case PORTFOLIO_REPORTS:

--- a/src/modules/portfolio/components/portfolio-header/portfolio-header.styles.less
+++ b/src/modules/portfolio/components/portfolio-header/portfolio-header.styles.less
@@ -4,7 +4,7 @@
   .view();
 
   color: white;
-  padding-top: 7rem;
+  padding-top: 4.5rem;
 }
 
 .PortfolioHeader__export {

--- a/src/modules/portfolio/components/portfolio-header/portfolio-header.styles.less
+++ b/src/modules/portfolio/components/portfolio-header/portfolio-header.styles.less
@@ -1,8 +1,10 @@
 @import (reference) '~assets/styles/shared';
 
 .PortfolioHeader {
-  color: white;
   .view();
+
+  color: white;
+  padding-top: 7rem;
 }
 
 .PortfolioHeader__export {
@@ -21,6 +23,11 @@
   }
 }
 
+.PortfolioHeader__graph {
+  position: relative;
+  top: -0.75rem;
+}
+
 .PortfolioHeader__header {
   align-items: flex-end;
   display: flex;
@@ -29,6 +36,7 @@
 }
 
 .PortfolioHeader__title {
+  font-weight: 500;
   margin-bottom: 0;
   text-transform: uppercase;
 }

--- a/src/modules/portfolio/components/portfolio-header/portfolio-header.styles.less
+++ b/src/modules/portfolio/components/portfolio-header/portfolio-header.styles.less
@@ -1,10 +1,8 @@
 @import (reference) '~assets/styles/shared';
 
 .PortfolioHeader {
-  .view();
-
   color: white;
-  padding-top: 4.5rem;
+  padding: 4.5rem 2rem 2rem;
 }
 
 .PortfolioHeader__export {
@@ -41,6 +39,14 @@
   text-transform: uppercase;
 }
 
+@media @breakpoint-mobile {
+  .PortfolioHeader {
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 3.25rem;
+  }
+}
+
 @media @breakpoint-mobile-medium {
   .PortfolioHeader__export {
     margin-top: 0.5rem;
@@ -48,6 +54,5 @@
 
   .PortfolioHeader__header {
     display: block;
-    padding: 2rem 1rem 0;
   }
 }

--- a/src/modules/portfolio/components/portfolio-view/portfolio-view.jsx
+++ b/src/modules/portfolio/components/portfolio-view/portfolio-view.jsx
@@ -6,13 +6,13 @@ import AuthenticatedRoute from 'modules/routes/components/authenticated-route/au
 import PortfolioHeader from 'modules/portfolio/containers/portfolio-header'
 import MyPositions from 'modules/portfolio/containers/positions'
 import MyMarkets from 'modules/portfolio/containers/markets'
-import Watchlist from 'modules/portfolio/containers/watchlist'
+import Favorites from 'modules/portfolio/containers/favorites'
 import Transactions from 'modules/portfolio/containers/transactions'
 import Reports from 'modules/portfolio/containers/reports'
 
 import makePath from 'modules/routes/helpers/make-path'
 
-import { MY_POSITIONS, MY_MARKETS, WATCHLIST, PORTFOLIO_TRANSACTIONS, PORTFOLIO_REPORTS } from 'modules/routes/constants/views'
+import { MY_POSITIONS, MY_MARKETS, FAVORITES, PORTFOLIO_TRANSACTIONS, PORTFOLIO_REPORTS } from 'modules/routes/constants/views'
 
 const PortfolioView = p => (
   <section>
@@ -20,7 +20,7 @@ const PortfolioView = p => (
     <Switch>
       <AuthenticatedRoute path={makePath(MY_POSITIONS)} component={MyPositions} />
       <AuthenticatedRoute path={makePath(MY_MARKETS)} component={MyMarkets} />
-      <AuthenticatedRoute path={makePath(WATCHLIST)} component={Watchlist} />
+      <AuthenticatedRoute path={makePath(FAVORITES)} component={Favorites} />
       <AuthenticatedRoute path={makePath(PORTFOLIO_TRANSACTIONS)} component={Transactions} />
       <AuthenticatedRoute path={makePath(PORTFOLIO_REPORTS)} component={Reports} />
     </Switch>

--- a/src/modules/portfolio/components/positions-markets-list/positions-markets-list.styles.less
+++ b/src/modules/portfolio/components/positions-markets-list/positions-markets-list.styles.less
@@ -2,7 +2,7 @@
 
 .PositionsMarketsList {
   align-items: center;
-  padding: 0 2rem 2rem 0;
+  padding-bottom: 2rem;
   text-align: left;
   width: 100%;
 
@@ -29,13 +29,13 @@
 }
 
 .PositionsMarketsList__SortBar-title {
+  &:extend(.caps--large);
+
   color: @color-white;
-  font-size: @font-size-large;
-  font-weight: bold;
-  text-transform: uppercase;
 }
 
 .PositionsMarketsList__SortBar-sort {
+  align-items: baseline;
   display: flex;
   flex: 1;
   margin-left: 1rem;

--- a/src/modules/portfolio/components/transactions/transactions.styles.less
+++ b/src/modules/portfolio/components/transactions/transactions.styles.less
@@ -104,14 +104,18 @@
 .Transaction__data {
   align-items: baseline;
   display: flex;
-  flex-flow: row nowrap;
+  flex-wrap: nowrap;
+  margin-bottom: 1rem;
   padding: 0 2rem;
   width: 100%;
 }
 
 .Transaction__data-title {
   flex: 1;
-  padding: 0 1rem 1rem;
+
+  > h2 {
+    &:extend(.caps--large);
+  }
 }
 
 .Transactions__heading {

--- a/src/modules/portfolio/containers/favorites.js
+++ b/src/modules/portfolio/containers/favorites.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 
-import Watchlist from 'modules/portfolio/components/watchlist/watchlist'
+import Favorites from 'modules/portfolio/components/favorites/favorites'
 import { toggleFavorite } from 'modules/markets/actions/update-favorites'
 import { loadMarketsInfo } from 'modules/markets/actions/load-markets-info'
 import selectAllMarkets from 'modules/markets/selectors/markets-all'
@@ -33,6 +33,6 @@ const mapDispatchToProps = dispatch => ({
   toggleFavorite: marketId => dispatch(toggleFavorite(marketId)),
 })
 
-const WatchListContainer = withRouter(connect(mapStateToProps, mapDispatchToProps)(Watchlist))
+const FavoritesContainer = withRouter(connect(mapStateToProps, mapDispatchToProps)(Favorites))
 
-export default WatchListContainer
+export default FavoritesContainer

--- a/src/modules/reporting/components/reporting-dispute/reporting-dispute.styles.less
+++ b/src/modules/reporting/components/reporting-dispute/reporting-dispute.styles.less
@@ -2,11 +2,6 @@
 
 .ReportDispute {
   color: @color-white;
-
-  & > article {
-    margin-left: 2rem;
-    margin-right: 2rem;
-  }
 }
 
 .NoMarkets__container {
@@ -23,3 +18,9 @@
   justify-content: center;
 }
 
+@media @breakpoint-mobile {
+  .NoMarkets__container {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}

--- a/src/modules/reporting/components/reporting-header/reporting-header.styles.less
+++ b/src/modules/reporting/components/reporting-header/reporting-header.styles.less
@@ -3,7 +3,7 @@
 .ReportingHeader {
   color: @color-white;
   margin-bottom: 2.125rem;
-  padding-top: 6em;
+  padding-top: 4.5rem;
 }
 
 .ReportingHeader__dispute-graph {
@@ -59,7 +59,7 @@
 }
 
 .ReportingHeader__heading {
-  margin: 1rem 0;
+  margin: 0 0 1rem;
   text-transform: uppercase;
 
   &:extend(.h1--heavy);

--- a/src/modules/reporting/components/reporting-header/reporting-header.styles.less
+++ b/src/modules/reporting/components/reporting-header/reporting-header.styles.less
@@ -3,7 +3,7 @@
 .ReportingHeader {
   color: @color-white;
   margin-bottom: 2.125rem;
-  padding-top: 4.5rem;
+  padding: 4.5rem 2rem 2rem;
 }
 
 .ReportingHeader__dispute-graph {
@@ -84,6 +84,7 @@
 
   border-bottom: 1px solid @color-white;
   padding-bottom: 2px;
+  white-space: nowrap;
 }
 
 .ReportingHeader__stake {
@@ -94,9 +95,11 @@
   padding-left: 1rem;
 }
 
-@media @breakpoint-mobile-medium {
+@media @breakpoint-mobile {
   .ReportingHeader {
-    padding-top: 2em;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 3.25rem;
   }
 }
 

--- a/src/modules/routes/components/routes/routes.jsx
+++ b/src/modules/routes/components/routes/routes.jsx
@@ -21,10 +21,9 @@ const Routes = p => (
     <Route path={makePath(VIEWS.CONNECT)} component={COMPONENTS.Connect} />
     <Route path={makePath(VIEWS.CREATE)} component={COMPONENTS.Create} />
     <AuthenticatedRoute path={makePath(VIEWS.REPORT)} component={COMPONENTS.Report} />
-    <AuthenticatedRoute path={makePath(VIEWS.FAVORITES)} component={COMPONENTS.Markets} />
     <AuthenticatedRoute path={makePath(VIEWS.MY_POSITIONS)} component={COMPONENTS.Portfolio} />
     <AuthenticatedRoute path={makePath(VIEWS.MY_MARKETS)} component={COMPONENTS.Portfolio} />
-    <AuthenticatedRoute path={makePath(VIEWS.WATCHLIST)} component={COMPONENTS.Portfolio} />
+    <AuthenticatedRoute path={makePath(VIEWS.FAVORITES)} component={COMPONENTS.Portfolio} />
     <AuthenticatedRoute path={makePath(VIEWS.PORTFOLIO_TRANSACTIONS)} component={COMPONENTS.Portfolio} />
     <AuthenticatedRoute path={makePath(VIEWS.PORTFOLIO_REPORTS)} component={COMPONENTS.Portfolio} />
     <AuthenticatedRoute path={makePath(VIEWS.ACCOUNT)} component={COMPONENTS.Account} />

--- a/src/modules/routes/constants/views.js
+++ b/src/modules/routes/constants/views.js
@@ -1,7 +1,6 @@
 // MAIN VIEWS
 export const MARKET = 'market'
 export const MARKETS = 'markets'
-export const FAVORITES = 'favorites'
 export const CREATE_MARKET = 'create-market'
 export const TRANSACTIONS = 'transactions'
 export const ACCOUNT = 'account'
@@ -21,7 +20,7 @@ export const DEFAULT_VIEW = CATEGORIES
 //  Portfolio
 export const MY_POSITIONS = 'my-positions'
 export const MY_MARKETS = 'my-markets'
-export const WATCHLIST = 'watch-list'
+export const FAVORITES = 'favorites'
 export const PORTFOLIO_TRANSACTIONS = 'transactions'
 export const PORTFOLIO_REPORTS = 'reports'
 


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/6548/portfolio-view-desktop-style-updates

Style cleanup:
- cleaning up Portfolio Header highcharts styles
- standardizing subsection titles within the Portfolio section

I also renamed the "Portfolio: Watchlist" view to "Portfolio: Favorites", and renamed all associated code. The one iffy thing here was the removal of another (toplevel) "Favorites" route in the `routes/constants/views` file, but so far as I remember (and I double checked with John) this was a vestige of an older system.

Might want @stephensprinkle's memory on that one too.