### PR TITLE
7144-positions-orders-dropdown

### DIFF
--- a/src/env-dev.json
+++ b/src/env-dev.json
@@ -4,7 +4,7 @@
     "http": "http://127.0.0.1:8545",
     "ws": "ws://127.0.0.1:8546"
   },
-  "network-id": 4,
+  "network-id": 12346,
   "auto-login": true,
   "universe": null,
   "bug-bounty": false,

--- a/src/modules/market/components/market-portfolio-card/market-portfolio-card.jsx
+++ b/src/modules/market/components/market-portfolio-card/market-portfolio-card.jsx
@@ -139,7 +139,12 @@ export default class MarketPortfolioCard extends Component {
         </section>
         <section className={Styles.MarketCard__tablesection}>
           {(myPositionOutcomes || []).filter(outcome => outcome.position).length !== 0 &&
-            <div className={Styles.MarketCard__headingcontainer}>
+            <div
+              className={Styles.MarketCard__headingcontainer}
+              role="button"
+              tabIndex="0"
+              onClick={() => this.toggleTable('myPositions')}
+            >
               <h1 className={Styles.MarketCard__tableheading}>
                 My Positions
               </h1>
@@ -201,7 +206,12 @@ export default class MarketPortfolioCard extends Component {
         <section className={Styles.MarketCard__tablesection}>
           <div className={PositionStyles.MarketPositionsList__table}>
             {this.props.market.outcomes[0] && this.props.market.outcomes[0].userOpenOrders && this.props.market.outcomes[0].userOpenOrders.length !== 0 &&
-              <div className={Styles.MarketCard__headingcontainer}>
+              <div
+                className={Styles.MarketCard__headingcontainer}
+                role="button"
+                tabIndex="0"
+                onClick={() => this.toggleTable('openOrders')}
+              >
                 <h1 className={Styles.MarketCard__tableheading}>
                   Open Orders
                 </h1>

--- a/src/modules/market/components/market-portfolio-card/market-portfolio-card.jsx
+++ b/src/modules/market/components/market-portfolio-card/market-portfolio-card.jsx
@@ -139,10 +139,8 @@ export default class MarketPortfolioCard extends Component {
         </section>
         <section className={Styles.MarketCard__tablesection}>
           {(myPositionOutcomes || []).filter(outcome => outcome.position).length !== 0 &&
-            <div
+            <button
               className={Styles.MarketCard__headingcontainer}
-              role="button"
-              tabIndex="0"
               onClick={() => this.toggleTable('myPositions')}
             >
               <h1 className={Styles.MarketCard__tableheading}>
@@ -154,27 +152,7 @@ export default class MarketPortfolioCard extends Component {
               >
                 <CaretDropdown flipped={this.state.tableOpen.myPositions} />
               </button>
-              {p.linkType && p.linkType !== TYPE_CLAIM_PROCEEDS &&
-                <MarketLink
-                  key={p.market.id}
-                  className={Styles.MarketCard__action}
-                  id={p.market.id}
-                  formattedDescription={p.market.description}
-                  linkType={p.linkType}
-                >
-                  { p.buttonText || buttonText }
-                </MarketLink>
-              }
-              {p.linkType && p.linkType === TYPE_CLAIM_PROCEEDS && (myPositionOutcomes && myPositionOutcomes.filter(outcome => outcome.position).length > 0 && myPositionOutcomes.filter(outcome => outcome.position && outcome.position.unrealizedNet.formattedValue > 0).length > 0) &&
-                <button
-                  className={Styles.MarketCard__action}
-                  onClick={() => p.claimTradingProceeds([p.market.id])
-                  }
-                >
-                  { p.buttonText || buttonText }
-                </button>
-              }
-            </div>
+            </button>
           }
           <div className={PositionStyles.MarketPositionsList__table}>
             { this.state.tableOpen.myPositions && (myPositionOutcomes || []).filter(outcome => outcome.position).length > 0 &&
@@ -206,10 +184,8 @@ export default class MarketPortfolioCard extends Component {
         <section className={Styles.MarketCard__tablesection}>
           <div className={PositionStyles.MarketPositionsList__table}>
             {this.props.market.outcomes[0] && this.props.market.outcomes[0].userOpenOrders && this.props.market.outcomes[0].userOpenOrders.length !== 0 &&
-              <div
+              <button
                 className={Styles.MarketCard__headingcontainer}
-                role="button"
-                tabIndex="0"
                 onClick={() => this.toggleTable('openOrders')}
               >
                 <h1 className={Styles.MarketCard__tableheading}>
@@ -221,7 +197,7 @@ export default class MarketPortfolioCard extends Component {
                 >
                   <CaretDropdown flipped={this.state.tableOpen.openOrders} />
                 </button>
-              </div>
+              </button>
             }
             <div className={PositionStyles.MarketPositionsList__table}>
               { this.state.tableOpen.openOrders &&

--- a/src/modules/market/components/market-portfolio-card/market-portfolio-card.styles.less
+++ b/src/modules/market/components/market-portfolio-card/market-portfolio-card.styles.less
@@ -107,6 +107,9 @@
   cursor: pointer;
   display: flex;
   flex-flow: row nowrap;
+  outline: none;
+  text-align: left;
+  width: inherit;
 }
 
 .MarketCard__headingcontainer-mobile {

--- a/src/modules/market/components/market-portfolio-card/market-portfolio-card.styles.less
+++ b/src/modules/market/components/market-portfolio-card/market-portfolio-card.styles.less
@@ -104,6 +104,7 @@
 .MarketCard__headingcontainer {
   align-items: center;
   clear: both;
+  cursor: pointer;
   display: flex;
   flex-flow: row nowrap;
 }


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/7144/clicking-on-open-orders-or-my-positions-title-should-expand-corresponding-section

Added the dropdown tray functionality to the positions/orders headers as well as just that little carrot on the far right.