### PR TITLE
additional details fix

### DIFF
--- a/src/modules/reporting/components/reporting-report/reporting-report.jsx
+++ b/src/modules/reporting/components/reporting-report/reporting-report.jsx
@@ -32,7 +32,6 @@ export default class ReportingReport extends Component {
     this.state = {
       currentStep: 0,
       showingDetails: true,
-      showToggleDetails: this.props.market && this.props.market.extraInfo,
       isMarketInValid: null,
       selectedOutcome: '',
       selectedOutcomeName: '',
@@ -110,7 +109,7 @@ export default class ReportingReport extends Component {
             history={p.history}
             cardStyle="single-card"
             buttonText="View"
-            showAdditionalDetailsToggle={s.showToggleDetails}
+            showAdditionalDetailsToggle
             showingDetails={s.showingDetails}
             toggleDetails={this.toggleDetails}
           />


### PR DESCRIPTION
found issue where `additional details` button doesn't show b/c there isn't any extra info but there is always the case of showing resolution source. fixed to always show `additional details` button on report form. 