### PR TITLE
Missed placeholder dispute markets

### DIFF
--- a/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets-test.jsx
+++ b/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets-test.jsx
@@ -1,0 +1,55 @@
+import React from 'react'
+
+import { describe, it } from 'mocha'
+import { assert } from 'chai'
+
+import { shallow } from 'enzyme'
+import { NoMarketsFound, ReportSection } from 'src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets'
+import ConnectedMarketPreview from 'src/modules/reporting/containers/market-preview'
+
+describe('reporting-dispute-markets', () => {
+  describe('props', () => {
+    let cmp
+    let exampleTitle
+
+    beforeEach(() => {
+      exampleTitle = 'some title'
+      cmp = shallow(<ReportSection title={exampleTitle} items={[]} />)
+    })
+
+    it('should display the passed in title', () => {
+      assert.include(cmp.text(), exampleTitle)
+    })
+
+    describe('when items array is empty', () => {
+      it('should render no markets found component', () => {
+        assert.lengthOf(cmp.find(NoMarketsFound), 1)
+      })
+    })
+
+    describe('when items array is not empty', () => {
+      it('should render no markets found component', () => {
+        const items = [{
+          id: 1,
+        }, {
+          id: 2,
+        }, {
+          id: 3,
+        }]
+
+        cmp = shallow(<ReportSection title={exampleTitle} items={items} />)
+        assert.lengthOf(cmp.find(ConnectedMarketPreview), 3)
+      })
+    })
+  })
+
+  describe('NoMarketFound', () => {
+    it('should display the message passed in', () => {
+      const message = 'some message'
+      const cmp = shallow(<NoMarketsFound message={message} />)
+
+      assert.include(cmp.text(), message)
+    })
+  })
+
+})

--- a/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets.jsx
+++ b/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets.jsx
@@ -1,0 +1,81 @@
+import React from 'react'
+
+import { Helmet } from 'react-helmet'
+import PropTypes from 'prop-types'
+
+import ReportingHeader from 'modules/reporting/containers/reporting-header'
+import MarketPreview from 'src/modules/reporting/containers/market-preview'
+
+import Styles from './reporting-dispute-markets.styles'
+
+export const NoMarketsFound = ({ message }) => (
+  <article className={Styles.NoMarketsFound}>
+    <section className={Styles.NoMarketsFound__message}>{message}</section>
+  </article>
+)
+
+NoMarketsFound.propTypes = {
+  message: PropTypes.string.isRequired,
+}
+
+export const ReportSection = ({
+  title, items, buttonText='Report', emptyMessage,
+}) => {
+  let theChildren
+  if (items.length === 0) {
+    theChildren = <NoMarketsFound message={emptyMessage} />
+  } else {
+    theChildren = items.map(item => (<MarketPreview key={item.id} buttonText={buttonText} {...item} />))
+  }
+
+  return (
+    <article className={Styles.ReportSection}>
+      <h4 className={Styles.ReportSection__heading}>{title}</h4>
+      <section>
+        {theChildren}
+      </section>
+    </article>
+  )
+}
+
+ReportSection.propTypes = {
+  buttonText: PropTypes.string,
+  emptyMessage: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  items: PropTypes.arrayOf(PropTypes.object),
+}
+
+class ReportingReporting extends React.Component {
+  componentDidMount() {
+    this.props.loadReporting()
+  }
+
+  render() {
+    const {
+      designated,
+      open,
+      upcoming,
+    } = this.props.markets
+
+    return (
+      <section>
+        <Helmet>
+          <title>Reporting: Markets</title>
+        </Helmet>
+        <ReportingHeader
+          heading="Markets"
+        />
+        <ReportSection title="Designated Reporting" items={designated} emptyMessage="There are no markets available for you to report on. " />
+        <ReportSection title="Open Reporting" items={open} emptyMessage="There are no markets in Open Reporting." />
+        <ReportSection title="Upcoming Reporting" items={upcoming} buttonText="View" emptyMessage="There are no upcoming markets for you to report on." />
+      </section>
+    )
+  }
+}
+
+ReportingReporting.propTypes = {
+  markets: PropTypes.object.isRequired,
+  loadReporting: PropTypes.func.isRequired,
+}
+
+export default ReportingReporting

--- a/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets.jsx
+++ b/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets.jsx
@@ -45,7 +45,7 @@ ReportSection.propTypes = {
   items: PropTypes.arrayOf(PropTypes.object),
 }
 
-class ReportingReporting extends React.Component {
+class ReportingDisputeMarkets extends React.Component {
   componentDidMount() {
     this.props.loadReporting()
   }
@@ -73,9 +73,9 @@ class ReportingReporting extends React.Component {
   }
 }
 
-ReportingReporting.propTypes = {
+ReportingDisputeMarkets.propTypes = {
   markets: PropTypes.object.isRequired,
   loadReporting: PropTypes.func.isRequired,
 }
 
-export default ReportingReporting
+export default ReportingDisputeMarkets

--- a/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets.styles.less
+++ b/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets.styles.less
@@ -1,0 +1,38 @@
+@import (reference) '~assets/styles/shared';
+
+.ReportSection {
+  margin-bottom: 3.75rem;
+}
+
+.ReportSection__heading {
+  &:extend(.caps--large);
+
+  color: @color-white;
+  margin-bottom: 1rem;
+  padding: 0 2rem;
+}
+
+.NoMarketsFound {
+  border-bottom: 1px rgba(151, 151, 151, 0.31) solid;
+  margin-left: 2em;
+  margin-right: 2em;
+}
+
+.NoMarketsFound__message {
+  color: @color-lightgray;
+  font-size: @font-size-large;
+  letter-spacing: 0;
+  padding-bottom: 3.75rem;
+}
+
+@media @breakpoint-mobile {
+  .ReportSection__heading {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .NoMarketsFound {
+    margin-left: 1rem;
+    margin-right: 1rem;
+  }
+}

--- a/src/modules/reporting/components/reporting-view/reporting-view.jsx
+++ b/src/modules/reporting/components/reporting-view/reporting-view.jsx
@@ -3,7 +3,7 @@ import { Switch } from 'react-router-dom'
 
 import AuthenticatedRoute from 'modules/routes/components/authenticated-route/authenticated-route'
 import ReportingDisputeMarkets from 'modules/reporting/containers/reporting-dispute-markets'
-import ReportingReporting from 'modules/reporting/containers/reporting-report-markets'
+import ReportingReportMarkets from 'modules/reporting/containers/reporting-report-markets'
 import makePath from 'modules/routes/helpers/make-path'
 
 import { REPORTING_DISPUTE_MARKETS, REPORTING_REPORT_MARKETS } from 'modules/routes/constants/views'
@@ -12,7 +12,7 @@ const ReportingView = p => (
   <section>
     <Switch>
       <AuthenticatedRoute path={makePath(REPORTING_DISPUTE_MARKETS)} component={ReportingDisputeMarkets} />
-      <AuthenticatedRoute path={makePath(REPORTING_REPORT_MARKETS)} component={ReportingReporting} />
+      <AuthenticatedRoute path={makePath(REPORTING_REPORT_MARKETS)} component={ReportingReportMarkets} />
     </Switch>
   </section>
 )

--- a/src/modules/reporting/containers/reporting-dispute-markets.js
+++ b/src/modules/reporting/containers/reporting-dispute-markets.js
@@ -2,39 +2,18 @@ import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 
 import ReportingDisputeMarkets from 'modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets'
-import makePath from 'src/modules/routes/helpers/make-path'
-import { ACCOUNT_DEPOSIT } from 'src/modules/routes/constants/views'
-import { selectLoginAccount } from 'src/modules/auth/selectors/login-account'
-import disputeMarkets from 'modules/reporting/selectors/select-dispute-markets'
-import loadMarkets from 'modules/markets/actions/load-markets'
-import { loadMarketsInfo } from 'modules/markets/actions/load-markets-info'
-import logError from 'utils/log-error'
+import { loadReporting } from 'src/modules/reporting/actions/load-reporting'
+import { selectMarketsToReport } from 'src/modules/reporting/selectors'
 
-const mapStateToProps = (state, { history }) => {
-
-  const loginAccount = selectLoginAccount(state)
-  const disputableMarkets = disputeMarkets() || []
-
-  return ({
-    isLogged: state.isLogged,
-    isConnected: state.connection.isConnected && state.universe.id != null,
-    isMarketsLoaded: state.hasLoadedMarkets,
-    doesUserHaveRep: (loginAccount.rep.value > 0),
-    markets: disputableMarkets,
-    marketsCount: disputableMarkets.length,
-    isMobile: state.isMobile,
-    disputeRound: 1,
-    navigateToAccountDepositHandler: () => history.push(makePath(ACCOUNT_DEPOSIT)),
-  })
-}
-
-const mapDispatchToProps = dispatch => ({
-  loadMarkets: () => dispatch(loadMarkets((err, marketIds) => {
-    if (err) return logError(err)
-    dispatch(loadMarketsInfo(marketIds))
-  })),
+const mapStateToProps = state => ({
+  isLogged: state.isLogged,
+  markets: selectMarketsToReport(state),
 })
 
-const ReportingDisputeContainer = connect(mapStateToProps, mapDispatchToProps)(withRouter(ReportingDisputeMarkets))
+const mapDispatchToProps = dispatch => ({
+  loadReporting: () => dispatch(loadReporting()),
+})
 
-export default ReportingDisputeContainer
+const ReportingReportingContainer = withRouter(connect(mapStateToProps, mapDispatchToProps)(ReportingDisputeMarkets))
+
+export default ReportingReportingContainer

--- a/src/modules/reporting/containers/reporting-dispute-markets.js
+++ b/src/modules/reporting/containers/reporting-dispute-markets.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 
-import ReportingDispute from 'modules/reporting/components/reporting-dispute/reporting-dispute'
+import ReportingDisputeMarkets from 'modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets'
 import makePath from 'src/modules/routes/helpers/make-path'
 import { ACCOUNT_DEPOSIT } from 'src/modules/routes/constants/views'
 import { selectLoginAccount } from 'src/modules/auth/selectors/login-account'
@@ -35,6 +35,6 @@ const mapDispatchToProps = dispatch => ({
   })),
 })
 
-const ReportingDisputeContainer = connect(mapStateToProps, mapDispatchToProps)(withRouter(ReportingDispute))
+const ReportingDisputeContainer = connect(mapStateToProps, mapDispatchToProps)(withRouter(ReportingDisputeMarkets))
 
 export default ReportingDisputeContainer

--- a/src/modules/reporting/containers/reporting-report-markets.js
+++ b/src/modules/reporting/containers/reporting-report-markets.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 
-import ReportingReporting from 'modules/reporting/components/reporting-report-markets/reporting-report-markets'
+import ReportingReportMarkets from 'modules/reporting/components/reporting-report-markets/reporting-report-markets'
 import { loadReporting } from 'src/modules/reporting/actions/load-reporting'
 import { selectMarketsToReport } from 'src/modules/reporting/selectors'
 
@@ -14,6 +14,6 @@ const mapDispatchToProps = dispatch => ({
   loadReporting: () => dispatch(loadReporting()),
 })
 
-const ReportingReportingContainer = withRouter(connect(mapStateToProps, mapDispatchToProps)(ReportingReporting))
+const ReportingReportingContainer = withRouter(connect(mapStateToProps, mapDispatchToProps)(ReportingReportMarkets))
 
 export default ReportingReportingContainer


### PR DESCRIPTION
Non-Clubhouse Story

cleaning up naming convention in the reporting dir. browse Reporting. dispute markets should be the same as reporting b/c it's used a placeholder.

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
- [ ] Post merge, story marked complete 
