### PR TITLE
fix-reconnection-here-text

### DIFF
--- a/src/modules/modal/components/modal-network-disconnected/modal-network-disconnected.jsx
+++ b/src/modules/modal/components/modal-network-disconnected/modal-network-disconnected.jsx
@@ -87,7 +87,7 @@ export default class ModalNetworkDisconnected extends Component {
         {!s.showEnvForm &&
           <div>
             <h1>{titleText}</h1>
-            <span>{descriptionText}<a href="#" onClick={this.showForm}>here.</a></span>
+            <span>{descriptionText}<button onClick={this.showForm}>here</button>.</span>
           </div>
         }
         {s.showEnvForm &&

--- a/src/modules/modal/components/modal-network-disconnected/modal-network-disconnected.styles.less
+++ b/src/modules/modal/components/modal-network-disconnected/modal-network-disconnected.styles.less
@@ -50,7 +50,7 @@
     .caps--extra-large();
   }
 
-  a {
+  div > span > button {
     text-decoration: underline;
   }
 }


### PR DESCRIPTION
converted the a tag to a button in the disconnected modal, this should prevent any odd redirection issues.

This pr fixes an issue @tinybike had in the below discord conversation:

<img width="716" alt="screen shot 2018-03-09 at 5 31 46 pm" src="https://user-images.githubusercontent.com/10524630/37234856-dc8fbdea-23bf-11e8-919a-cbbe5313ce29.png">
