### PR TITLE
6362 dispute progress

### DIFF
--- a/src/modules/market/containers/market-properties.js
+++ b/src/modules/market/containers/market-properties.js
@@ -9,7 +9,7 @@ const mapStateToProps = (state, ownProps) => ({
   isLogged: state.isLogged,
   isMobile: state.isMobile,
   loginAccount: state.loginAccount,
-  linktype: ownProps.linkType || determineMarketLinkType(selectMarket(ownProps.id), state.loginAccount),
+  linkType: ownProps.linkType || determineMarketLinkType(selectMarket(ownProps.id), state.loginAccount),
 })
 
 const MarketTradingContainer = withRouter(connect(mapStateToProps)(MarketProperties))

--- a/src/modules/reporting/components/reporting-dispute-confirm/reporting-dispute-confirm.jsx
+++ b/src/modules/reporting/components/reporting-dispute-confirm/reporting-dispute-confirm.jsx
@@ -46,6 +46,7 @@ ReportingDisputeConfirm.propTypes = {
   selectedOutcome: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   stake: PropTypes.number.isRequired,
   gasEstimate: PropTypes.string.isRequired,
+  disputeBond: PropTypes.string.isRequired,
   isMarketInValid: PropTypes.bool,
 }
 

--- a/src/modules/reporting/components/reporting-dispute-form/reporting-dispute-form.jsx
+++ b/src/modules/reporting/components/reporting-dispute-form/reporting-dispute-form.jsx
@@ -9,6 +9,7 @@ import { BINARY, SCALAR } from 'modules/markets/constants/market-types'
 import { ExclamationCircle as InputErrorIcon } from 'modules/common/components/icons'
 import FormStyles from 'modules/common/less/form'
 import Styles from 'modules/reporting/components/reporting-dispute-form/reporting-dispute-form.styles'
+import ReportingDisputeProgress from 'modules/reporting/components/reporting-dispute-progress/reporting-dispute-progress'
 
 export default class ReportingDisputeForm extends Component {
 
@@ -18,7 +19,6 @@ export default class ReportingDisputeForm extends Component {
     validations: PropTypes.object.isRequired,
     selectedOutcome: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     currentOutcome: PropTypes.object.isRequired,
-    disputeBond: PropTypes.string.isRequired,
     disputeOutcomes: PropTypes.array.isRequired,
     stakes: PropTypes.array.isRequired,
     stake: PropTypes.number,
@@ -41,6 +41,7 @@ export default class ReportingDisputeForm extends Component {
       outcomes: [],
       inputStake: '',
       inputSelectedOutcome: '',
+      paddingBuffer: 0,
     }
 
     this.state.outcomes = this.props.market ? this.props.market.outcomes.slice() : []
@@ -52,13 +53,21 @@ export default class ReportingDisputeForm extends Component {
     if (this.props.stake) this.state.inputStake = this.props.stake.toString()
 
     this.componentWillReceiveProps(this.props)
+
   }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.disputeOutcomes && nextProps.disputeOutcomes.length > 0) {
-      this.state.outcomes = nextProps.disputeOutcomes.filter(item => !item.tentativeWinning) || []
+      this.state.outcomes = (nextProps.disputeOutcomes.filter(item => !item.tentativeWinning) || [])
+        .sort((a, b) => a.name > b.name)
+        .sort((a, b) => b.percentageComplete > a.percentageComplete)
       const outcome = this.state.outcomes.find(o => o.name === 'Indeterminate')
       if (outcome) outcome.name = 'Market Is Invalid'
+
+      this.state.paddingBuffer = this.state.outcomes.reduce((p, i) => {
+        const result = i.name.length > p ? i.name.length : p
+        return result
+      }, 0)
 
       if (nextProps.selectedOutcome) {
         if (!this.state.outcomes.find(o => o.id === nextProps.selectedOutcome)) {
@@ -67,7 +76,6 @@ export default class ReportingDisputeForm extends Component {
       }
     }
   }
-
 
   validateStake(rawStake) {
     const updatedValidations = { ...this.props.validations }
@@ -179,6 +187,14 @@ export default class ReportingDisputeForm extends Component {
                   onClick={(e) => { this.validateOutcome(p.validations, outcome.id, outcome.name, false) }}
                 >{outcome.name}
                 </button>
+                <ReportingDisputeProgress
+                  key={outcome.id}
+                  {...outcome}
+                  paddingAmount={s.paddingBuffer - outcome.name.length}
+                  percentageComplete={outcome.percentageComplete}
+                  remainingRep={outcome.remainingRep}
+                  accountPercentage={outcome.accountPercentage}
+                />
               </li>
             ))
             }

--- a/src/modules/reporting/components/reporting-dispute-progress/reporting-dispute-progress.jsx
+++ b/src/modules/reporting/components/reporting-dispute-progress/reporting-dispute-progress.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Styles from 'modules/reporting/components/reporting-dispute-progress/reporting-dispute-progress.styles'
+
+const ReportingDisputeProgress = (p) => {
+
+  const currentPeriodStyle = {
+    width: `${p.percentageComplete}%`,
+  }
+
+  // using magic number to align dispute bars
+  const paddingValue = {
+    paddingLeft: `${(p.paddingAmount * 7.5) + 80}px`,
+  }
+
+  return (
+    <article>
+      <section className={Styles['ReportingDisputeProgress__dispute-wrapper']}>
+        <div className={Styles['ReportingDisputeProgress__dispute-graph']} style={paddingValue}>
+          <div className={Styles.ReportingDisputeProgress__graph}>
+            <div className={Styles['ReportingDisputeProgress__graph-current']}>
+              <div style={currentPeriodStyle} />
+            </div>
+          </div>
+        </div>
+        <div className={Styles['ReportingDisputeProgress__dispute-label']}>{ p.remainingRep } REP</div>
+      </section>
+    </article>
+  )
+}
+
+ReportingDisputeProgress.propTypes = {
+  paddingAmount: PropTypes.number,
+  percentageComplete: PropTypes.number,
+  remainingRep: PropTypes.string,
+  accountPercentage: PropTypes.number,
+}
+
+export default ReportingDisputeProgress

--- a/src/modules/reporting/components/reporting-dispute-progress/reporting-dispute-progress.styles.less
+++ b/src/modules/reporting/components/reporting-dispute-progress/reporting-dispute-progress.styles.less
@@ -1,0 +1,43 @@
+@import (reference) '~assets/styles/shared';
+
+.ReportingDisputeProgress__dispute-wrapper {
+  display: flex;
+  justify-content: flex-start;
+  width: 30rem;
+}
+
+.ReportingDisputeProgress__dispute-graph {
+  margin-top: 0.25rem;
+  padding-left: 5rem;
+}
+
+.ReportingDisputeProgress__graph {
+  background-color: @color-darkgray;
+  border-radius: 3px;
+  display: flex;
+  height: 0.5rem;
+  justify-content: space-between;
+  overflow: hidden;
+  right: 80%;
+  white-space: nowrap;
+}
+
+.ReportingDisputeProgress__dispute-label {
+  color: @color-lightgray;
+  font-size: @font-size-small;
+  line-height: 0.625rem;
+  margin-left: 0.5rem;
+  margin-top: 0.25rem;
+  white-space: nowrap;
+}
+
+.ReportingDisputeProgress__graph-current {
+  width: 15rem;
+
+  > div {
+    background-image: linear-gradient(-90deg, #a7a2b2 100%, rgba(155, 139, 245, 0) 100%);
+    border-right: 2px solid @color-white;
+    height: 100%;
+    position: relative;
+  }
+}

--- a/src/modules/reporting/components/reporting-dispute/reporting-dispute.jsx
+++ b/src/modules/reporting/components/reporting-dispute/reporting-dispute.jsx
@@ -90,7 +90,7 @@ export default class ReportingDispute extends Component {
         .map(o => fillDisputeOutcomeProgress(disputeBond, o))
       const currentOutcome = disputeOutcomes.find(item => item.tentativeWinning) || {}
       // disputeRound signifies round completed
-      const round = parseInt(disputeInfo.disputeRound || -1, 10) + 1
+      const round = parseInt(disputeInfo.disputeRound, 10)
 
       this.setState({
         disputeRound: round,

--- a/src/modules/reporting/selectors/fill-dispute-outcome-progress-test.js
+++ b/src/modules/reporting/selectors/fill-dispute-outcome-progress-test.js
@@ -1,0 +1,215 @@
+import { describe, it } from 'mocha'
+import { assert } from 'chai'
+import fillDisputeOutcomeProgess, { __RewireAPI__ as RewireAPI } from 'modules/reporting/selectors/fill-dispute-outcome-progress'
+
+describe(`modules/reporting/selectors/fill-dispute-outcome-progress.js`, () => {
+  const test = (t) => {
+    it(t.description, () => {
+      t.assertions()
+    })
+  }
+
+  const formatAttoRepStubb = (a, format) => {
+    const value = { formatted: a.toString() }
+    return value
+  }
+
+  RewireAPI.__Rewire__('formatAttoRep', formatAttoRepStubb)
+
+  test({
+    description: `mismatch bond and size, old dispute value`,
+    assertions: () => {
+      const outcome = {
+        size: 2098083496093750000,
+        currentStake: 109680582682291650,
+        accountStakeComplete: 103333582682291650,
+      }
+      const disputeBond = 6294250488281250000
+      const actual = fillDisputeOutcomeProgess(disputeBond, outcome)
+      const expected = {
+        ...outcome,
+        percentageComplete: 0,
+        remainingRep: '6294250488281250000',
+        accountPercentage: 0,
+      }
+      assert.deepEqual(actual, expected, `Didn't call the expected method`)
+    },
+  })
+
+  test({
+    description: `big numbers account % complete, rounding up`,
+    assertions: () => {
+      const outcome = {
+        size: 6294250488281250000,
+        currentStake: 349680582682291650,
+        accountStakeComplete: 133333582682291650,
+      }
+      const disputeBond = 6294250488281250000
+      const actual = fillDisputeOutcomeProgess(disputeBond, outcome)
+      const expected = {
+        ...outcome,
+        percentageComplete: 6,
+        remainingRep: '5944569905598959000',
+        accountPercentage: 2,
+      }
+      assert.deepEqual(actual, expected, `Didn't call the expected method`)
+    },
+  })
+
+  test({
+    description: `big numbers account % complete, 10, total 50 complete `,
+    assertions: () => {
+      const outcome = {
+        size: 20000000000000000000,
+        currentStake: 10000000000000000000,
+        accountStakeComplete: 2000000000000000000,
+      }
+      const disputeBond = 20000000000000000000
+      const actual = fillDisputeOutcomeProgess(disputeBond, outcome)
+      const expected = {
+        ...outcome,
+        percentageComplete: 50,
+        remainingRep: '10000000000000000000',
+        accountPercentage: 10,
+      }
+      assert.deepEqual(actual, expected, `Didn't call the expected method`)
+    },
+  })
+
+  test({
+    description: `big numbers account % complete, 50 `,
+    assertions: () => {
+      const outcome = {
+        size: 2000000000000000000,
+        currentStake: 1000000000000000000,
+        accountStakeComplete: 1000000000000000000,
+      }
+      const disputeBond = 2000000000000000000
+      const actual = fillDisputeOutcomeProgess(disputeBond, outcome)
+      const expected = {
+        ...outcome,
+        percentageComplete: 50,
+        remainingRep: '1000000000000000000',
+        accountPercentage: 50,
+      }
+      assert.deepEqual(actual, expected, `Didn't call the expected method`)
+    },
+  })
+
+  test({
+    description: `big numbers % complete, 50 `,
+    assertions: () => {
+      const outcome = {
+        size: 2000000000000000000,
+        currentStake: 1000000000000000000,
+        accountStakeComplete: 0,
+      }
+      const disputeBond = 2000000000000000000
+      const actual = fillDisputeOutcomeProgess(disputeBond, outcome)
+      const expected = {
+        ...outcome,
+        percentageComplete: 50,
+        remainingRep: '1000000000000000000',
+        accountPercentage: 0,
+      }
+      assert.deepEqual(actual, expected, `Didn't call the expected method`)
+    },
+  })
+
+  test({
+    description: `% complete, 75 `,
+    assertions: () => {
+      const outcome = {
+        size: 10,
+        currentStake: 7.5,
+        accountStakeComplete: 0,
+      }
+      const disputeBond = 10
+      const actual = fillDisputeOutcomeProgess(disputeBond, outcome)
+      const expected = {
+        ...outcome,
+        percentageComplete: 75,
+        remainingRep: '2.5',
+        accountPercentage: 0,
+      }
+      assert.deepEqual(actual, expected, `Didn't call the expected method`)
+    },
+  })
+
+  test({
+    description: `% complete, 50 `,
+    assertions: () => {
+      const outcome = {
+        size: 10,
+        currentStake: 5,
+        accountStakeComplete: 0,
+      }
+      const disputeBond = 10
+      const actual = fillDisputeOutcomeProgess(disputeBond, outcome)
+      const expected = {
+        ...outcome,
+        percentageComplete: 50,
+        remainingRep: '5',
+        accountPercentage: 0,
+      }
+      assert.deepEqual(actual, expected, `Didn't call the expected method`)
+    },
+  })
+
+  test({
+    description: `all zeros`,
+    assertions: () => {
+      const outcome = {
+        size: 0,
+        currentStake: 0,
+        accountStakeComplete: 0,
+      }
+      const disputeBond = 0
+      const actual = fillDisputeOutcomeProgess(disputeBond, outcome)
+      const expected = {
+        ...outcome,
+        percentageComplete: 0,
+        remainingRep: '0',
+        accountPercentage: 0,
+      }
+      assert.deepEqual(actual, expected, `Didn't call the expected method`)
+    },
+  })
+
+  test({
+    description: `empty object with bond`,
+    assertions: () => {
+      const outcome = { }
+      const disputeBond = 10
+      const actual = fillDisputeOutcomeProgess(disputeBond, outcome)
+      const expected = {
+        size: 10,
+        currentStake: 0,
+        accountStakeComplete: 0,
+        percentageComplete: 0,
+        remainingRep: '10',
+        accountPercentage: 0,
+      }
+      assert.deepEqual(actual, expected, `Didn't call the expected method`)
+    },
+  })
+
+  test({
+    description: `empty object`,
+    assertions: () => {
+      const outcome = { }
+      const disputeBond = 0
+      const actual = fillDisputeOutcomeProgess(disputeBond, outcome)
+      const expected = {
+        size: 0,
+        currentStake: 0,
+        accountStakeComplete: 0,
+        percentageComplete: 0,
+        remainingRep: '0',
+        accountPercentage: 0,
+      }
+      assert.deepEqual(actual, expected, `Didn't call the expected method`)
+    },
+  })
+
+})

--- a/src/modules/reporting/selectors/fill-dispute-outcome-progress.js
+++ b/src/modules/reporting/selectors/fill-dispute-outcome-progress.js
@@ -1,0 +1,49 @@
+import { formatAttoRep } from 'utils/format-number'
+import BigNumber from 'bignumber.js'
+
+export default function (disputeBond, outcome) {
+  const format = { decimals: 4, denomination: ' REP' }
+  if (!outcome) return
+  outcome.remainingRep = 0
+  outcome.percentageComplete = 0
+  outcome.accountPercentage = 0
+
+  // past dispute no progress, set size and remaining
+  if (outcome.size && outcome.size !== disputeBond) {
+    outcome.size = disputeBond
+    outcome.remainingRep = calculateRemainingRep(new BigNumber(disputeBond), 0, format)
+    return outcome
+  }
+
+  // defaults if not present
+  if (!outcome.size) outcome.size = disputeBond
+  if (!outcome.currentStake) outcome.currentStake = 0
+  if (!outcome.accountStakeComplete) outcome.accountStakeComplete = 0
+  if (outcome.currentStake.toString() === '0') {
+    outcome.remainingRep = calculateRemainingRep(new BigNumber(disputeBond), 0, format)
+  }
+
+  const { size, currentStake, accountStakeComplete } = outcome
+  const BNSize = new BigNumber(size)
+  const BNCurrentStake = new BigNumber(currentStake)
+
+  const BNAccountStakeComplete = new BigNumber(accountStakeComplete)
+  if (outcome.currentStake > 0) {
+    outcome.percentageComplete = calculatePercentage(BNSize, BNCurrentStake)
+    outcome.remainingRep = calculateRemainingRep(BNSize, BNCurrentStake, format)
+  }
+
+  if (accountStakeComplete > 0) outcome.accountPercentage = calculatePercentage(BNSize, BNAccountStakeComplete, format)
+  return outcome
+}
+
+const calculatePercentage = (BNSize, BNCurrentStake) => {
+  const ratio = BNSize.minus(BNCurrentStake).dividedBy(BNSize)
+  return Math.round(new BigNumber(1).minus(ratio).times(new BigNumber(100)).toNumber())
+}
+
+const calculateRemainingRep = (BNSize, BNCurrentStake, format) => {
+  const BNRemaining = BNSize.minus(BNCurrentStake)
+  const remaining = formatAttoRep(BNRemaining.toNumber(), format)
+  return remaining.formatted
+}

--- a/src/modules/reporting/selectors/select-dispute-outcomes.js
+++ b/src/modules/reporting/selectors/select-dispute-outcomes.js
@@ -17,7 +17,7 @@ export default function (market, disputeStakes) {
     }
     return p
   }, [])
-    .sort((a, b) => a.totalStake < b.totalStake).slice(0, 8)
+    .sort((a, b) => a.size < b.size).slice(0, 8)
     .reduce(fillInOutcomes, outcomes)
     .sort((a, b) => a.totalStake < b.totalStake)
 

--- a/src/utils/format-number.js
+++ b/src/utils/format-number.js
@@ -217,6 +217,12 @@ export function formatGasCostToEther(num, opts, gasPrice) {
   return formatGasCost(ethGasCost, opts).rounded
 }
 
+export function formatAttoRep(num, opts) {
+  if (!num || num === 0 || isNaN(num)) return 0
+  const { ETHER } = augur.rpc.constants
+  return formatNumber(new BigNumber(num).dividedBy(ETHER).toNumber(), opts)
+}
+
 export function formatGasCost(num, opts) {
   return formatNumber(
     num,

--- a/test/utils/format-number-test.js
+++ b/test/utils/format-number-test.js
@@ -161,4 +161,20 @@ describe('utils/format-number.js', () => {
       assert.deepEqual(formatNumber.formatGasCostToEther('0x632ea0', { decimalsRounded: 8 }, 2000000), '0.00021810', 'returned gas cost formated in ether given gas price')
     })
   })
+
+  describe('format attoREP', () => {
+    it('should return a properly formatted attoREP number', () => {
+      const result = formatNumber.formatAttoRep(349680582682291650, { decimals: 4 })
+      assert.deepEqual(result.formatted, '0.3497', 'returned attoREP formated to 4 decimals')
+    })
+  })
+
+  describe('format largish attoREP', () => {
+    it('should return a properly formatted attoREP number', () => {
+      const result = formatNumber.formatAttoRep(3496805826822916500000, { decimals: 4 })
+      assert.deepEqual(result.formatted, '3,496.8058', 'returned larger formatted attoREP to 4 decimals')
+    })
+  })
+
+
 })


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/6362)

to Test:

after designate-report on market start disputing with dispute-contribute. When a dispute happens the progress bar should increase and the needed REP to fill bond value decreases in the dispute form.

From the reporting-dispute-market page there should be a dispute button on markets that have been initially reported on.

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
- [ ] Post merge, story marked complete 
