### PR TITLE
7877-min-max-scalar-values

### DIFF
--- a/src/modules/market/components/market-basics/market-basics.jsx
+++ b/src/modules/market/components/market-basics/market-basics.jsx
@@ -69,7 +69,7 @@ const MarketBasics = (p) => {
         </h1>
 
         {(p.marketType === BINARY || p.marketType === SCALAR) &&
-        <MarketOutcomesBinaryScalar outcomes={p.outcomes} min={p.minValue} max={p.maxValue} type={p.marketType} />
+        <MarketOutcomesBinaryScalar outcomes={p.outcomes} min={p.minPrice} max={p.maxPrice} type={p.marketType} />
         }
 
         {p.marketType === 'categorical' &&

--- a/src/modules/market/components/market-outcomes-binary-scalar/market-outcomes-binary-scalar.jsx
+++ b/src/modules/market/components/market-outcomes-binary-scalar/market-outcomes-binary-scalar.jsx
@@ -14,16 +14,16 @@ const MarketOutcomes = (p) => {
     if (p.type === BINARY) {
       return lastPrice
     }
-
-    return `${(lastPrice / (p.max - p.min)) * 100}%`
+    // TODO: add scalar denomination to end of this template string
+    return `${(lastPrice / (p.max - p.min)) * 100}`
   }
 
   const currentValuePosition = {
     left: calculatePosition(),
   }
 
-  const minValue = p.min && p.type !== BINARY ? p.min : '0%'
-  const maxValue = p.min && p.type !== BINARY ? p.max : '100%'
+  const minValue = !isNaN(p.min) && p.type !== BINARY ? p.min : '0%'
+  const maxValue = !isNaN(p.max) && p.type !== BINARY ? p.max : '100%'
 
   return (
     <div className={Styles.MarketOutcomes}>
@@ -51,8 +51,8 @@ const MarketOutcomes = (p) => {
 
 MarketOutcomes.propTypes = {
   outcomes: PropTypes.array.isRequired,
-  max: PropTypes.string,
-  min: PropTypes.string,
+  max: PropTypes.number,
+  min: PropTypes.number,
   type: PropTypes.string,
 }
 


### PR DESCRIPTION
fixes the scalar ...scales... on the market cards so that they don't always show 0%-100% but instead use the min/max of the scalar market. Removed the hardcoded % denominations from scalar, will replace with real denominations when AugurNode is updated to return them to the UI.

[Clubhouse Story](https://app.clubhouse.io/augur/story/7877/min-and-max-are-no-longer-displaying-for-scalar-markets)

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [x] Screenshot (If applicable)

## Reviewer Checklist
- [x] Test/lint pass 
- [x] Post merge, story marked complete 
