### PR TITLE
6543-&-6699-fix-market-list-pagination

### DIFF
--- a/src/modules/markets/components/markets-list.jsx
+++ b/src/modules/markets/components/markets-list.jsx
@@ -88,7 +88,7 @@ export default class MarketsList extends Component {
     const p = this.props
     const s = this.state
 
-    const marketsLength = p.markets.length
+    const marketsLength = p.filteredMarkets.length
 
     return (
       <article className="markets-list">


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/6543/market-category-pagination-not-working)
and
[Clubhouse Story 2](https://app.clubhouse.io/augur/story/6699/market-totals-are-not-calculated-correctly)

To reproduce, go to the markets list and confirm that you don't get blank pages anymore and the pagination values are correct.

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [x] Test/lint pass 
- [x] Post merge, story marked complete 
