### PR TITLE
clean-formatEtherTokens

### DIFF
--- a/src/modules/account/selectors/core-stats.js
+++ b/src/modules/account/selectors/core-stats.js
@@ -4,7 +4,7 @@ import store from 'src/store'
 import { selectAccountTradesState, selectBlockchainState, selectOutcomesDataState } from 'src/select-state'
 import { augur } from 'services/augurjs'
 import { dateToBlock } from 'utils/date-to-block-to-date'
-import { formatEtherTokens } from 'utils/format-number'
+import { formatEther } from 'utils/format-number'
 import { ZERO } from 'modules/trade/constants/numbers'
 import { selectLoginAccount } from 'modules/auth/selectors/login-account'
 import selectLoginAccountPositions from 'modules/my-positions/selectors/login-account-positions'
@@ -96,12 +96,12 @@ export const selectCoreStats = createSelector(
       totalPLMonth: {
         label: '30 Day P/L',
         title: 'Profit/Loss -- net of all trades over the last 30 days',
-        value: formatEtherTokens(totalPLMonth),
+        value: formatEther(totalPLMonth),
       },
       totalPLDay: {
         label: '1 Day P/L',
         title: 'Profit/Loss -- net of all trades over the last day',
-        value: formatEtherTokens(totalPLDay),
+        value: formatEther(totalPLDay),
       },
     },
   ],

--- a/src/modules/create-market/components/create-market-form-review/create-market-form-review.jsx
+++ b/src/modules/create-market/components/create-market-form-review/create-market-form-review.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import { augur } from 'services/augurjs'
 // import BigNumber from 'bignumber.js'
 
-import { formatEtherEstimate, formatEtherTokensEstimate } from 'utils/format-number'
+import { formatEtherEstimate } from 'utils/format-number'
 import { EXPIRY_SOURCE_GENERIC } from 'modules/create-market/constants/new-market-constraints'
 
 import Styles from 'modules/create-market/components/create-market-form-review/create-market-form-review.styles'
@@ -29,9 +29,9 @@ export default class CreateMarketReview extends Component {
       // gas: null,
       // fees: null
       // },
-      formattedInitialLiquidityEth: formatEtherTokensEstimate(this.props.newMarket.initialLiquidityEth),
+      formattedInitialLiquidityEth: formatEtherEstimate(this.props.newMarket.initialLiquidityEth),
       formattedInitialLiquidityGas: formatEtherEstimate(this.props.newMarket.initialLiquidityGas),
-      formattedInitialLiquidityFees: formatEtherTokensEstimate(this.props.newMarket.initialLiquidityFees),
+      formattedInitialLiquidityFees: formatEtherEstimate(this.props.newMarket.initialLiquidityFees),
     }
 
     this.calculateMarketCreationCosts = this.calculateMarketCreationCosts.bind(this)
@@ -42,9 +42,9 @@ export default class CreateMarketReview extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.newMarket.initialLiquidityEth !== nextProps.newMarket.initialLiquidityEth) this.setState({ formattedInitialLiquidityEth: formatEtherTokensEstimate(nextProps.newMarket.initialLiquidityEth) })
+    if (this.props.newMarket.initialLiquidityEth !== nextProps.newMarket.initialLiquidityEth) this.setState({ formattedInitialLiquidityEth: formatEtherEstimate(nextProps.newMarket.initialLiquidityEth) })
     if (this.props.newMarket.initialLiquidityGas !== nextProps.newMarket.initialLiquidityGas) this.setState({ formattedInitialLiquidityGas: formatEtherEstimate(nextProps.newMarket.initialLiquidityGas) })
-    if (this.props.newMarket.initialLiquidityFees !== nextProps.newMarket.initialLiquidityFees) this.setState({ formattedInitialLiquidityFees: formatEtherTokensEstimate(nextProps.newMarket.initialLiquidityFees) })
+    if (this.props.newMarket.initialLiquidityFees !== nextProps.newMarket.initialLiquidityFees) this.setState({ formattedInitialLiquidityFees: formatEtherEstimate(nextProps.newMarket.initialLiquidityFees) })
   }
 
   calculateMarketCreationCosts() {

--- a/src/modules/create-market/components/create-market-review.jsx
+++ b/src/modules/create-market/components/create-market-review.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import { augur } from 'services/augurjs'
 import BigNumber from 'bignumber.js'
 
-import { formatEtherEstimate, formatEtherTokensEstimate } from 'utils/format-number'
+import { formatEtherEstimate } from 'utils/format-number'
 import getValue from 'utils/get-value'
 
 import newMarketCreationOrder from 'modules/create-market/constants/new-market-creation-order'
@@ -38,9 +38,9 @@ export default class CreateMarketReview extends Component {
       // gas: null,
       // fees: null
       // },
-      formattedInitialLiquidityEth: formatEtherTokensEstimate(this.props.initialLiquidityEth),
+      formattedInitialLiquidityEth: formatEtherEstimate(this.props.initialLiquidityEth),
       formattedInitialLiquidityGas: formatEtherEstimate(this.props.initialLiquidityGas),
-      formattedInitialLiquidityFees: formatEtherTokensEstimate(this.props.initialLiquidityFees),
+      formattedInitialLiquidityFees: formatEtherEstimate(this.props.initialLiquidityFees),
     }
   }
 
@@ -55,9 +55,9 @@ export default class CreateMarketReview extends Component {
       this.calculateMarketCreationCosts()
     }
 
-    if (this.props.initialLiquidityEth !== nextProps.initialLiquidityEth) this.setState({ formattedInitialLiquidityEth: formatEtherTokensEstimate(nextProps.initialLiquidityEth) })
+    if (this.props.initialLiquidityEth !== nextProps.initialLiquidityEth) this.setState({ formattedInitialLiquidityEth: formatEtherEstimate(nextProps.initialLiquidityEth) })
     if (this.props.initialLiquidityGas !== nextProps.initialLiquidityGas) this.setState({ formattedInitialLiquidityGas: formatEtherEstimate(nextProps.initialLiquidityGas) })
-    if (this.props.initialLiquidityFees !== nextProps.initialLiquidityFees) this.setState({ formattedInitialLiquidityFees: formatEtherTokensEstimate(nextProps.initialLiquidityFees) })
+    if (this.props.initialLiquidityFees !== nextProps.initialLiquidityFees) this.setState({ formattedInitialLiquidityFees: formatEtherEstimate(nextProps.initialLiquidityFees) })
   }
 
   calculateMarketCreationCosts() {

--- a/src/modules/escape-hatch/components/escape-hatch.jsx
+++ b/src/modules/escape-hatch/components/escape-hatch.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import Styles from 'modules/escape-hatch/components/escape-hatch.styles'
-import { formatGasCost, formatEtherTokensEstimate } from 'utils/format-number'
+import { formatGasCost, formatEtherEstimate } from 'utils/format-number'
 import PropTypes from 'prop-types'
 
 export default class EscapeHatchView extends Component {
@@ -94,11 +94,11 @@ export default class EscapeHatchView extends Component {
             </div>
             <div>
               <span className={Styles.EscapeHatch_LabelCell}>REP</span>
-              <span>{formatEtherTokensEstimate(p.escapeHatchData.rep).rounded}</span>
+              <span>{formatEtherEstimate(p.escapeHatchData.rep).rounded}</span>
             </div>
             <div>
               <span className={Styles.EscapeHatch_LabelCell}>ETH</span>
-              <span>{formatEtherTokensEstimate(p.escapeHatchData.eth).rounded}</span>
+              <span>{formatEtherEstimate(p.escapeHatchData.eth).rounded}</span>
             </div>
             <div>
               <span className={Styles.EscapeHatch_LabelCell}>GAS</span>

--- a/src/modules/market/selectors/market.js
+++ b/src/modules/market/selectors/market.js
@@ -22,7 +22,7 @@ This is true for all selectors, but especially important for this one.
 
 import BigNumber from 'bignumber.js'
 import memoize from 'memoizee'
-import { formatShares, formatEtherTokens, formatEther, formatPercent, formatNumber } from 'utils/format-number'
+import { formatShares, formatEther, formatPercent, formatNumber } from 'utils/format-number'
 import { formatDate, getCurrentDateTimestamp, convertUnixToFormattedDate } from 'utils/format-date'
 import { isMarketDataOpen, isMarketDataExpired } from 'utils/is-market-data-open'
 
@@ -233,7 +233,7 @@ export function assembleMarket(
           ...outcomeData,
           id: outcomeId,
           marketId,
-          lastPrice: formatEtherTokens(outcomeData.price || 0, { positiveSign: false }),
+          lastPrice: formatEther(outcomeData.price || 0, { positiveSign: false }),
         }
 
         if (market.isScalar) {

--- a/src/modules/my-markets/selectors/my-markets.js
+++ b/src/modules/my-markets/selectors/my-markets.js
@@ -5,7 +5,7 @@ import store from 'src/store'
 import { selectLoginAccountAddress, selectPriceHistoryState, selectMarketCreatorFeesState } from 'src/select-state'
 import selectAllMarkets from 'modules/markets/selectors/markets-all'
 import { ZERO } from 'modules/trade/constants/numbers'
-import { formatNumber, formatEtherTokens } from 'utils/format-number'
+import { formatNumber, formatEther } from 'utils/format-number'
 
 export default function () {
   return selectLoginAccountMarkets(store.getState())
@@ -28,7 +28,7 @@ export const selectLoginAccountMarkets = createSelector(
     if (!authorOwnedMarkets) return []
     const markets = []
     authorOwnedMarkets.forEach((market) => {
-      const fees = formatEtherTokens(marketCreatorFees[market.id] || 0)
+      const fees = formatEther(marketCreatorFees[market.id] || 0)
       const numberOfTrades = formatNumber(selectNumberOfTrades(priceHistory[market.id]))
       const averageTradeSize = formatNumber(selectAverageTradeSize(priceHistory[market.id]))
       const openVolume = formatNumber(selectOpenVolume(market))

--- a/src/modules/my-positions/selectors/my-positions-summary.js
+++ b/src/modules/my-positions/selectors/my-positions-summary.js
@@ -8,7 +8,7 @@ import { closePosition } from 'modules/my-positions/actions/close-position'
 import { ZERO } from 'modules/trade/constants/numbers'
 
 // import { augur } from 'services/augurjs'
-import { formatEtherTokens, formatShares, formatNumber } from 'utils/format-number'
+import { formatEther, formatShares, formatNumber } from 'utils/format-number'
 
 export const generateOutcomePositionSummary = memoize((adjustedPosition) => {
   if (!adjustedPosition) {
@@ -74,10 +74,10 @@ export const generatePositionsSummary = memoize((numPositions, qtyShares, meanTr
       zeroStyled: false,
     }),
     qtyShares: formatShares(qtyShares),
-    purchasePrice: formatEtherTokens(meanTradePrice),
-    realizedNet: formatEtherTokens(realizedNet),
-    unrealizedNet: formatEtherTokens(unrealizedNet),
-    totalNet: formatEtherTokens(totalNet),
+    purchasePrice: formatEther(meanTradePrice),
+    realizedNet: formatEther(realizedNet),
+    unrealizedNet: formatEther(unrealizedNet),
+    totalNet: formatEther(totalNet),
   }
 }, { max: 20 })
 

--- a/src/modules/my-reports/selectors/my-reports.js
+++ b/src/modules/my-reports/selectors/my-reports.js
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { formatEtherTokens, formatPercent, formatRep } from 'utils/format-number'
+import { formatEther, formatPercent, formatRep } from 'utils/format-number'
 import { formatDate } from 'utils/format-date'
 import { TWO } from 'modules/trade/constants/numbers'
 import store from 'src/store'
@@ -59,7 +59,7 @@ export default function () {
 
 export const calculateFeesEarned = (market) => {
   if (!market.marketFees || !market.repBalance || !market.marketWeight) return null
-  return formatEtherTokens(new BigNumber(market.marketFees, 10)
+  return formatEther(new BigNumber(market.marketFees, 10)
     .times(new BigNumber(market.repBalance, 10))
     .dividedBy(TWO)
     .dividedBy(new BigNumber(market.marketWeight, 10)))

--- a/src/modules/portfolio/selectors/portfolio-nav-items.js
+++ b/src/modules/portfolio/selectors/portfolio-nav-items.js
@@ -4,7 +4,7 @@ import selectMyMarketsSummary from 'modules/my-markets/selectors/my-markets-summ
 import selectMyReportsSummary from 'modules/my-reports/selectors/my-reports-summary'
 
 import { MY_POSITIONS, MY_MARKETS, MY_REPORTS } from 'modules/routes/constants/views'
-import { formatNumber, formatEtherTokens, formatRep } from 'utils/format-number'
+import { formatNumber, formatEther, formatRep } from 'utils/format-number'
 
 export default function () {
   return selectPortfolioNavItems()
@@ -33,7 +33,7 @@ export const selectPortfolioNavItems = () => {
       leadingValue: formatNumber(((marketsSummary && marketsSummary.numMarkets) || 0), { denomination: 'Markets' }),
       leadingValueNull: 'No Markets',
       trailingTitle: 'Total Gain/Loss',
-      trailingValue: formatEtherTokens(((marketsSummary && marketsSummary.totalValue) || 0)),
+      trailingValue: formatEther(((marketsSummary && marketsSummary.totalValue) || 0)),
       trailingValueNull: 'No Gain/Loss',
     },
     {

--- a/src/modules/portfolio/selectors/portfolio-totals.js
+++ b/src/modules/portfolio/selectors/portfolio-totals.js
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { formatEtherTokens } from 'utils/format-number'
+import { formatEther } from 'utils/format-number'
 import { generateMarketsPositionsSummary } from 'modules/my-positions/selectors/my-positions-summary'
 import selectAllMarkets from 'modules/markets/selectors/markets-all'
 import selectMyMarketsSummary from 'modules/my-markets/selectors/my-markets-summary'
@@ -8,8 +8,8 @@ export default function () {
   const positionsSummary = generateMarketsPositionsSummary(selectAllMarkets())
   const marketsSummary = selectMyMarketsSummary()
 
-  const totalValue = formatEtherTokens(new BigNumber((positionsSummary && positionsSummary.totalNet && positionsSummary.totalNet.value) || 0, 10).plus(new BigNumber((marketsSummary && marketsSummary.totalNet) || 0, 10)))
-  const netChange = formatEtherTokens(new BigNumber((positionsSummary && positionsSummary.netChange && positionsSummary.netChange.value) || 0, 10).plus(new BigNumber((marketsSummary && marketsSummary.totalValue) || 0, 10)))
+  const totalValue = formatEther(new BigNumber((positionsSummary && positionsSummary.totalNet && positionsSummary.totalNet.value) || 0, 10).plus(new BigNumber((marketsSummary && marketsSummary.totalNet) || 0, 10)))
+  const netChange = formatEther(new BigNumber((positionsSummary && positionsSummary.netChange && positionsSummary.netChange.value) || 0, 10).plus(new BigNumber((marketsSummary && marketsSummary.totalValue) || 0, 10)))
 
   return {
     totalValue,

--- a/src/modules/transactions/selectors/transactions.js
+++ b/src/modules/transactions/selectors/transactions.js
@@ -7,7 +7,7 @@ import { BUY } from 'modules/transactions/constants/types'
 import { PENDING, SUCCESS, FAILED, SUBMITTED, INTERRUPTED } from 'modules/transactions/constants/statuses'
 
 import getValue from 'utils/get-value'
-import { formatShares, formatEtherTokens, formatEther, formatRep } from 'utils/format-number'
+import { formatShares, formatEther, formatRep } from 'utils/format-number'
 
 export default function () {
   return selectTransactions(store.getState())
@@ -50,7 +50,7 @@ export function formatTransaction(transaction) {
     ...transaction,
     data: transaction.data,
     gas: transaction.gas && formatEther(transaction.gas),
-    ethTokens: transaction.etherWithoutGas && formatEtherTokens(transaction.etherWithoutGas),
+    ethTokens: transaction.etherWithoutGas && formatEther(transaction.etherWithoutGas),
     shares: transaction.sharesChange && formatShares(transaction.sharesChange),
     rep: transaction.repChange && formatRep(transaction.repChange),
   }

--- a/src/modules/user-open-orders/selectors/user-open-orders.js
+++ b/src/modules/user-open-orders/selectors/user-open-orders.js
@@ -7,7 +7,7 @@ import { isOrderOfUser } from 'modules/bids-asks/helpers/is-order-of-user'
 
 import { BUY, SELL } from 'modules/transactions/constants/types'
 
-import { formatNone, formatEtherTokens, formatShares } from 'utils/format-number'
+import { formatNone, formatEther, formatShares } from 'utils/format-number'
 import { cancelOrder } from 'modules/bids-asks/actions/cancel-order'
 /**
  * Pulls off existing order book in state
@@ -65,7 +65,7 @@ function getUserOpenOrders(marketId, orders, orderType, outcomeId, userId, order
         outcomeId,
         pending: orderCancellation[order.orderId],
         originalShares: formatNone(),
-        avgPrice: formatEtherTokens(order.price),
+        avgPrice: formatEther(order.price),
         matchedShares: formatNone(),
         unmatchedShares: formatShares(order.amount),
         cancelOrder: (orderId, marketId, outcome, type) => {

--- a/src/utils/format-number.js
+++ b/src/utils/format-number.js
@@ -8,7 +8,7 @@ import addCommas from 'utils/add-commas-to-number'
   Produces a formatted number object used for display and calculations
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-The main function is `formatNumber`, however there are top-level functions that wrap for common cases like `formatEtherTokens`, `formatShares`, etc.
+The main function is `formatNumber`, however there are top-level functions that wrap for common cases like `formatEther`, `formatShares`, etc.
 
 A formatted number generally has three parts: the sign (+ or -), the stylized number, and a denomination (Eth, Rep, %, etc.)
 
@@ -49,22 +49,6 @@ if 1.1 + 1.4 = 2.6. If perfect precision isn't necessary, consider adding them u
 
 */
 
-export function formatEtherTokens(num, opts) {
-  return formatNumber(
-    encodeNumberAsJSNumber(num),
-    {
-      decimals: constants.PRECISION.decimals,
-      decimalsRounded: constants.PRECISION.decimals,
-      denomination: ' ETH Tokens',
-      positiveSign: false,
-      zeroStyled: false,
-      blankZero: false,
-      bigUnitPostfix: false,
-      ...opts,
-    },
-  )
-}
-
 export function formatEther(num, opts) {
   return formatNumber(
     encodeNumberAsJSNumber(num),
@@ -72,22 +56,6 @@ export function formatEther(num, opts) {
       decimals: constants.PRECISION.decimals,
       decimalsRounded: constants.PRECISION.decimals,
       denomination: ' ETH',
-      positiveSign: false,
-      zeroStyled: false,
-      blankZero: false,
-      bigUnitPostfix: false,
-      ...opts,
-    },
-  )
-}
-
-export function formatEtherTokensEstimate(num, opts) {
-  return formatNumber(
-    encodeNumberAsJSNumber(num),
-    {
-      decimals: constants.PRECISION.decimals,
-      decimalsRounded: constants.PRECISION.decimals,
-      denomination: ' ETH Tokens (estimated)',
       positiveSign: false,
       zeroStyled: false,
       blankZero: false,

--- a/test/account/selectors/core-stats-test.js
+++ b/test/account/selectors/core-stats-test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon'
 import BigNumber from 'bignumber.js'
 
 import coreStats, { selectOutcomeLastPrice, createPeriodPLSelector, selectCoreStats, __RewireAPI__ as CoreStatsRewireAPI } from 'modules/account/selectors/core-stats'
-import { formatEther, formatRep, formatEtherTokens } from 'utils/format-number'
+import { formatEther, formatRep } from 'utils/format-number'
 
 import { ZERO } from 'modules/trade/constants/numbers'
 
@@ -216,13 +216,13 @@ describe('modules/account/selectors/core-stats', () => {
       description: `should return the expected object`,
       assertions: () => {
         const loginAccount = {
-          ethTokens: formatEtherTokens(10),
+          ethTokens: formatEther(10),
           eth: formatEther(10),
           rep: formatRep(10),
         }
         const loginAccountPositions = {
           summary: {
-            totalNet: formatEtherTokens(10),
+            totalNet: formatEther(10),
           },
         }
         const periodPL = new BigNumber('10')
@@ -256,12 +256,12 @@ describe('modules/account/selectors/core-stats', () => {
             totalPLMonth: {
               label: '30 Day P/L',
               title: 'Profit/Loss -- net of all trades over the last 30 days',
-              value: formatEtherTokens(periodPL),
+              value: formatEther(periodPL),
             },
             totalPLDay: {
               label: '1 Day P/L',
               title: 'Profit/Loss -- net of all trades over the last day',
-              value: formatEtherTokens(periodPL),
+              value: formatEther(periodPL),
             },
           },
         ]

--- a/test/my-markets/selectors/my-markets-test.js
+++ b/test/my-markets/selectors/my-markets-test.js
@@ -6,7 +6,7 @@ import BigNumber from 'bignumber.js'
 
 import * as mockStore from 'test/mockStore'
 
-import { formatNumber, formatEtherTokens, formatShares } from 'utils/format-number'
+import { formatNumber, formatEther, formatShares } from 'utils/format-number'
 import { formatDate } from 'utils/format-date'
 
 describe('modules/portfolio/selectors/login-account-markets', () => {
@@ -37,7 +37,7 @@ describe('modules/portfolio/selectors/login-account-markets', () => {
       endDate: formatDate(new Date('2017/12/12')),
       repBalance: undefined,
       volume: formatNumber(100),
-      fees: formatEtherTokens(new BigNumber('10', 10)),
+      fees: formatEther(new BigNumber('10', 10)),
       numberOfTrades: formatNumber(4),
       averageTradeSize: formatNumber(15),
       openVolume: formatNumber(80),
@@ -91,7 +91,7 @@ describe('modules/portfolio/selectors/login-account-markets', () => {
       endDate: formatDate(new Date('2017/12/12')),
       repBalance: undefined,
       volume: formatNumber(100),
-      fees: formatEtherTokens(new BigNumber('11', 10)),
+      fees: formatEther(new BigNumber('11', 10)),
       numberOfTrades: formatNumber(4),
       averageTradeSize: formatNumber(15),
       openVolume: formatNumber(80),

--- a/test/my-positions/selectors/my-positions-summary-test.js
+++ b/test/my-positions/selectors/my-positions-summary-test.js
@@ -7,7 +7,7 @@ import {
   generatePositionsSummary,
 } from 'modules/my-positions/selectors/my-positions-summary'
 
-import { formatEtherTokens, formatShares, formatNumber } from 'utils/format-number'
+import { formatEther, formatShares, formatNumber } from 'utils/format-number'
 
 describe(`modules/my-positions/selectors/my-positions-summary.js`, () => {
   describe('generateOutcomePositionSummary', () => {
@@ -46,10 +46,10 @@ describe(`modules/my-positions/selectors/my-positions-summary.js`, () => {
             zeroStyled: false,
           }),
           qtyShares: formatShares(0),
-          purchasePrice: formatEtherTokens(0),
-          realizedNet: formatEtherTokens(0),
-          unrealizedNet: formatEtherTokens(0),
-          totalNet: formatEtherTokens(0),
+          purchasePrice: formatEther(0),
+          realizedNet: formatEther(0),
+          unrealizedNet: formatEther(0),
+          totalNet: formatEther(0),
           isClosable: false,
         }
 
@@ -88,10 +88,10 @@ describe(`modules/my-positions/selectors/my-positions-summary.js`, () => {
             zeroStyled: false,
           }),
           qtyShares: formatShares(10),
-          purchasePrice: formatEtherTokens(0.2),
-          realizedNet: formatEtherTokens(0.1),
-          unrealizedNet: formatEtherTokens(0.5),
-          totalNet: formatEtherTokens(0.6),
+          purchasePrice: formatEther(0.2),
+          realizedNet: formatEther(0.1),
+          unrealizedNet: formatEther(0.5),
+          totalNet: formatEther(0.6),
           isClosable: true,
         }
 
@@ -141,10 +141,10 @@ describe(`modules/my-positions/selectors/my-positions-summary.js`, () => {
                 zeroStyled: false,
               }),
               qtyShares: formatShares(1),
-              purchasePrice: formatEtherTokens(0.2),
-              realizedNet: formatEtherTokens(0),
-              unrealizedNet: formatEtherTokens(0),
-              totalNet: formatEtherTokens(0),
+              purchasePrice: formatEther(0.2),
+              realizedNet: formatEther(0),
+              unrealizedNet: formatEther(0),
+              totalNet: formatEther(0),
             },
             outcomes: [{}],
           },
@@ -159,10 +159,10 @@ describe(`modules/my-positions/selectors/my-positions-summary.js`, () => {
             zeroStyled: false,
           }),
           qtyShares: formatShares(0),
-          purchasePrice: formatEtherTokens(0),
-          realizedNet: formatEtherTokens(0),
-          unrealizedNet: formatEtherTokens(0),
-          totalNet: formatEtherTokens(0),
+          purchasePrice: formatEther(0),
+          realizedNet: formatEther(0),
+          unrealizedNet: formatEther(0),
+          totalNet: formatEther(0),
           positionOutcomes: [],
         }
 
@@ -185,10 +185,10 @@ describe(`modules/my-positions/selectors/my-positions-summary.js`, () => {
                 zeroStyled: false,
               }),
               qtyShares: formatShares(1),
-              purchasePrice: formatEtherTokens(0.2),
-              realizedNet: formatEtherTokens(0),
-              unrealizedNet: formatEtherTokens(0),
-              totalNet: formatEtherTokens(0),
+              purchasePrice: formatEther(0.2),
+              realizedNet: formatEther(0),
+              unrealizedNet: formatEther(0),
+              totalNet: formatEther(0),
             },
             outcomes: [
               {
@@ -201,10 +201,10 @@ describe(`modules/my-positions/selectors/my-positions-summary.js`, () => {
                     zeroStyled: false,
                   }),
                   qtyShares: formatShares(1),
-                  purchasePrice: formatEtherTokens(0.2),
-                  realizedNet: formatEtherTokens(10),
-                  unrealizedNet: formatEtherTokens(-1),
-                  totalNet: formatEtherTokens(9),
+                  purchasePrice: formatEther(0.2),
+                  realizedNet: formatEther(10),
+                  unrealizedNet: formatEther(-1),
+                  totalNet: formatEther(9),
                   isClosable: true,
                 },
               },
@@ -221,10 +221,10 @@ describe(`modules/my-positions/selectors/my-positions-summary.js`, () => {
             zeroStyled: false,
           }),
           qtyShares: formatShares(1),
-          purchasePrice: formatEtherTokens(0),
-          realizedNet: formatEtherTokens(10),
-          unrealizedNet: formatEtherTokens(-1),
-          totalNet: formatEtherTokens(9),
+          purchasePrice: formatEther(0),
+          realizedNet: formatEther(10),
+          unrealizedNet: formatEther(-1),
+          totalNet: formatEther(9),
           positionOutcomes: [
             {
               position: {
@@ -236,10 +236,10 @@ describe(`modules/my-positions/selectors/my-positions-summary.js`, () => {
                   zeroStyled: false,
                 }),
                 qtyShares: formatShares(1),
-                purchasePrice: formatEtherTokens(0.2),
-                realizedNet: formatEtherTokens(10),
-                unrealizedNet: formatEtherTokens(-1),
-                totalNet: formatEtherTokens(9),
+                purchasePrice: formatEther(0.2),
+                realizedNet: formatEther(10),
+                unrealizedNet: formatEther(-1),
+                totalNet: formatEther(9),
                 isClosable: true,
               },
             },
@@ -272,10 +272,10 @@ describe(`modules/my-positions/selectors/my-positions-summary.js`, () => {
             zeroStyled: false,
           }),
           qtyShares: formatShares(2),
-          purchasePrice: formatEtherTokens(0.2),
-          realizedNet: formatEtherTokens(10),
-          unrealizedNet: formatEtherTokens(-1),
-          totalNet: formatEtherTokens(9),
+          purchasePrice: formatEther(0.2),
+          realizedNet: formatEther(10),
+          unrealizedNet: formatEther(-1),
+          totalNet: formatEther(9),
         }
 
         assert.deepEqual(actual, expected, `Didn't return the expected value`)

--- a/test/order-book/selectors/order-book-series-test.js
+++ b/test/order-book/selectors/order-book-series-test.js
@@ -5,7 +5,7 @@ import orderBookSeries from 'modules/order-book/selectors/order-book-series'
 
 import { BIDS, ASKS } from 'modules/order-book/constants/order-book-order-types'
 
-import { formatEtherTokens, formatShares } from 'utils/format-number'
+import { formatEther, formatShares } from 'utils/format-number'
 
 describe('modules/order-book/selectors/order-book-series', () => {
   const test = (t) => {
@@ -31,29 +31,29 @@ describe('modules/order-book/selectors/order-book-series', () => {
       const actual = orderBookSeries({
         [BIDS]: [
           {
-            price: formatEtherTokens(0.2),
+            price: formatEther(0.2),
             shares: formatShares(10),
           },
           {
-            price: formatEtherTokens(0.1),
+            price: formatEther(0.1),
             shares: formatShares(10),
           },
           {
-            price: formatEtherTokens(0.1),
+            price: formatEther(0.1),
             shares: formatShares(10),
           },
         ],
         [ASKS]: [
           {
-            price: formatEtherTokens(0.5),
+            price: formatEther(0.5),
             shares: formatShares(10),
           },
           {
-            price: formatEtherTokens(0.5),
+            price: formatEther(0.5),
             shares: formatShares(10),
           },
           {
-            price: formatEtherTokens(0.6),
+            price: formatEther(0.6),
             shares: formatShares(10),
           },
         ],

--- a/test/portfolio/selectors/nav-items-test.js
+++ b/test/portfolio/selectors/nav-items-test.js
@@ -6,7 +6,7 @@ import proxyquire from 'proxyquire'
 
 import { MY_POSITIONS, MY_MARKETS, MY_REPORTS } from 'modules/routes/constants/views'
 
-import { formatNumber, formatEtherTokens, formatRep } from 'utils/format-number'
+import { formatNumber, formatEther, formatRep } from 'utils/format-number'
 
 describe('modules/portfolio/selectors/nav-items', () => {
   proxyquire.noPreserveCache().noCallThru()
@@ -53,7 +53,7 @@ describe('modules/portfolio/selectors/nav-items', () => {
   const stubbedGenerateMarketsPositionsSummary = sinon.stub(selectors, 'generateMarketsPositionsSummary').callsFake(() => (
     {
       numPositions: formatNumber(10, { denomination: 'positions' }),
-      totalNet: formatEtherTokens(2),
+      totalNet: formatEther(2),
     }
   ))
   const stubbedMyMarketsSummary = sinon.stub(selectors, 'selectMyMarketsSummary').callsFake(() => (
@@ -88,7 +88,7 @@ describe('modules/portfolio/selectors/nav-items', () => {
       leadingValue: formatNumber(10, { denomination: 'positions' }),
       leadingValueNull: 'No Positions',
       trailingTitle: 'Total Profit/Loss',
-      trailingValue: formatEtherTokens(2),
+      trailingValue: formatEther(2),
       trailingValueNull: 'No Profit/Loss',
     },
     {
@@ -98,7 +98,7 @@ describe('modules/portfolio/selectors/nav-items', () => {
       leadingValue: formatNumber(30, { denomination: 'Markets' }),
       leadingValueNull: 'No Markets',
       trailingTitle: 'Total Gain/Loss',
-      trailingValue: formatEtherTokens(10),
+      trailingValue: formatEther(10),
       trailingValueNull: 'No Gain/Loss',
     },
     {

--- a/test/trade/helpers/has-user-enough-funds-test.js
+++ b/test/trade/helpers/has-user-enough-funds-test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'mocha'
 import { assert } from 'chai'
-import { formatEtherTokens } from 'utils/format-number'
+import { formatEther } from 'utils/format-number'
 
 describe('modules/trade/helpers/has-user-enough-funds.js', () => {
   const hasUserEnoughFunds = require('../../../src/modules/trade/helpers/has-user-enough-funds').default
@@ -8,29 +8,29 @@ describe('modules/trade/helpers/has-user-enough-funds.js', () => {
   it(`should return false if user doesn't have enough money`, () => {
     assert.isFalse(hasUserEnoughFunds([], { address: 'address', ether: undefined }))
     assert.isFalse(hasUserEnoughFunds([], { address: 'address', ether: null }))
-    assert.isFalse(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEtherTokens('11') }], { address: 'address', ether: '10' }))
+    assert.isFalse(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEther('11') }], { address: 'address', ether: '10' }))
     assert.isFalse(hasUserEnoughFunds([], { address: 'address', ether: undefined }))
-    assert.isFalse(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEtherTokens('10') }], { address: 'address', ether: '0' }))
+    assert.isFalse(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEther('10') }], { address: 'address', ether: '0' }))
   })
 
   it(`should return false if user has no id defined`, () => {
     assert.isFalse(hasUserEnoughFunds([], { address: null, ether: undefined }))
     assert.isFalse(hasUserEnoughFunds([], { address: undefined, ether: undefined }))
-    assert.isFalse(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEtherTokens('10') }], { address: null, ether: '10' }))
-    assert.isFalse(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEtherTokens('10') }], { address: undefined, ether: '10' }))
+    assert.isFalse(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEther('10') }], { address: null, ether: '10' }))
+    assert.isFalse(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEther('10') }], { address: undefined, ether: '10' }))
   })
 
   it(`should return false if there is no logged in user`, () => {
     assert.isFalse(hasUserEnoughFunds([], undefined))
     assert.isFalse(hasUserEnoughFunds([], null))
     assert.isFalse(hasUserEnoughFunds([], {}))
-    assert.isFalse(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEtherTokens('10') }], null))
-    assert.isFalse(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEtherTokens('10') }], undefined))
-    assert.isFalse(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEtherTokens('10') }], {}))
+    assert.isFalse(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEther('10') }], null))
+    assert.isFalse(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEther('10') }], undefined))
+    assert.isFalse(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEther('10') }], {}))
   })
 
   it('should return true if user has enough money', () => {
-    assert.isTrue(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEtherTokens('10') }], { address: 'address', ether: '10' }))
-    assert.isTrue(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEtherTokens('9') }], { address: 'address', ether: '10' }))
+    assert.isTrue(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEther('10') }], { address: 'address', ether: '10' }))
+    assert.isTrue(hasUserEnoughFunds([{ side: 'buy', totalCost: formatEther('9') }], { address: 'address', ether: '10' }))
   })
 })

--- a/test/transactions/actions/construct-transaction-test.js
+++ b/test/transactions/actions/construct-transaction-test.js
@@ -11,7 +11,7 @@ import { strip0xPrefix } from 'speedomatic'
 
 import * as TYPES from 'modules/transactions/constants/types'
 
-import { formatEther, formatEtherTokens, formatPercent, formatRep, formatShares } from 'utils/format-number'
+import { formatEther, formatPercent, formatRep, formatShares } from 'utils/format-number'
 import { formatDate } from 'utils/format-date'
 
 import {
@@ -570,8 +570,8 @@ describe('modules/transactions/actions/construct-transaction.js', () => {
           data: {
             balances: [
               {
-                change: formatEtherTokens(log.cashFeesCollected, { positiveSign: true }),
-                balance: formatEtherTokens(log.newCashBalance),
+                change: formatEther(log.cashFeesCollected, { positiveSign: true }),
+                balance: formatEther(log.newCashBalance),
               },
               {
                 change: formatRep(repGain, { positiveSign: true }),
@@ -743,10 +743,10 @@ describe('modules/transactions/actions/construct-transaction.js', () => {
           type: TYPES.CREATE_MARKET,
           description: 'test description',
           category: 'Testing',
-          marketCreationFee: formatEtherTokens(log.marketCreationFee),
+          marketCreationFee: formatEther(log.marketCreationFee),
           bond: {
             label: 'validity',
-            value: formatEtherTokens(log.validityBond),
+            value: formatEther(log.validityBond),
           },
           message: 'created market',
         }
@@ -776,10 +776,10 @@ describe('modules/transactions/actions/construct-transaction.js', () => {
           type: TYPES.CREATE_MARKET,
           description: 'test description',
           category: 'Testing',
-          marketCreationFee: formatEtherTokens(log.marketCreationFee),
+          marketCreationFee: formatEther(log.marketCreationFee),
           bond: {
             label: 'validity',
-            value: formatEtherTokens(log.validityBond),
+            value: formatEther(log.validityBond),
           },
           message: 'creating market',
         }
@@ -871,8 +871,8 @@ describe('modules/transactions/actions/construct-transaction.js', () => {
             marketId: '0xMARKETID',
             balances: [
               {
-                change: formatEtherTokens(log.payoutTokens, { positiveSign: true }),
-                balance: formatEtherTokens(log.tokenBalance),
+                change: formatEther(log.payoutTokens, { positiveSign: true }),
+                balance: formatEther(log.tokenBalance),
               },
             ],
           },
@@ -936,15 +936,15 @@ describe('modules/transactions/actions/construct-transaction.js', () => {
               outcomeId: '1',
               marketId: '0xMARKETID',
             },
-            message: 'sold 2 shares for 0.1050 ETH Tokens / share',
+            message: 'sold 2 shares for 0.1050 ETH / share',
             numShares: formatShares('2'),
-            noFeePrice: formatEtherTokens('0.1'),
+            noFeePrice: formatEther('0.1'),
             timestamp: formatDate(new Date(order.timestamp * 1000)),
-            settlementFee: formatEtherTokens('0.01'),
+            settlementFee: formatEther('0.01'),
             feePercent: formatPercent('4.761904761904762'),
-            totalReturn: formatEtherTokens('0.19'),
+            totalReturn: formatEther('0.19'),
             gasFees: formatEther('0.001'),
-            avgPrice: formatEtherTokens('0.1'),
+            avgPrice: formatEther('0.1'),
             totalCost: undefined,
             blockNumber: 123456,
           },
@@ -988,14 +988,14 @@ describe('modules/transactions/actions/construct-transaction.js', () => {
               outcomeId: '1',
               marketId: '0xMARKETID',
             },
-            message: 'bought 2 shares for 0.0950 ETH Tokens / share',
+            message: 'bought 2 shares for 0.0950 ETH / share',
             numShares: formatShares('2'),
-            avgPrice: formatEtherTokens('0.1'),
+            avgPrice: formatEther('0.1'),
             timestamp: formatDate(new Date(order.timestamp * 1000)),
-            noFeePrice: formatEtherTokens('0.1'),
-            totalCost: formatEtherTokens('0.21'),
+            noFeePrice: formatEther('0.1'),
+            totalCost: formatEther('0.21'),
             totalReturn: undefined,
-            settlementFee: formatEtherTokens('0.01'),
+            settlementFee: formatEther('0.01'),
             feePercent: formatPercent('4.761904761904762'),
             gasFees: formatEther('0.001'),
             blockNumber: 123456,
@@ -1040,14 +1040,14 @@ describe('modules/transactions/actions/construct-transaction.js', () => {
               outcomeId: '1',
               marketId: '0xMARKETID',
             },
-            message: 'bought 2 shares for 0.1050 ETH Tokens / share',
+            message: 'bought 2 shares for 0.1050 ETH / share',
             numShares: formatShares('2'),
-            avgPrice: formatEtherTokens('0.1'),
-            noFeePrice: formatEtherTokens('0.1'),
+            avgPrice: formatEther('0.1'),
+            noFeePrice: formatEther('0.1'),
             timestamp: formatDate(new Date(order.timestamp * 1000)),
-            settlementFee: formatEtherTokens('0.01'),
+            settlementFee: formatEther('0.01'),
             feePercent: formatPercent('4.761904761904762'),
-            totalCost: formatEtherTokens('0.21'),
+            totalCost: formatEther('0.21'),
             totalReturn: undefined,
             gasFees: formatEther('0.001'),
             blockNumber: 123456,
@@ -1092,15 +1092,15 @@ describe('modules/transactions/actions/construct-transaction.js', () => {
               outcomeId: '1',
               marketId: '0xMARKETID',
             },
-            message: 'sold 2 shares for 0.0950 ETH Tokens / share',
+            message: 'sold 2 shares for 0.0950 ETH / share',
             numShares: formatShares('2'),
-            avgPrice: formatEtherTokens('0.1'),
-            noFeePrice: formatEtherTokens('0.1'),
+            avgPrice: formatEther('0.1'),
+            noFeePrice: formatEther('0.1'),
             timestamp: formatDate(new Date(order.timestamp * 1000)),
-            settlementFee: formatEtherTokens('0.01'),
+            settlementFee: formatEther('0.01'),
             feePercent: formatPercent('4.761904761904762'),
             totalCost: undefined,
-            totalReturn: formatEtherTokens('0.19'),
+            totalReturn: formatEther('0.19'),
             gasFees: formatEther('0.001'),
             blockNumber: 123456,
           },
@@ -1157,19 +1157,19 @@ describe('modules/transactions/actions/construct-transaction.js', () => {
                 outcomeId: '1',
                 marketId: '0xMARKETID',
               },
-              message: 'bid 2 shares for 0.1250 ETH Tokens / share',
+              message: 'bid 2 shares for 0.1250 ETH / share',
               numShares: formatShares('2'),
-              avgPrice: formatEtherTokens('0.1'),
-              noFeePrice: formatEtherTokens('0.1'),
+              avgPrice: formatEther('0.1'),
+              noFeePrice: formatEther('0.1'),
               freeze: {
-                noFeeCost: formatEtherTokens('0.2'),
-                settlementFee: formatEtherTokens('0.05'),
+                noFeeCost: formatEther('0.2'),
+                settlementFee: formatEther('0.05'),
                 verb: 'froze',
               },
               timestamp: formatDate(new Date(order.timestamp * 1000)),
               hash: '0xHASH',
               feePercent: formatPercent('20'),
-              totalCost: formatEtherTokens('0.25'),
+              totalCost: formatEther('0.25'),
               totalReturn: undefined,
               gasFees: formatEther('0.001'),
               blockNumber: 123456,
@@ -1197,20 +1197,20 @@ describe('modules/transactions/actions/construct-transaction.js', () => {
                 outcomeId: '1',
                 marketId: '0xMARKETID',
               },
-              message: 'ask 2 shares for 0.0750 ETH Tokens / share',
+              message: 'ask 2 shares for 0.0750 ETH / share',
               numShares: formatShares('2'),
-              noFeePrice: formatEtherTokens('0.1'),
-              avgPrice: formatEtherTokens('0.1'),
+              noFeePrice: formatEther('0.1'),
+              avgPrice: formatEther('0.1'),
               freeze: {
                 noFeeCost: undefined,
-                settlementFee: formatEtherTokens('0.05'),
+                settlementFee: formatEther('0.05'),
                 verb: 'froze',
               },
               timestamp: formatDate(new Date(order.timestamp * 1000)),
               hash: '0xHASH',
               feePercent: formatPercent('20'),
               totalCost: undefined,
-              totalReturn: formatEtherTokens('0.15'),
+              totalReturn: formatEther('0.15'),
               gasFees: formatEther('0.001'),
               blockNumber: 123456,
               orderId: '0xORDERID',
@@ -1256,7 +1256,7 @@ describe('modules/transactions/actions/construct-transaction.js', () => {
       assertions: (store) => {
         const actual = store.dispatch(action.constructCancelOrderTransaction(trade, marketId, marketType, description, outcomeId, null, minPrice, maxPrice, status))
 
-        const price = formatEtherTokens(trade.price)
+        const price = formatEther(trade.price)
         const shares = formatShares(trade.amount)
 
         const expected = {
@@ -1282,7 +1282,7 @@ describe('modules/transactions/actions/construct-transaction.js', () => {
             avgPrice: price,
             timestamp: formatDate(new Date(trade.timestamp * 1000)),
             hash: trade.transactionHash,
-            totalReturn: formatEtherTokens(trade.cashRefund),
+            totalReturn: formatEther(trade.cashRefund),
             gasFees: formatEther(trade.gasFees),
             blockNumber: trade.blockNumber,
             orderId: trade.orderId,
@@ -1303,7 +1303,7 @@ describe('modules/transactions/actions/construct-transaction.js', () => {
 
         const actual = store.dispatch(action.constructCancelOrderTransaction(trade, marketId, marketType, description, outcomeId, null, minPrice, maxPrice, status))
 
-        const price = formatEtherTokens(trade.price)
+        const price = formatEther(trade.price)
         const shares = formatShares(trade.amount)
 
         const expected = {

--- a/test/transactions/selectors/transactions-test.js
+++ b/test/transactions/selectors/transactions-test.js
@@ -6,7 +6,7 @@ import thunk from 'redux-thunk'
 
 import { SUCCESS, FAILED, PENDING, SUBMITTED, INTERRUPTED } from 'modules/transactions/constants/statuses'
 
-import { formatShares, formatEther, formatEtherTokens, formatRep } from 'utils/format-number'
+import { formatShares, formatEther, formatRep } from 'utils/format-number'
 import { formatDate } from 'utils/format-date'
 
 describe(`modules/transactions/selectors/transactions.js`, () => {
@@ -155,7 +155,7 @@ describe(`modules/transactions/selectors/transactions.js`, () => {
           etherWithoutGas: '2',
           sharesChange: '4',
           repChange: '5',
-          ethTokens: formatEtherTokens(2),
+          ethTokens: formatEther(2),
           shares: formatShares(4),
           rep: formatRep(5),
         },
@@ -174,7 +174,7 @@ describe(`modules/transactions/selectors/transactions.js`, () => {
           etherWithoutGas: '2',
           sharesChange: '4',
           repChange: '5',
-          ethTokens: formatEtherTokens(2),
+          ethTokens: formatEther(2),
           shares: formatShares(4),
           rep: formatRep(5),
         },
@@ -199,7 +199,7 @@ describe(`modules/transactions/selectors/transactions.js`, () => {
               etherWithoutGas: '2',
               sharesChange: '4',
               repChange: '5',
-              ethTokens: formatEtherTokens(2),
+              ethTokens: formatEther(2),
               shares: formatShares(4),
               rep: formatRep(5),
             },
@@ -218,7 +218,7 @@ describe(`modules/transactions/selectors/transactions.js`, () => {
               etherWithoutGas: '2',
               sharesChange: '4',
               repChange: '5',
-              ethTokens: formatEtherTokens(2),
+              ethTokens: formatEther(2),
               shares: formatShares(4),
               rep: formatRep(5),
             },
@@ -237,7 +237,7 @@ describe(`modules/transactions/selectors/transactions.js`, () => {
               etherWithoutGas: '2',
               sharesChange: '4',
               repChange: '5',
-              ethTokens: formatEtherTokens(2),
+              ethTokens: formatEther(2),
               shares: formatShares(4),
               rep: formatRep(5),
             },
@@ -257,7 +257,7 @@ describe(`modules/transactions/selectors/transactions.js`, () => {
           etherWithoutGas: '2',
           sharesChange: '4',
           repChange: '5',
-          ethTokens: formatEtherTokens(2),
+          ethTokens: formatEther(2),
           shares: formatShares(4),
           rep: formatRep(5),
         },

--- a/test/user-open-orders/selectors/user-open-orders-test.js
+++ b/test/user-open-orders/selectors/user-open-orders-test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai'
 import proxyquire from 'proxyquire'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
-import { formatEtherTokens, formatShares, formatNone } from 'utils/format-number'
+import { formatEther, formatShares, formatNone } from 'utils/format-number'
 import { CLOSE_DIALOG_CLOSING } from 'modules/market/constants/close-dialog-status'
 
 describe(`modules/user-open-orders/selectors/user-open-orders.js`, () => {
@@ -194,7 +194,7 @@ describe(`modules/user-open-orders/selectors/user-open-orders.js`, () => {
 
     const results =[{
       id: 'order1',
-      avgPrice: formatEtherTokens('100'),
+      avgPrice: formatEther('100'),
       type: 'sell',
       matchedShares: formatNone(),
       originalShares: formatNone(),
@@ -204,7 +204,7 @@ describe(`modules/user-open-orders/selectors/user-open-orders.js`, () => {
       cancelOrder: () => { },
     }, {
       id: 'order2',
-      avgPrice: formatEtherTokens('70'),
+      avgPrice: formatEther('70'),
       type: 'sell',
       matchedShares: formatNone(),
       originalShares: formatNone(),
@@ -214,7 +214,7 @@ describe(`modules/user-open-orders/selectors/user-open-orders.js`, () => {
       cancelOrder: () => { },
     }, {
       id: 'order3',
-      avgPrice: formatEtherTokens('10'),
+      avgPrice: formatEther('10'),
       type: 'sell',
       matchedShares: formatNone(),
       originalShares: formatNone(),
@@ -224,7 +224,7 @@ describe(`modules/user-open-orders/selectors/user-open-orders.js`, () => {
       cancelOrder: () => { },
     }, {
       id: 'order11',
-      avgPrice: formatEtherTokens('60'),
+      avgPrice: formatEther('60'),
       type: 'buy',
       matchedShares: formatNone(),
       originalShares: formatNone(),
@@ -234,7 +234,7 @@ describe(`modules/user-open-orders/selectors/user-open-orders.js`, () => {
       cancelOrder: () => { },
     }, {
       id: 'order13',
-      avgPrice: formatEtherTokens('20'),
+      avgPrice: formatEther('20'),
       type: 'buy',
       matchedShares: formatNone(),
       originalShares: formatNone(),
@@ -244,7 +244,7 @@ describe(`modules/user-open-orders/selectors/user-open-orders.js`, () => {
       cancelOrder: () => { },
     }, {
       id: 'order14',
-      avgPrice: formatEtherTokens('10'),
+      avgPrice: formatEther('10'),
       type: 'buy',
       matchedShares: formatNone(),
       originalShares: formatNone(),

--- a/test/utils/format-number-test.js
+++ b/test/utils/format-number-test.js
@@ -7,20 +7,6 @@ describe('utils/format-number.js', () => {
   const	num = 1000.100
   const utils = [
     {
-      func: 'formatEtherTokens',
-      denom: 'ETH Tokens',
-      out: {
-        value: 1000.1,
-        formattedValue: 1000.1,
-        roundedValue: 1000.1,
-        formatted: '1,000.1000',
-        rounded: '1,000.1000',
-        minimized: '1,000.1',
-        denomination: ' ETH Tokens',
-        full: '1,000.1000 ETH Tokens',
-      },
-    },
-    {
       func: 'formatEther',
       denom: 'ETH',
       out: {
@@ -32,20 +18,6 @@ describe('utils/format-number.js', () => {
         minimized: '1,000.1',
         denomination: ' ETH',
         full: '1,000.1000 ETH',
-      },
-    },
-    {
-      func: 'formatEtherTokensEstimate',
-      denom: 'ETH Tokens (estimated)',
-      out: {
-        value: 1000.1,
-        formattedValue: 1000.1,
-        roundedValue: 1000.1,
-        formatted: '1,000.1000',
-        rounded: '1,000.1000',
-        minimized: '1,000.1',
-        denomination: ' ETH Tokens (estimated)',
-        full: '1,000.1000 ETH Tokens (estimated)',
       },
     },
     {


### PR DESCRIPTION
removed formatEtherToken and formatEtherTokenEstimate and updated all references to use formatEther and formatEtherEstimate respectively.

[Clubhouse Story](https://app.clubhouse.io/augur/story/7920/remove-formatethertoken)

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [x] Test/lint pass 
- [x] Post merge, story marked complete 
