### PR TITLE
6528-volume-fee-update

### DIFF
--- a/src/modules/market/containers/market-header.js
+++ b/src/modules/market/containers/market-header.js
@@ -16,8 +16,8 @@ const mapStateToProps = (state, ownProps) => {
     marketType: market.marketType,
     resolutionSource: market.resolutionSource,
     coreProperties: {
-      volume: getValue(market, 'volume.formatted'),
-      fee: getValue(market, 'settlementFeePercent.formatted'), // FIXME -- right now really small fees display as 0.0
+      volume: getValue(market, 'volume.full'),
+      fee: getValue(market, 'settlementFeePercent.full'),
       expires: getValue(market, 'endDate.formattedLocal'),
     },
   }

--- a/src/utils/format-number.js
+++ b/src/utils/format-number.js
@@ -117,7 +117,7 @@ export function formatPercent(num, opts) {
   return formatNumber(
     encodeNumberAsJSNumber(num),
     {
-      decimals: 1,
+      decimals: 2,
       decimalsRounded: 0,
       denomination: '%',
       positiveSign: false,

--- a/test/utils/format-number-test.js
+++ b/test/utils/format-number-test.js
@@ -69,11 +69,11 @@ describe('utils/format-number.js', () => {
         value: 1000.1,
         formattedValue: 1000.1,
         roundedValue: 1000,
-        formatted: '1,000.1',
+        formatted: '1,000.10',
         rounded: '1,000',
         minimized: '1,000.1',
         denomination: '%',
-        full: '1,000.1%',
+        full: '1,000.10%',
       },
     },
     {


### PR DESCRIPTION
corrected missing shares/% label for market info, updated % formatting to show 2 decimal places so that settlement fees of .01% will display correctly instead of as 0.0%.

[Clubhouse Story](https://app.clubhouse.io/augur/story/6528/volume-and-fee-on-the-trade-page-should-have-units)

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [x] Test/lint pass 
- [x] Post merge, story marked complete 
