### PR TITLE
7687-remove-filters-portfolio

### DIFF
--- a/src/modules/portfolio/components/favorites/favorites.jsx
+++ b/src/modules/portfolio/components/favorites/favorites.jsx
@@ -1,112 +1,51 @@
-import React, { Component } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { Helmet } from 'react-helmet'
 
-import Dropdown from 'modules/common/components/dropdown/dropdown'
 import MarketsList from 'modules/markets/components/markets-list'
 import Styles from 'modules/portfolio/components/favorites/favorites.styles'
 import { TYPE_TRADE } from 'modules/market/constants/link-types'
 
-class Favorites extends Component {
-  static propTypes = {
-    markets: PropTypes.array.isRequired,
-    filteredMarkets: PropTypes.array.isRequired,
-    isLogged: PropTypes.bool.isRequired,
-    hasAllTransactionsLoaded: PropTypes.bool.isRequired,
-    history: PropTypes.object.isRequired,
-    location: PropTypes.object.isRequired,
-    match: PropTypes.object.isRequired,
-    toggleFavorite: PropTypes.func.isRequired,
-    loadMarketsInfo: PropTypes.func.isRequired,
-    isMobile: PropTypes.bool,
-  }
+const Favorites = p => (
+  <section className={Styles.Favorites}>
+    <Helmet>
+      <title>Favorites</title>
+    </Helmet>
+    <div
+      className={Styles.Favorites__SortBar}
+    >
+      <div
+        className={Styles['Favorites__SortBar-title']}
+      >
+        Favorites
+      </div>
 
-  constructor(props) {
-    super(props)
+    </div>
+    <MarketsList
+      isLogged={p.isLogged}
+      markets={p.markets}
+      filteredMarkets={p.filteredMarkets}
+      location={p.location}
+      history={p.history}
+      toggleFavorite={p.toggleFavorite}
+      loadMarketsInfo={p.loadMarketsInfo}
+      linkType={TYPE_TRADE}
+      isMobile={p.isMobile}
+    />
+  </section>
+)
 
-    this.state = {
-      sortOptions: [
-        { label: 'Volume', value: 'volume' },
-        { label: 'Newest', value: 'newest' },
-        { label: 'Fees', value: 'fees' },
-        { label: 'Expiring Soon', value: 'expiring' },
-      ],
-      sortDefault: 'volume',
-      sortType: 'volume',
-      filterOptions: [
-        { label: 'Cryptocurrency', value: 'cryptocurrency' },
-        { label: 'Blockchain', value: 'blockchain' },
-        { label: 'Bitcoin', value: 'bitcoin' },
-        { label: 'Ethereum', value: 'ethereum' },
-      ],
-      filterDefault: 'cryptocurrency',
-      filterType: 'cryptocurrency',
-    }
-
-    this.changeDropdown = this.changeDropdown.bind(this)
-  }
-
-  changeDropdown(value) {
-    let { sortType } = this.state
-    let { filterType } = this.state
-
-    this.state.sortOptions.forEach((type, ind) => {
-      if (type.value === value) {
-        sortType = value
-      }
-    })
-
-    this.state.filterOptions.forEach((type, ind) => {
-      if (type.value === value) {
-        filterType = value
-      }
-    })
-
-    this.setState({ sortType, filterType })
-  }
-
-  render() {
-    const p = this.props
-    const s = this.state
-
-    return (
-      <section className={Styles.Favorites}>
-        <Helmet>
-          <title>Favorites</title>
-        </Helmet>
-        <div
-          className={Styles.Favorites__SortBar}
-        >
-          <div
-            className={Styles['Favorites__SortBar-title']}
-          >
-            Favorites
-          </div>
-          <div
-            className={Styles['Favorites__SortBar-sort']}
-          >
-            <Dropdown default={s.sortDefault} options={s.sortOptions} onChange={this.changeDropdown} />
-          </div>
-          <div
-            className={Styles['Favorites__SortBar-filter']}
-          >
-            <Dropdown default={s.filterDefault} options={s.filterOptions} onChange={this.changeDropdown} />
-          </div>
-        </div>
-        <MarketsList
-          isLogged={p.isLogged}
-          markets={p.markets}
-          filteredMarkets={p.filteredMarkets}
-          location={p.location}
-          history={p.history}
-          toggleFavorite={p.toggleFavorite}
-          loadMarketsInfo={p.loadMarketsInfo}
-          linkType={TYPE_TRADE}
-          isMobile={p.isMobile}
-        />
-      </section>
-    )
-  }
+Favorites.propTypes = {
+  markets: PropTypes.array.isRequired,
+  filteredMarkets: PropTypes.array.isRequired,
+  isLogged: PropTypes.bool.isRequired,
+  hasAllTransactionsLoaded: PropTypes.bool.isRequired,
+  history: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  match: PropTypes.object.isRequired,
+  toggleFavorite: PropTypes.func.isRequired,
+  loadMarketsInfo: PropTypes.func.isRequired,
+  isMobile: PropTypes.bool,
 }
 
 export default Favorites

--- a/src/modules/portfolio/components/markets/markets.jsx
+++ b/src/modules/portfolio/components/markets/markets.jsx
@@ -5,7 +5,6 @@ import { Link } from 'react-router-dom'
 
 import makePath from 'modules/routes/helpers/make-path'
 
-import Dropdown from 'modules/common/components/dropdown/dropdown'
 import MarketsList from 'modules/markets/components/markets-list'
 import Styles from 'modules/portfolio/components/markets/markets.styles'
 import PortfolioStyles from 'modules/portfolio/components/portfolio-view/portfolio-view.styles'
@@ -39,7 +38,7 @@ class MyMarkets extends Component {
     this.reportingStates = constants.REPORTING_STATE
 
     this.props.myMarkets.forEach((market, index) => {
-      if (market.reportingState === this.reportingStates.DESIGNATED_REPORTING) {
+      if (market.reportingState === this.reportingStates.PRE_REPORTING) {
         openMarkets.push(market)
         filteredMarketsOpen.push(market.id)
       } else if (market.reportingState === this.reportingStates.FINALIZED) {
@@ -52,57 +51,6 @@ class MyMarkets extends Component {
     })
 
     this.state = {
-      sortOptionsOpen: [
-        { label: 'Volume', value: 'volume' },
-        { label: 'Newest', value: 'newest' },
-        { label: 'Fees', value: 'fees' },
-        { label: 'Expiring Soon', value: 'expiring' },
-      ],
-      sortDefaultOpen: 'volume',
-      sortTypeOpen: 'volume',
-      filterOptionsOpen: [
-        { label: 'Sports', value: 'sports' },
-        { label: 'Finance', value: 'finance' },
-        { label: 'Healthcare', value: 'healthcare' },
-        { label: 'Politics', value: 'politics' },
-        { label: 'Environment', value: 'environment' },
-      ],
-      filterDefaultOpen: 'finance',
-      filterTypeOpen: 'finance',
-      sortOptionsReporting: [
-        { label: 'Volume', value: 'volume' },
-        { label: 'Newest', value: 'newest' },
-        { label: 'Fees', value: 'fees' },
-        { label: 'Expiring Soon', value: 'expiring' },
-      ],
-      sortDefaultReporting: 'volume',
-      sortTypeReporting: 'volume',
-      filterOptionsReporting: [
-        { label: 'Sports', value: 'sports' },
-        { label: 'Finance', value: 'finance' },
-        { label: 'Healthcare', value: 'healthcare' },
-        { label: 'Politics', value: 'politics' },
-        { label: 'Environment', value: 'environment' },
-      ],
-      filterDefaultReporting: 'sports',
-      filterTypeReporting: 'sports',
-      sortOptionsFinal: [
-        { label: 'Volume', value: 'volume' },
-        { label: 'Newest', value: 'newest' },
-        { label: 'Fees', value: 'fees' },
-        { label: 'Expiring Soon', value: 'expiring' },
-      ],
-      sortDefaultFinal: 'volume',
-      sortTypeFinal: 'volume',
-      filterOptionsFinal: [
-        { label: 'Sports', value: 'sports' },
-        { label: 'Finance', value: 'finance' },
-        { label: 'Healthcare', value: 'healthcare' },
-        { label: 'Politics', value: 'politics' },
-        { label: 'Environment', value: 'environment' },
-      ],
-      filterDefaultFinal: 'healthcare',
-      filterTypeFinal: 'healthcare',
       openMarkets,
       reportingMarkets,
       finalMarkets,
@@ -110,8 +58,6 @@ class MyMarkets extends Component {
       filteredMarketsReporting,
       filteredMarketsFinal,
     }
-
-    this.changeDropdown = this.changeDropdown.bind(this)
   }
 
   componentWillMount() {
@@ -144,72 +90,14 @@ class MyMarkets extends Component {
       })
 
       this.setState({
-        filteredMarketsOpen,
         openMarkets,
-        filteredMarketsReporting,
         reportingMarkets,
-        filteredMarketsFinal,
         finalMarkets,
+        filteredMarketsOpen,
+        filteredMarketsReporting,
+        filteredMarketsFinal,
       })
     }
-  }
-
-  // TODO -- clean up this method
-  changeDropdown(value) {
-    let {
-      sortTypeOpen,
-      filterTypeOpen,
-      sortTypeReporting,
-      filterTypeReporting,
-      sortTypeFinal,
-      filterTypeFinal,
-    } = this.state
-
-    this.state.sortOptionsOpen.forEach((type, ind) => {
-      if (type.value === value) {
-        sortTypeOpen = value
-      }
-    })
-
-    this.state.filterOptionsOpen.forEach((type, ind) => {
-      if (type.value === value) {
-        filterTypeOpen = value
-      }
-    })
-
-    this.state.sortOptionsReporting.forEach((type, ind) => {
-      if (type.value === value) {
-        sortTypeReporting = value
-      }
-    })
-
-    this.state.filterOptionsReporting.forEach((type, ind) => {
-      if (type.value === value) {
-        filterTypeReporting = value
-      }
-    })
-
-    this.state.sortOptionsFinal.forEach((type, ind) => {
-      if (type.value === value) {
-        sortTypeFinal = value
-      }
-    })
-
-    this.state.filterOptionsFinal.forEach((type, ind) => {
-      if (type.value === value) {
-        filterTypeFinal = value
-      }
-    })
-
-
-    this.setState({
-      sortTypeOpen,
-      filterTypeOpen,
-      sortTypeReporting,
-      filterTypeReporting,
-      sortTypeFinal,
-      filterTypeFinal,
-    })
   }
 
   render() {
@@ -227,16 +115,6 @@ class MyMarkets extends Component {
             className={Styles.Markets__SortBar}
           >
             <h2 className={Styles['Markets__SortBar-title']}>Open</h2>
-            <div
-              className={Styles['Markets__SortBar-sort']}
-            >
-              <Dropdown default={s.sortDefaultOpen} options={s.sortOptionsOpen} onChange={this.changeDropdown} />
-            </div>
-            <div
-              className={Styles['Markets__SortBar-filter']}
-            >
-              <Dropdown default={s.filterDefaultOpen} options={s.filterOptionsOpen} onChange={this.changeDropdown} />
-            </div>
           </div>
         }
         {haveMarkets &&
@@ -265,16 +143,6 @@ class MyMarkets extends Component {
             >
               In Reporting
             </div>
-            <div
-              className={Styles['Markets__SortBar-sort']}
-            >
-              <Dropdown default={s.sortDefaultReporting} options={s.sortOptionsReporting} onChange={this.changeDropdown} />
-            </div>
-            <div
-              className={Styles['Markets__SortBar-filter']}
-            >
-              <Dropdown default={s.filterDefaultReporting} options={s.filterOptionsReporting} onChange={this.changeDropdown} />
-            </div>
           </div>
         }
         {haveMarkets &&
@@ -302,16 +170,6 @@ class MyMarkets extends Component {
               className={Styles['Markets__SortBar-title']}
             >
               Finalized
-            </div>
-            <div
-              className={Styles.Markets__SortBar}
-            >
-              <Dropdown default={s.sortDefaultFinal} options={s.sortOptionsFinal} onChange={this.changeDropdown} />
-            </div>
-            <div
-              className={Styles['Markets__SortBar-filter']}
-            >
-              <Dropdown default={s.filterDefaultFinal} options={s.filterOptionsFinal} onChange={this.changeDropdown} />
             </div>
           </div>
         }

--- a/src/modules/portfolio/components/positions-markets-list/positions-markets-list.jsx
+++ b/src/modules/portfolio/components/positions-markets-list/positions-markets-list.jsx
@@ -1,92 +1,46 @@
-import React, { Component } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import Dropdown from 'modules/common/components/dropdown/dropdown'
 import MarketPortfolioCard from 'modules/market/components/market-portfolio-card/market-portfolio-card'
 import NullStateMessage from 'modules/common/components/null-state-message/null-state-message'
 
 import Styles from 'modules/portfolio/components/positions-markets-list/positions-markets-list.styles'
 
-class PositionsMarketsList extends Component {
-  static propTypes = {
-    title: PropTypes.string.isRequired,
-    markets: PropTypes.array.isRequired,
-    closePositionStatus: PropTypes.object.isRequired,
-    location: PropTypes.object.isRequired,
-    history: PropTypes.object.isRequired,
-    linkType: PropTypes.string,
-    positionsDefault: PropTypes.bool,
-    claimTradingProceeds: PropTypes.func,
-    isMobile: PropTypes.bool,
-  }
-
-  constructor(props) {
-    super(props)
-    // NOTE: didn't make this component a container because it is reused in 3 different ways, seemed easier to seperate markets in positions and pass market arrays and filter categories
-    this.state = {
-      sortType: 'volume',
-      defaultSortType: 'volume',
-      sortOptions: [
-        { label: 'Volume', value: 'volume' },
-        { label: 'Newest', value: 'newest' },
-        { label: 'Expiring Soon', value: 'expiring' },
-        { label: 'Fees', value: 'fees' },
-      ],
-    }
-
-    this.changeDropdown = this.changeDropdown.bind(this)
-  }
-
-  changeDropdown(value) {
-    let { sortType } = this.state
-    let { filterType } = this.state
-
-    this.state.sortOptions.forEach((type, ind) => {
-      if (type.value === value) {
-        sortType = value
-      }
-    })
-
-    this.state.filterOptions.forEach((type, ind) => {
-      if (type.value === value) {
-        filterType = value
-      }
-    })
-
-    this.setState({ sortType, filterType })
-  }
-
-  render() {
-    const p = this.props
-    const s = this.state
-
-    return (
-      <div className={classNames(Styles.PositionsMarketsList, { [`${Styles.PositionMarketsListNullState}`]: p.markets.length === 0 })}>
-        <div className={Styles.PositionsMarketsList__SortBar}>
-          <div className={Styles['PositionsMarketsList__SortBar-title']}>
-            {p.title}
-          </div>
-          <div className={Styles['PositionsMarketsList__SortBar-sort']}>
-            <Dropdown default={s.defaultSortType} options={s.sortOptions} onChange={this.changeDropdown} />
-          </div>
-        </div>
-        {p.markets.length ?
-          p.markets.map(market =>
-            (<MarketPortfolioCard
-              key={market.id}
-              market={market}
-              closePositionStatus={p.closePositionStatus}
-              location={p.location}
-              history={p.history}
-              linkType={p.linkType}
-              positionsDefault={p.positionsDefault}
-              claimTradingProceeds={p.claimTradingProceeds}
-              isMobile={p.isMobile}
-            />)):
-          <NullStateMessage message="No Markets Available" />}
+const PositionsMarketsList = p => (
+  <div className={classNames(Styles.PositionsMarketsList, { [`${Styles.PositionMarketsListNullState}`]: p.markets.length === 0 })}>
+    <div className={Styles.PositionsMarketsList__SortBar}>
+      <div className={Styles['PositionsMarketsList__SortBar-title']}>
+        {p.title}
       </div>
-    )
-  }
+    </div>
+    {p.markets.length ?
+      p.markets.map(market =>
+        (<MarketPortfolioCard
+          key={market.id}
+          market={market}
+          closePositionStatus={p.closePositionStatus}
+          location={p.location}
+          history={p.history}
+          linkType={p.linkType}
+          positionsDefault={p.positionsDefault}
+          claimTradingProceeds={p.claimTradingProceeds}
+          isMobile={p.isMobile}
+        />)):
+      <NullStateMessage message="No Markets Available" />}
+  </div>
+)
+
+PositionsMarketsList.propTypes = {
+  title: PropTypes.string.isRequired,
+  markets: PropTypes.array.isRequired,
+  closePositionStatus: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired,
+  linkType: PropTypes.string,
+  positionsDefault: PropTypes.bool,
+  claimTradingProceeds: PropTypes.func,
+  isMobile: PropTypes.bool,
 }
+
 
 export default PositionsMarketsList


### PR DESCRIPTION
removed the filters/sorts from Portfolio views (my markets, my positions, favorites)

[Clubhouse Story](https://app.clubhouse.io/augur/story/7687/remove-filters-sorts-from-positions-and-my-markets-views)

to reproduce, go to the portfolio view and note that there are no longer options to filter/sort the various lists of markets.

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [x] Test/lint pass 
- [x] Post merge, story marked complete 
