### PR TITLE
…

### DIFF
--- a/test/trade/actions/place-trade-test.js
+++ b/test/trade/actions/place-trade-test.js
@@ -53,22 +53,27 @@ describe(`modules/trade/actions/place-trade.js`, () => {
       allowance: '0',
     }
     const store = mockStore(testState)
+    const CheckAccountAllowance = { checkAccountAllowance: () => {} }
     const SelectMarket = { selectMarket: () => {} }
+    const checkAllownaceActionObject = { type: 'UPDATE_LOGIN_ACCOUNT', allowance: '0' }
     sinon.stub(SelectMarket, 'selectMarket').callsFake(marketId => store.getState().marketsData[marketId])
+    sinon.stub(CheckAccountAllowance, 'checkAccountAllowance').callsFake(() => checkAllownaceActionObject)
     const action = proxyquire('../../../src/modules/trade/actions/place-trade.js', {
       '../../market/selectors/market': SelectMarket,
+      '../../auth/actions/approve-account': CheckAccountAllowance,
     })
     store.dispatch(action.placeTrade('testBinaryMarketId', '1', {
       totalCost: '10000000',
     }))
     const storeActions = store.getActions()
-    const firstAction = storeActions[0]
-    assert.deepEqual(store.getActions().length, 1, 'more actions dispatched then expected')
-    assert.isObject(firstAction)
-    assert.deepEqual(firstAction.type, 'UPDATE_MODAL')
-    assert.isObject(firstAction.data)
-    assert.deepEqual(firstAction.data.type, 'MODAL_ACCOUNT_APPROVAL')
-    assert.isFunction(firstAction.data.approveCallback)
+    const approvalAction = storeActions[1]
+    assert.deepEqual(storeActions.length, 2, 'more/less actions dispatched then expected')
+    assert.deepEqual(storeActions[0], checkAllownaceActionObject, `first action wasn't a call to checkAllowanceActionObject`)
+    assert.isObject(approvalAction)
+    assert.deepEqual(approvalAction.type, 'UPDATE_MODAL')
+    assert.isObject(approvalAction.data)
+    assert.deepEqual(approvalAction.data.type, 'MODAL_ACCOUNT_APPROVAL')
+    assert.isFunction(approvalAction.data.approveCallback)
     store.clearActions()
   })
 })


### PR DESCRIPTION
updated place trade to do an additional `checkAccountAllowance` call if the `loginAccount.allowance` is 0. this should prevent any recurring attempts at approval after successfully approving the first time.

[Clubhouse Story](https://app.clubhouse.io/augur/story/7935/update-allowance-for-account-after-approval)

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
- [ ] Post merge, story marked complete 
