### PR TITLE
7957-switch-reporting-dispute

### DIFF
--- a/src/modules/app/components/app/app.jsx
+++ b/src/modules/app/components/app/app.jsx
@@ -128,7 +128,7 @@ export default class AppView extends Component {
         iconName: 'nav-reporting-icon',
         icon: NavReportingIcon,
         mobileClick: () => this.setState({ mobileMenuState: mobileMenuStates.FIRSTMENU_OPEN }),
-        route: REPORTING_DISPUTE_MARKETS,
+        route: REPORTING_REPORT_MARKETS,
         requireLogin: true,
       },
       {

--- a/src/modules/app/components/inner-nav/reporting-inner-nav.jsx
+++ b/src/modules/app/components/inner-nav/reporting-inner-nav.jsx
@@ -5,19 +5,19 @@ export default class ReportingInnerNav extends BaseInnerNav {
   getMainMenuData() {
     return [
       {
-        label: 'Dispute',
-        visible: true,
-        isSelected: (this.props.currentBasePath === REPORTING_DISPUTE_MARKETS),
-        link: {
-          pathname: REPORTING_DISPUTE_MARKETS,
-        },
-      },
-      {
         label: 'Reporting',
         visible: true,
         isSelected: (this.props.currentBasePath === REPORTING_REPORT_MARKETS),
         link: {
           pathname: REPORTING_REPORT_MARKETS,
+        },
+      },
+      {
+        label: 'Dispute',
+        visible: true,
+        isSelected: (this.props.currentBasePath === REPORTING_DISPUTE_MARKETS),
+        link: {
+          pathname: REPORTING_DISPUTE_MARKETS,
         },
       },
       {


### PR DESCRIPTION
updated reporting nav to have reporting first then dispute then resolved, now navigate to reporting on first navigation instead of dispute.

[Clubhouse Story](https://app.clubhouse.io/augur/story/7957/switch-the-order-of-reporting-and-dispute-in-the-subnav)

to reproduce, go to the reporting section of the site. You should be on the `reporting` subnav. The subnav should now be in an order of:
```
reporting
dispute
resolved
```

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [x] Test/lint pass 
- [x] Post merge, story marked complete 
