### PR TITLE
7948-participation-alignment

### DIFF
--- a/src/modules/reporting/components/reporting-header/reporting-header.styles.less
+++ b/src/modules/reporting/components/reporting-header/reporting-header.styles.less
@@ -10,6 +10,7 @@
 }
 
 .ReportingHeader__dispute-header {
+  align-items: flex-end;
   display: flex;
   justify-content: space-between;
   margin-bottom: 0.875rem;
@@ -142,6 +143,7 @@
 
 @media @breakpoint-mobile {
   .ReportingHeader__dispute-header {
+    align-items: flex-start;
     flex-flow: column-reverse nowrap;
   }
 


### PR DESCRIPTION
updated alignment of participation text and other info in the dispute header for the dispute view

[Clubhouse Story](https://app.clubhouse.io/augur/story/7948/the-dispute-window-info-and-the-participate-link-should-be-inline-with-one-another)

just checkout the dispute view, the text above the progress bar should be aligned now. mobile view should look the same (participation far left, above the other text)

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [x] Test/lint pass 
- [ ] Post merge, story marked complete 
