### PR TITLE
7521-inconsistent-rounding

### DIFF
--- a/src/modules/market/components/market-positions-list--order/market-positions-list--order.jsx
+++ b/src/modules/market/components/market-positions-list--order/market-positions-list--order.jsx
@@ -51,7 +51,7 @@ export default class Order extends Component {
       height: s.confirmHeight,
       marginTop: s.confirmMargin,
     }
-    // if (p.order.outcomeId === "1" && p.order.type === 'sell') console.log('or', p.order);
+
     return (
       <ul
         ref={(order) => { this.order = order }}

--- a/src/modules/market/components/market-positions-list--order/market-positions-list--order.jsx
+++ b/src/modules/market/components/market-positions-list--order/market-positions-list--order.jsx
@@ -51,7 +51,7 @@ export default class Order extends Component {
       height: s.confirmHeight,
       marginTop: s.confirmMargin,
     }
-
+    // if (p.order.outcomeId === "1" && p.order.type === 'sell') console.log('or', p.order);
     return (
       <ul
         ref={(order) => { this.order = order }}
@@ -68,7 +68,7 @@ export default class Order extends Component {
           }
         </li>
         <li>
-          { p.type === SELL ? <span>-</span> : <span>+</span> } { getValue(p, 'order.unmatchedShares.formatted') }
+          { p.order.type === SELL ? <span>-</span> : <span>+</span> } { getValue(p, 'order.unmatchedShares.formatted') }
         </li>
         <li>
           { getValue(p, 'order.avgPrice.formatted') }

--- a/src/modules/user-open-orders/selectors/user-open-orders.js
+++ b/src/modules/user-open-orders/selectors/user-open-orders.js
@@ -65,7 +65,7 @@ function getUserOpenOrders(marketId, orders, orderType, outcomeId, userId, order
         outcomeId,
         pending: orderCancellation[order.orderId],
         originalShares: formatNone(),
-        avgPrice: formatEther(order.price),
+        avgPrice: formatEther(order.fullPrecisionPrice),
         matchedShares: formatNone(),
         unmatchedShares: formatShares(order.amount),
         cancelOrder: (orderId, marketId, outcome, type) => {


### PR DESCRIPTION
updated user-open-orders to use the fullPrecisionPrice as the `avgPrice` value passed back. Updated the +/- indicator on open orders as it wasn't properly setting the +/-.

[Clubhouse Story](https://app.clubhouse.io/augur/story/7521/inconsistent-rounding-on-trade-page)

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
- [ ] Post merge, story marked complete 
