### PR TITLE
Move definition of totalItems before it is used

### DIFF
--- a/src/modules/common/components/paginator/paginator.jsx
+++ b/src/modules/common/components/paginator/paginator.jsx
@@ -176,6 +176,7 @@ class Paginator extends Component {
     }
     //    Forward
     let forwardQuery
+    const totalItems = options.itemsLength
     if (currentPage * options.itemsPerPage >= totalItems) {
       const queryParams = parseQuery(options.location.search)
       queryParams[options.pageParam] = currentPage
@@ -186,7 +187,6 @@ class Paginator extends Component {
       forwardQuery = makeQuery(queryParams)
     }
 
-    const totalItems = options.itemsLength
     const boundedLength = (upperBound - lowerBound) + 1
 
     this.setState({


### PR DESCRIPTION
Saw this error on lgtm.com here:
https://lgtm.com/projects/g/AugurProject/augur/snapshot/dist-81795862-1520931448129/files/src/modules/common/components/paginator.jsx?#xd27fe39cd6890662:1

And thought I should fix it.. I don't have an account in clubhouse, so there's no story to link to.

[Clubhouse Story](https://app.clubhouse.io/augur/story/ENTER_STORY_NUMBER_HERE)

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
- [ ] Post merge, story marked complete 
