### PR TITLE
6698-filter-markets-tag

### DIFF
--- a/src/modules/app/components/inner-nav/markets-inner-nav.jsx
+++ b/src/modules/app/components/inner-nav/markets-inner-nav.jsx
@@ -67,22 +67,24 @@ export default class MarketsInnerNav extends BaseInnerNav {
 
   addTags(tags) {
     const newTags = {}
+    // NOTE: changed this to just display true since we aren't going to show in 50 milliseconds anymore.
     tags.forEach((tag) => {
-      newTags[tag] = { visible: false }
+      newTags[tag] = { visible: true }
     })
 
     const visibleTags = { ...this.state.visibleTags, ...newTags }
     this.setState({ visibleTags })
-
+    // NOTE: Removed this for now, we shoudl find a better way to animate as this will re-show things tags that should be hidden.
     // animate tags after mounting
-    window.setTimeout(() => {
-      const animTags = {}
-      tags.forEach((tag) => {
-        animTags[tag] = { visible: true }
-      })
-      const visibleTags = { ...this.state.visibleTags, ...animTags }
-      this.setState({ visibleTags })
-    }, 50)
+    // window.setTimeout(() => {
+    //   const animTags = {}
+    //   tags.forEach((tag) => {
+    //     animTags[tag] = { visible: true }
+    //   })
+    //   const visibleTags = { ...this.state.visibleTags, ...animTags }
+    //   console.log('new tags 3', visibleTags);
+    //   this.setState({ visibleTags })
+    // }, 50)
   }
 
   removeTags(tags) {

--- a/src/modules/filter-sort/helpers/filter-by-tags.js
+++ b/src/modules/filter-sort/helpers/filter-by-tags.js
@@ -6,9 +6,9 @@ export default function filterByTags(tags, items) {
   return items.reduce((p, item, i) => {
     if (tags.every(filterTag =>
       item.tags.some((tag, tagIndex) =>
-        tagIndex !== 0 && tag === filterTag))
+        tag === filterTag))
     ) {
-      return [...p, i]
+      return [...p, items[i].id]
     }
 
     return p

--- a/src/modules/markets/components/markets-view.jsx
+++ b/src/modules/markets/components/markets-view.jsx
@@ -13,7 +13,9 @@ import isEqual from 'lodash/isEqual'
 // import makePath from 'modules/routes/helpers/make-path'
 
 // import { FAVORITES, MARKETS } from 'modules/routes/constants/views'
-import { CATEGORY_PARAM_NAME, FILTER_SEARCH_PARAM } from 'modules/filter-sort/constants/param-names'
+import { CATEGORY_PARAM_NAME, FILTER_SEARCH_PARAM, TAGS_PARAM_NAME } from 'modules/filter-sort/constants/param-names'
+import { QUERY_VALUE_DELIMITER } from 'modules/routes/constants/query-value-delimiter'
+import filterByTags from 'modules/filter-sort/helpers/filter-by-tags'
 import { TYPE_TRADE } from 'modules/market/constants/link-types'
 
 export default class MarketsView extends Component {
@@ -66,6 +68,14 @@ export default class MarketsView extends Component {
   }
 
   componentWillUpdate(nextProps, nextState) {
+    const newTags = decodeURIComponent(parseQuery(nextProps.location.search)[TAGS_PARAM_NAME] || '')
+    if (newTags.length) {
+      const marketsFilteredByTags = filterByTags(newTags.split(QUERY_VALUE_DELIMITER), nextProps.markets)
+      if (!isEqual(marketsFilteredByTags, nextProps.filteredMarkets)) {
+        this.props.updateMarketsFilteredSorted(marketsFilteredByTags)
+      }
+    }
+    // }
     // if (!isEqual(this.state.markets, nextState.markets)) {
     //   this.props.updateMarketsFilteredSorted(nextState.markets)
     //   checkFavoriteMarketsCount(nextState.markets, nextProps.location, nextProps.history)
@@ -109,12 +119,13 @@ function loadMarkets(options) {
   if (options.canLoadMarkets) {
     const category = parseQuery(options.location.search)[CATEGORY_PARAM_NAME]
     const search = parseQuery(options.location.search)[FILTER_SEARCH_PARAM]
+    const tag = parseQuery(options.location.search)[TAGS_PARAM_NAME]
     // Expected behavior is to load a specific category if one is present
     // else, if we aren't searching (which is a local market data search)
     // then load markets (loads all markets)
-    if (category) {
+    if (category && (!tag || !options.hasLoadedCategory[category])) {
       options.loadMarketsByCategory(category)
-    } else if (!search) {
+    } else if (!search && !tag) {
       options.loadMarkets()
     }
   }

--- a/test/filter-sort/helpers/filter-by-tags-test.js
+++ b/test/filter-sort/helpers/filter-by-tags-test.js
@@ -1,0 +1,57 @@
+
+
+import mocks from 'test/mockStore'
+import filterByTags from 'modules/filter-sort/helpers/filter-by-tags'
+
+describe('modules/filter-sort/helpers/filter-by-tags.js', () => {
+  const test = t => it(t.description, () => t.assertions())
+  const { state } = mocks
+  const defaultItems = [
+    {
+      ...state.marketsData.testMarketId,
+      tags: ['test', 'two words'],
+    }, {
+      ...state.marketsData.testMarketId2,
+    },
+  ]
+  test({
+    description: 'should handle a empty tag array and items array',
+    assertions: () => {
+      assert.isNull(filterByTags([], []))
+    },
+  })
+  test({
+    description: 'should handle a null tag array',
+    assertions: () => {
+      assert.isNull(filterByTags(null, defaultItems))
+    },
+  })
+  test({
+    description: 'should handle a single tag',
+    assertions: () => {
+      const expected = ['testMarketId']
+      assert.deepEqual(filterByTags(['test'], defaultItems), expected)
+    },
+  })
+  test({
+    description: 'should handle two tags',
+    assertions: () => {
+      const expected = ['testMarketId2']
+      assert.deepEqual(filterByTags(['tag1', 'tag2'], defaultItems), expected)
+    },
+  })
+  test({
+    description: 'should handle a two word tag',
+    assertions: () => {
+      const expected = ['testMarketId']
+      assert.deepEqual(filterByTags(['two words'], defaultItems), expected)
+    },
+  })
+  test({
+    description: 'should handle finding no market ideas (no match)',
+    assertions: () => {
+      const expected = []
+      assert.deepEqual(filterByTags(['hippopotamus'], defaultItems), expected)
+    },
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -510,9 +510,9 @@ augur-core@0.12.3:
     path "0.12.7"
     recursive-readdir "2.2.1"
 
-augur.js@4.9.2-0:
-  version "4.9.2-0"
-  resolved "https://registry.yarnpkg.com/augur.js/-/augur.js-4.9.2-0.tgz#217b55c8a0ecfafde52a812be0457017b3d74aa9"
+augur.js@4.9.2-1:
+  version "4.9.2-1"
+  resolved "https://registry.yarnpkg.com/augur.js/-/augur.js-4.9.2-1.tgz#2e33313231883d0f80eda536f9ebcb5f901007c6"
   dependencies:
     async "1.5.2"
     augur-core "0.12.3"


### PR DESCRIPTION
fixed an issue with tags not filtering when selected on the side menu, fixed another visual issue where tags were displaying for markets not present in the filtered view.

[Clubhouse Story](https://app.clubhouse.io/augur/story/6698/unable-to-filter-market-categories-by-tag)

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
- [ ] Post merge, story marked complete 
