### PR TITLE
add example of using wrapped bn to sort

### DIFF
--- a/test/utils/wrapped-big-number-test.js
+++ b/test/utils/wrapped-big-number-test.js
@@ -33,4 +33,19 @@ describe('src/utils/wrapped-big-number.js', () => {
   it('should act like a big number', () => {
     assert.equal(WrappedBigNumber(2).plus(WrappedBigNumber(4)).toString(), '6')
   })
+
+  it('should sort like a big number', () => {
+    const expected = [
+      { value: '77' },
+      { value: '12' },
+      { value: '4' },
+    ]
+    const myObjectArray = [
+      { value: '12' },
+      { value: '4' },
+      { value: '77' },
+    ]
+    const result = myObjectArray.sort((a, b) => WrappedBigNumber(a.value).isLessThan(WrappedBigNumber(b.value)))
+    assert.deepEqual(result, expected, 'was not sorted correctly')
+  })
 })


### PR DESCRIPTION
added example of sorting with Wrapped big number.

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
- [ ] Post merge, story marked complete 
