### PR TITLE
7388-transaction-warnings

### DIFF
--- a/src/modules/portfolio/components/transaction-linked/transaction-linked.jsx
+++ b/src/modules/portfolio/components/transaction-linked/transaction-linked.jsx
@@ -34,7 +34,7 @@ export default class LinkedTransaction extends Component {
             }
             <span className={Styles['LinkedTransaction__message-text']}>{ p.transaction.message }</span>
           </div>
-          <span className={classNames(Styles['LinkedTransaction__message-chevron'], { [`${Styles['is-open']}`]: s.isOpen })}>{ ChevronDown }</span>
+          <span className={classNames(Styles['LinkedTransaction__message-chevron'], { [`${Styles['is-open']}`]: s.isOpen })}>{ <ChevronDown /> }</span>
         </button>
         <div
           ref={(metaWrapper) => { this.metaWrapper = metaWrapper }}

--- a/src/modules/portfolio/components/transaction-meta/transaction-meta.jsx
+++ b/src/modules/portfolio/components/transaction-meta/transaction-meta.jsx
@@ -5,7 +5,10 @@ import Styles from 'modules/portfolio/components/transaction-meta/transaction-me
 export default class TransactionMeta extends Component {
   static propTypes = {
     meta: PropTypes.object.isRequired,
-    networkId: PropTypes.number.isRequired,
+    networkId: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]).isRequired,
   }
 
   static networkLink = {

--- a/src/modules/portfolio/components/transaction-multiple/transaction-multiple.jsx
+++ b/src/modules/portfolio/components/transaction-multiple/transaction-multiple.jsx
@@ -41,7 +41,7 @@ export default class TransactionMultiple extends Component {
           onClick={() => { toggleHeight(this.multipleTransactions, s.isOpen, () => { this.setState({ isOpen: !s.isOpen }) }) }}
         >
           <span className={classNames(CommonStyles['Transaction__linked-more-text'], { [`${CommonStyles['is-open']}`]: s.isOpen })}>{ s.isOpen ? 'Hide' : '+' } {(transaction.transactions && transaction.transactions.length) || 0} Linked Transactions</span>
-          <span className={classNames(CommonStyles['Transaction__linked-more-chevron'], { [`${CommonStyles['is-open']}`]: s.isOpen })}>{ ChevronDown }</span>
+          <span className={classNames(CommonStyles['Transaction__linked-more-chevron'], { [`${CommonStyles['is-open']}`]: s.isOpen })}>{ <ChevronDown /> }</span>
         </button>
         <div className={ToggleHeightStyles['toggle-height-target']} ref={(multipleTransactions) => { this.multipleTransactions = multipleTransactions }}>
           { (transaction.transactions || []).map((linkedTransaction, i) => (

--- a/src/modules/portfolio/components/transaction-single/transaction-single.jsx
+++ b/src/modules/portfolio/components/transaction-single/transaction-single.jsx
@@ -36,7 +36,7 @@ export default class TransactionSingle extends Component {
           onClick={() => { toggleHeight(this.singleTransactionMeta, s.isOpen, () => { this.setState({ isOpen: !s.isOpen }) }) }}
         >
           <TransactionHeader transaction={transaction} />
-          <span className={classNames({ [`${CommonStyles['is-open']}`]: s.isOpen })}>{ ChevronDown }</span>
+          <span className={classNames({ [`${CommonStyles['is-open']}`]: s.isOpen })}>{ <ChevronDown /> }</span>
         </button>
         <div
           ref={(singleTransactionMeta) => { this.singleTransactionMeta = singleTransactionMeta }}

--- a/src/modules/portfolio/containers/transaction-meta.js
+++ b/src/modules/portfolio/containers/transaction-meta.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 import TransactionMeta from 'modules/portfolio/components/transaction-meta/transaction-meta'
 
 const mapStateToProps = state => ({
-  networkId: state.env['network-id'],
+  networkId: state.connection.augurNodeNetworkId,
 })
 
 const Transactions = connect(mapStateToProps)(TransactionMeta)

--- a/yarn.lock
+++ b/yarn.lock
@@ -510,9 +510,9 @@ augur-core@0.12.3:
     path "0.12.7"
     recursive-readdir "2.2.1"
 
-augur.js@4.9.2-0:
-  version "4.9.2-0"
-  resolved "https://registry.yarnpkg.com/augur.js/-/augur.js-4.9.2-0.tgz#217b55c8a0ecfafde52a812be0457017b3d74aa9"
+augur.js@4.9.2-1:
+  version "4.9.2-1"
+  resolved "https://registry.yarnpkg.com/augur.js/-/augur.js-4.9.2-1.tgz#2e33313231883d0f80eda536f9ebcb5f901007c6"
   dependencies:
     async "1.5.2"
     augur-core "0.12.3"


### PR DESCRIPTION
fixed warnings around not passing a function to a react child. fixed `networkId` prop type warning for transaction meta

[Clubhouse Story](https://app.clubhouse.io/augur/story/7388/warning-functions-are-not-valid-as-a-react-child)

Login to the main default account after spinning up a local dev env with docker and all that jazz. Go to portfolio -> transactions. you should see no more console warnings, where as previously (and in seadragon) you see 3.

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
- [ ] Post merge, story marked complete 
