### PR TITLE
8174-shares-always-0

### DIFF
--- a/src/modules/transactions/actions/add-transactions.js
+++ b/src/modules/transactions/actions/add-transactions.js
@@ -87,7 +87,7 @@ function buildTradeTransaction(trade, marketsData) {
   if (transaction.market) {
     header.description = transaction.market.description
   }
-  transaction.message = `${transaction.type} ${transaction.amount} Shares @ ${transaction.price} ETH`
+  transaction.message = `${transaction.type} ${transaction.fullPrecisionAmount} Shares @ ${transaction.fullPrecisionPrice} ETH`
   header.transactions = [transaction]
   return header
 }
@@ -204,7 +204,7 @@ export function addOpenOrderTransactions(openOrders) {
               marketId, type, outcomeId, ...value4,
             }
             transaction.id = transaction.transactionHash + transaction.logIndex
-            transaction.message = `${transaction.orderState} - ${type} ${transaction.amount} Shares @ ${transaction.price} ETH`
+            transaction.message = `${transaction.orderState} - ${type} ${transaction.fullPrecisionAmount} Shares @ ${transaction.fullPrecisionPrice} ETH`
             const meta = {}
             creationTime = convertUnixToFormattedDate(transaction.creationTime)
             meta.txhash = transaction.transactionHash

--- a/yarn.lock
+++ b/yarn.lock
@@ -510,9 +510,9 @@ augur-core@0.12.3:
     path "0.12.7"
     recursive-readdir "2.2.1"
 
-augur.js@4.9.2-0:
-  version "4.9.2-0"
-  resolved "https://registry.yarnpkg.com/augur.js/-/augur.js-4.9.2-0.tgz#217b55c8a0ecfafde52a812be0457017b3d74aa9"
+augur.js@4.9.2-1:
+  version "4.9.2-1"
+  resolved "https://registry.yarnpkg.com/augur.js/-/augur.js-4.9.2-1.tgz#2e33313231883d0f80eda536f9ebcb5f901007c6"
   dependencies:
     async "1.5.2"
     augur-core "0.12.3"


### PR DESCRIPTION
fixed an issue where shares that were less than 2 decimal places would show up as 0 in the linked transaction message header, despite correcty displaying the amount in the call out when you click a transaction.

[Clubhouse Story](https://app.clubhouse.io/augur/story/8174/number-of-share-is-always-listed-as-0-in-linked-transactions)

to reproduce, Login with the default account after firing up a local dev environment with the popped node. 

Login > Portfolio > Transactions

click on any of the `N linked transactions` links and note that the shares values aren't 0.

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
- [ ] Post merge, story marked complete 
