### PR TITLE
Use Replace BigNumber constructor check with BigNumber.isBigNumber

### DIFF
--- a/src/modules/market/components/market-outcome-charts--header-depth/market-outcome-charts--header-depth.jsx
+++ b/src/modules/market/components/market-outcome-charts--header-depth/market-outcome-charts--header-depth.jsx
@@ -17,7 +17,7 @@ const MarketOutcomeDepthHeader = p => (
           {p.hoveredDepth[3] === ASKS ? 'ask' : 'bid'} price
         </span>
         <span className={Styles['MarketOutcomeChartsHeader__stat-value']}>
-          {p.hoveredDepth[1] && p.hoveredDepth[1].constructor === BigNumber ? p.hoveredDepth[1].toFixed(p.fixedPrecision).toString() : <span>&mdash;</span>}
+          {BigNumber.isBigNumber(p.hoveredDepth[1]) ? p.hoveredDepth[1].toFixed(p.fixedPrecision).toString() : <span>&mdash;</span>}
         </span>
       </span>
       <span className={Styles.MarketOutcomeChartsHeader__stat}>
@@ -25,7 +25,7 @@ const MarketOutcomeDepthHeader = p => (
           qty
         </span>
         <span className={Styles[`MarketOutcomeChartsHeader__stat-value`]}>
-          {p.hoveredDepth[2] && p.hoveredDepth[2].constructor === BigNumber ? p.hoveredDepth[2].toFixed(p.fixedPrecision).toString() : <span>&mdash;</span>}
+          {BigNumber.isBigNumber(p.hoveredDepth[2]) ? p.hoveredDepth[2].toFixed(p.fixedPrecision).toString() : <span>&mdash;</span>}
         </span>
       </span>
       <span className={Styles.MarketOutcomeChartsHeader__stat}>
@@ -33,7 +33,7 @@ const MarketOutcomeDepthHeader = p => (
           depth
         </span>
         <span className={Styles[`MarketOutcomeChartsHeader__stat-value`]}>
-          {p.hoveredDepth[0] && p.hoveredDepth[0].constructor === BigNumber ? p.hoveredDepth[0].toFixed(p.fixedPrecision).toString() : <span>&mdash;</span>}
+          {BigNumber.isBigNumber(p.hoveredDepth[0]) ? p.hoveredDepth[0].toFixed(p.fixedPrecision).toString() : <span>&mdash;</span>}
         </span>
       </span>
     </div>


### PR DESCRIPTION
@pgebheim Is there any practical different between `p.hoveredDepth[1].constructor === BigNumber` and BigNumber.isBigNumber(p.hoveredDepth[1])? If not, please merge this in.