### PR TITLE
markets not loading because state variable set, use new load markets …

### DIFF
--- a/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets.jsx
+++ b/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets.jsx
@@ -22,7 +22,6 @@ export default class ReportingDisputeMarkets extends Component {
     isMobile: PropTypes.bool,
     navigateToAccountDepositHandler: PropTypes.func.isRequired,
     isConnected: PropTypes.bool.isRequired,
-    isMarketsLoaded: PropTypes.bool.isRequired,
     loadMarkets: PropTypes.func.isRequired,
     outcomes: PropTypes.object.isRequired,
     account: PropTypes.string.isRequired,
@@ -34,10 +33,9 @@ export default class ReportingDisputeMarkets extends Component {
   componentWillMount() {
     const {
       isConnected,
-      isMarketsLoaded,
       loadMarkets,
     } = this.props
-    if (isConnected && !isMarketsLoaded) {
+    if (isConnected) {
       loadMarkets()
     }
   }

--- a/src/modules/reporting/containers/reporting-dispute-markets.js
+++ b/src/modules/reporting/containers/reporting-dispute-markets.js
@@ -8,7 +8,7 @@ import { selectLoginAccount } from 'src/modules/auth/selectors/login-account'
 import disputeMarkets from 'modules/reporting/selectors/select-dispute-markets'
 import awaitingDisputeMarkets from 'modules/reporting/selectors/select-awaiting-dispute-markets'
 import loadMarkets from 'modules/markets/actions/load-markets'
-import { loadMarketsInfo } from 'modules/markets/actions/load-markets-info'
+import { loadMarketsInfoIfNotLoaded } from 'modules/markets/actions/load-markets-info-if-not-loaded'
 import { loadMarketsDisputeInfo } from 'modules/markets/actions/load-markets-dispute-info'
 import marketDisputeOutcomes from 'modules/reporting/selectors/select-market-dispute-outcomes'
 import logError from 'utils/log-error'
@@ -23,7 +23,6 @@ const mapStateToProps = (state, { history }) => {
   return ({
     isLogged: state.isLogged,
     isConnected: state.connection.isConnected && state.universe.id != null,
-    isMarketsLoaded: state.hasLoadedMarkets,
     doesUserHaveRep: (loginAccount.rep.value > 0),
     markets: disputableMarkets,
     upcomingMarkets: upcomingDisputableMarkets,
@@ -42,8 +41,10 @@ const mapStateToProps = (state, { history }) => {
 const mapDispatchToProps = dispatch => ({
   loadMarkets: () => dispatch(loadMarkets((err, marketIds) => {
     if (err) return logError(err)
-    dispatch(loadMarketsInfo(marketIds))
-    dispatch(loadMarketsDisputeInfo(marketIds))
+    dispatch(loadMarketsInfoIfNotLoaded(marketIds, (err, data) => {
+      if (err) return logError(err)
+      dispatch(loadMarketsDisputeInfo(marketIds))
+    }))
   })),
 })
 


### PR DESCRIPTION
noticed issue where dispute market outcomes weren't loaded. using new loadMarketsInfoIfNotLoaded.

repro:

push markets to dispute and verify that outcomes show up in reporting dispute markets view

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
- [ ] Post merge, story marked complete 
