### PR TITLE
Add Error Messages to Connect to Augur Modal [ch5394]

### DIFF
--- a/src/modules/app/actions/init-augur.js
+++ b/src/modules/app/actions/init-augur.js
@@ -16,7 +16,7 @@ import networkConfig from 'config/network'
 
 import { isEmpty } from 'lodash'
 
-import { MODAL_NETWORK_MISMATCH, MODAL_ESCAPE_HATCH } from 'modules/modal/constants/modal-types'
+import { MODAL_NETWORK_MISMATCH, MODAL_ESCAPE_HATCH, MODAL_NETWORK_DISCONNECTED } from 'modules/modal/constants/modal-types'
 
 const ACCOUNTS_POLL_INTERVAL_DURATION = 3000
 const NETWORK_ID_POLL_INTERVAL_DURATION = 3000
@@ -98,6 +98,7 @@ function pollForEscapeHatch(dispatch, getState) {
 
 export function connectAugur(history, env, isInitialConnection = false, callback = logError) {
   return (dispatch, getState) => {
+    const { modal } = getState()
     AugurJS.connect(env, (err, ConnectionInfo) => {
       if (err || !ConnectionInfo.augurNode || !ConnectionInfo.ethereumNode) {
         return callback(err, ConnectionInfo)
@@ -110,7 +111,7 @@ export function connectAugur(history, env, isInitialConnection = false, callback
       dispatch(updateAugurNodeConnectionStatus(true))
       dispatch(registerTransactionRelay())
       dispatch(loadUniverse(env.universe || AugurJS.augur.contracts.addresses[AugurJS.augur.rpc.getNetworkID()].Universe, history))
-      dispatch(closeModal())
+      if (modal && modal.type === MODAL_NETWORK_DISCONNECTED) dispatch(closeModal())
       if (isInitialConnection) {
         pollForAccount(dispatch, getState)
         pollForNetwork(dispatch, getState)

--- a/src/modules/auth/helpers/is-augurjs-versions-equal.js
+++ b/src/modules/auth/helpers/is-augurjs-versions-equal.js
@@ -1,0 +1,20 @@
+import { augur } from 'services/augurjs'
+
+export default function isAugurJSVersionsEqual() {
+  return new Promise((resolve) => {
+    augur.augurNode.getContractAddresses((err, res) => {
+      if (err || (res.version !== augur.version)) {
+        resolve({
+          isEqual: false,
+          augurNode: res && res.version,
+          augurjs: augur && augur.version,
+        })
+      }
+      resolve({
+        isEqual: true,
+        augurNode: res && res.version,
+        augurjs: augur && augur.version,
+      })
+    })
+  })
+}

--- a/src/modules/modal/containers/modal-network-connect.js
+++ b/src/modules/modal/containers/modal-network-connect.js
@@ -6,6 +6,7 @@ import ModalNetworkConnect from 'modules/modal/components/modal-network-connect/
 import { closeModal } from 'modules/modal/actions/close-modal'
 import { updateEnv } from 'modules/app/actions/update-env'
 import { connectAugur } from 'modules/app/actions/init-augur'
+import isAugurJSVersionsEqual from 'modules/auth/helpers/is-augurjs-versions-equal'
 
 const mapStateToProps = state => ({
   modal: state.modal,
@@ -17,6 +18,7 @@ const mapDispatchToProps = dispatch => ({
   submitForm: e => e.preventDefault(),
   updateEnv: env => dispatch(updateEnv(env)),
   closeModal: () => dispatch(closeModal()),
+  isAugurJSVersionsEqual,
   connectAugur: (history, env, isInitialConnection, cb) => dispatch(connectAugur(history, env, isInitialConnection, cb)),
 })
 // to make sure we override the generic submitForm with the passed submitForm from a disconnection Modal we need to merge props...

--- a/test/auth/helpers/is-augurjs-versions-equal-test.js
+++ b/test/auth/helpers/is-augurjs-versions-equal-test.js
@@ -1,0 +1,73 @@
+import isAugurJSVersionsEqual, { __RewireAPI__ as isAugurJSVersionsEqualAPI } from 'modules/auth/helpers/is-augurjs-versions-equal'
+
+describe('modules/auth/helpers/is-augurjs-versions-equal', () => {
+  const test = t => it(t.description, async () => t.assertions())
+
+  afterEach(() => {
+    isAugurJSVersionsEqualAPI.__ResetDependency__('augur')
+  })
+
+  test({
+    description: `Should handle an error from augurNode.getContractAddresses, and return false`,
+    assertions: () => {
+      isAugurJSVersionsEqualAPI.__Rewire__('augur', {
+        version: 'helloWorld',
+        augurNode: {
+          getContractAddresses: (cb) => {
+            cb({ error: 1000, message: 'Uh-Oh!' })
+          },
+        },
+      })
+
+      isAugurJSVersionsEqual().then((res) => {
+        assert.isObject(res)
+        assert.isFalse(res.isEqual)
+        assert.isUndefined(res.augurNode)
+        assert.deepEqual(res.augurjs, 'helloWorld')
+      })
+    },
+  })
+
+  test({
+    description: `Should handle a versionMismatch and return false`,
+    assertions: () => {
+      isAugurJSVersionsEqualAPI.__Rewire__('augur', {
+        version: 'helloWorld',
+        augurNode: {
+          getContractAddresses: (cb) => {
+            cb(undefined, { version: 'goodbyeWorld' })
+          },
+        },
+      })
+
+      isAugurJSVersionsEqual().then((res) => {
+        assert.isObject(res)
+        assert.isFalse(res.isEqual)
+        assert.deepEqual(res.augurNode, 'goodbyeWorld')
+        assert.deepEqual(res.augurjs, 'helloWorld')
+      })
+    },
+  })
+
+  test({
+    description: `Should handle a matching version and return true`,
+    assertions: () => {
+      isAugurJSVersionsEqualAPI.__Rewire__('augur', {
+        version: 'helloWorld',
+        augurNode: {
+          getContractAddresses: (cb) => {
+            cb(undefined, { version: 'helloWorld' })
+          },
+        },
+      })
+      isAugurJSVersionsEqual().then((res) => {
+        assert.isObject(res)
+        assert.isTrue(res.isEqual)
+        assert.deepEqual(res.augurNode, 'helloWorld')
+        assert.deepEqual(res.augurjs, 'helloWorld')
+      })
+
+
+    },
+  })
+})

--- a/test/auth/helpers/is-augurjs-versions-equal-test.js
+++ b/test/auth/helpers/is-augurjs-versions-equal-test.js
@@ -19,7 +19,7 @@ describe('modules/auth/helpers/is-augurjs-versions-equal', () => {
         },
       })
 
-      isAugurJSVersionsEqual().then((res) => {
+      return isAugurJSVersionsEqual().then((res) => {
         assert.isObject(res)
         assert.isFalse(res.isEqual)
         assert.isUndefined(res.augurNode)
@@ -40,7 +40,7 @@ describe('modules/auth/helpers/is-augurjs-versions-equal', () => {
         },
       })
 
-      isAugurJSVersionsEqual().then((res) => {
+      return isAugurJSVersionsEqual().then((res) => {
         assert.isObject(res)
         assert.isFalse(res.isEqual)
         assert.deepEqual(res.augurNode, 'goodbyeWorld')
@@ -60,14 +60,12 @@ describe('modules/auth/helpers/is-augurjs-versions-equal', () => {
           },
         },
       })
-      isAugurJSVersionsEqual().then((res) => {
+      return isAugurJSVersionsEqual().then((res) => {
         assert.isObject(res)
         assert.isTrue(res.isEqual)
         assert.deepEqual(res.augurNode, 'helloWorld')
         assert.deepEqual(res.augurjs, 'helloWorld')
       })
-
-
     },
   })
 })


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/5394/add-error-messages-to-connect-to-augur-modal)

to reproduce, spin up a local dev env

1. Turn off the augur node.

2. Load the UI and you should be prompted to choose an augurnode to connect to.

3. Start your augur node and wait for it to spin up and catch up.

4. hit `connect`

this should connect you and close the modal.

modify line 6 of `src/modules/auth/helpers/is-augurjs-versions-equal.js` from:
`if (err || (res.version !== augur.version)) {`
to 
`if (err || (res.version !== 'pineapple')) {`

5. navigate away from the UI

6. repeat steps 1 - 4

7. You should now see an error below your augurnode address stating that AugurJS version doesn't match AugurNode...the version will be the same, since in reality they are and we forced a failure.

Revert the changes made to `src/modules/auth/helpers/is-augurjs-versions-equal.js`

Repeat step 5, then 2

you should now be on the UI which was automatically connected immediately to your augur node and local geth node.

Repeat step 1

you should now see the reconnection modal.

Repeat step 3

Your UI should automatically reconnect and close the modal.

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
