### PR TITLE
correct way to parse endTime using the timestamp and not market date …

### DIFF
--- a/src/modules/market/components/market-properties/market-properties.jsx
+++ b/src/modules/market/components/market-properties/market-properties.jsx
@@ -36,7 +36,7 @@ const MarketProperties = (p) => {
           </li>
           <li>
             <span>{p.endTime && dateHasPassed(p.currentTimestamp, p.endTime.timestamp) ? 'Expired' : 'Expires'}</span>
-            <span>{ p.isMobile ? p.endTime.formattedShort : p.endTime.formatted }</span>
+            <span>{ p.isMobile ? p.endTime.formattedLocalShort : p.endTime.formattedLocal }</span>
           </li>
           {p.outstandingReturns &&
           <li>

--- a/src/modules/market/selectors/market.js
+++ b/src/modules/market/selectors/market.js
@@ -23,7 +23,7 @@ This is true for all selectors, but especially important for this one.
 import { createBigNumber } from 'utils/create-big-number'
 import memoize from 'memoizee'
 import { formatShares, formatEther, formatPercent, formatNumber } from 'utils/format-number'
-import { formatDate, convertUnixToFormattedDate } from 'utils/format-date'
+import { convertUnixToFormattedDate } from 'utils/format-date'
 import { selectCurrentTimestamp, selectCurrentTimestampInSeconds } from 'src/select-state'
 import { isMarketDataOpen, isMarketDataExpired } from 'utils/is-market-data-open'
 
@@ -202,9 +202,9 @@ export function assembleMarket(
 
       market.loadingState = marketLoading !== null ? marketLoading.state : marketLoading
 
-      market.endTime = (endTimeYear >= 0 && endTimeMonth >= 0 && endTimeDay >= 0 && formatDate(new Date(endTimeYear, endTimeMonth, endTimeDay))) || null
+      market.endTime = convertUnixToFormattedDate(marketData.endTime)
       market.endTimeLabel = (market.endTime < now) ? 'ended' : 'ends'
-      market.creationTime = formatDate(new Date(marketData.creationTime * 1000))
+      market.creationTime = convertUnixToFormattedDate(marketData.creationTime)
 
       market.isOpen = isOpen
       // market.isExpired = isExpired;

--- a/test/utils/format-date-test.js
+++ b/test/utils/format-date-test.js
@@ -1,6 +1,6 @@
 
 
-import { dateHasPassed, formatDate, getDaysRemaining } from 'utils/format-date'
+import { dateHasPassed, formatDate, getDaysRemaining, convertUnixToFormattedDate } from 'utils/format-date'
 
 describe('utils/format-date', () => {
   const test = t => it(t.description, () => t.assertions())
@@ -90,9 +90,22 @@ describe('utils/format-date', () => {
   test({
     description: `current time after end time return 0`,
     assertions: () => {
-      const actual = getDaysRemaining(1520300344)
+      const actual = getDaysRemaining(1520300344, 1520300300)
 
       assert.strictEqual(actual, 0, `didn't return 0 as expected`)
     },
   })
+
+  test({
+    description: `given timestamp does format correct`,
+    assertions: () => {
+      const timestamp = 1520300344
+      const dateTime = 'March 6, 2018 1:39 AM'
+      const actual = convertUnixToFormattedDate(1520300344)
+
+      assert.strictEqual(actual.formatted, dateTime, `didn't get correct format`)
+      assert.strictEqual(actual.timestamp, timestamp, `didn't get correct timestamp`)
+    },
+  })
+
 })


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/8398)

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
