### PR TITLE
johndanz/ch8870/timestamp-issues-with-reporting-view

### DIFF
--- a/src/modules/market/components/market-basics/market-basics.jsx
+++ b/src/modules/market/components/market-basics/market-basics.jsx
@@ -29,7 +29,7 @@ const MarketBasics = (p) => {
 
     ReportEndingIndicator = () => (
       <div className={Styles.MarketBasics__reportingends}>
-        <div>Reporting Ends {displayDate.formattedShort}</div>
+        <div>{p.isMobile ? `In Reporting` : `Reporting Ends ${displayDate.formattedLocalShortTime}`}</div>
         <WrappedGraph startDate={p.endTime.value} endTime={endTime} currentTimestamp={p.currentTimestamp} />
       </div>
     )

--- a/src/modules/market/components/market-properties/market-properties.jsx
+++ b/src/modules/market/components/market-properties/market-properties.jsx
@@ -36,7 +36,7 @@ const MarketProperties = (p) => {
           </li>
           <li>
             <span>{p.endTime && dateHasPassed(p.currentTimestamp, p.endTime.timestamp) ? 'Expired' : 'Expires'}</span>
-            <span>{ p.isMobile ? p.endTime.formattedLocalShort : p.endTime.formattedLocal }</span>
+            <span>{ p.isMobile ? p.endTime.formattedLocalShort : p.endTime.formattedLocalShortTime }</span>
           </li>
           {p.outstandingReturns &&
           <li>

--- a/src/modules/market/containers/market-basics.js
+++ b/src/modules/market/containers/market-basics.js
@@ -4,7 +4,10 @@ import MarketBasics from 'modules/market/components/market-basics/market-basics'
 
 import { selectCurrentTimestamp } from 'src/select-state'
 
-const mapStateToProps = state => ({ currentTimestamp: selectCurrentTimestamp(state) })
+const mapStateToProps = state => ({
+  currentTimestamp: selectCurrentTimestamp(state),
+  isMobile: state.isMobile,
+})
 
 const MarketBasicsContainer = connect(mapStateToProps)(MarketBasics)
 

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -36,7 +36,8 @@ export function formatDate(d) {
     formatted: `${months[date.getUTCMonth()]} ${date.getUTCDate()}, ${date.getUTCFullYear()} ${utcTimeTwelve.join(':')} ${utcAMPM}`, // UTC time
     formattedShort: `${shortMonths[date.getUTCMonth()]} ${date.getUTCDate()}, ${date.getUTCFullYear()} ${utcTimeTwelve.join(':')} ${utcAMPM}`, // UTC time
     formattedLocal: `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} ${localTimeTwelve.join(':')} ${localAMPM} (UTC ${localOffset})`, // local time
-    formattedLocalShort: `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} (UTC ${localOffset})`, // local time
+    formattedLocalShort: `${shortMonths[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} (UTC ${localOffset})`, // local time
+    formattedLocalShortTime: `${shortMonths[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} ${localTimeTwelve.join(':')} ${localAMPM} (UTC ${localOffset})`, // local time
     full: date.toUTCString(),
     timestamp: date.getTime() / 1000,
     utcLocalOffset: localOffset,


### PR DESCRIPTION
made some modifications to market basics, and market properties to shorten the timestamp text, mainly by removing the full month name in favor of a shorter name. aka January => Jan. Also removed the visible date/time in mobile in favor of just `In Reporting` with the pie graph. this saves space in the mobile view while still giving an idea of what the timing is for the market.

[Clubhouse Story](https://app.clubhouse.io/augur/story/8870/timestamp-issues-with-reporting-view)

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
