### PR TITLE
johndanz/ch8888/fix-market-migrate-modal

### DIFF
--- a/src/modules/modal/components/modal-migrate-market/modal-migrate-market.jsx
+++ b/src/modules/modal/components/modal-migrate-market/modal-migrate-market.jsx
@@ -11,7 +11,6 @@ export default class ModalMigrateMarket extends Component {
     marketId: PropTypes.string.isRequired,
     marketDescription: PropTypes.string.isRequired,
     migrateMarketThroughFork: PropTypes.func.isRequired,
-    modal: PropTypes.string,
     closeModal: PropTypes.func.isRequired,
   }
 
@@ -50,7 +49,6 @@ export default class ModalMigrateMarket extends Component {
     const {
       closeModal,
       marketDescription,
-      modal,
     } = this.props
     const s = this.state
 
@@ -59,7 +57,9 @@ export default class ModalMigrateMarket extends Component {
         className={Styles.ModalMigrateMarket__form}
         onSubmit={this.submitForm}
       >
-        <h1 className={Styles.ModalMigrateMarket__heading}>{SigningPen} Migrate Market</h1>
+        <h1 className={Styles.ModalMigrateMarket__heading}>
+          {SigningPen} Migrate Market
+        </h1>
         <div className={Styles.ModalMigrateMarket__details}>
           <ul className={Styles.ModalMigrateMarket__labels}>
             <li>market</li>
@@ -76,7 +76,7 @@ export default class ModalMigrateMarket extends Component {
             type="button"
             onClick={closeModal}
           >
-            Back {modal}
+            Back
           </button>
           <button
             className={Styles.ModalMigrateMarket__button}

--- a/src/modules/modal/components/modal-migrate-market/modal-migrate-market.styles.less
+++ b/src/modules/modal/components/modal-migrate-market/modal-migrate-market.styles.less
@@ -2,7 +2,8 @@
 
 .ModalMigrateMarket__form {
   color: @color-white;
-  width: 50%;
+  max-width: 35rem;
+  width: 100%;
 }
 
 .ModalMigrateMarket__heading {


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/8888/fix-market-migrate-modal)

To reproduce, it's probably easiest to add a hook to main.jsx to pop the modal. This is done by adding the following lines to main.jsx:

```
import { updateModal } from 'modules/modal/actions/update-modal'
```
That impot should go below the import for `{ augur }`.

Then add this line below the line `window.augur = augur`:
```
window.test = () => store.dispatch(updateModal({
    type: 'MODAL_MIGRATE_MARKET',
    marketId: '0xdeadbeef',
    marketDescription: 'This is a test market!',
    canClose: true,
  }))
```

fire up the UI and open the console, type in `window.test()` and you should see the modal. 

Previously this modal wouldn't render because of broken JSX. I've also fixed the width of the modal to match all the others (100% width but with a max width of 35-rems, instead of just 50% width)

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
