### PR TITLE
Have to turn off animation in order to turn it on.

### DIFF
--- a/src/modules/app/components/loading-logo/loading-logo.jsx
+++ b/src/modules/app/components/loading-logo/loading-logo.jsx
@@ -14,7 +14,7 @@ export default class LoadingLogo extends Component {
     super(props)
 
     this.state = {
-      loading: true,
+      loading: false,
     }
   }
 
@@ -28,7 +28,7 @@ export default class LoadingLogo extends Component {
 
   animateEnd() {
     this.setState({
-      loading: this.props.isLoading,
+      loading: false,
     })
   }
 

--- a/src/modules/markets/actions/load-markets-by-category.js
+++ b/src/modules/markets/actions/load-markets-by-category.js
@@ -1,6 +1,6 @@
 import { augur } from 'services/augurjs'
 import { updateHasLoadedCategory } from 'modules/categories/actions/update-has-loaded-category'
-import { loadMarketsInfo } from 'modules/markets/actions/load-markets-info'
+import { loadMarketsInfoIfNotLoaded } from 'modules/markets/actions/load-markets-info-if-not-loaded'
 import { updateMarketsFilteredSorted, clearMarketsFilteredSorted } from 'modules/markets/actions/update-markets-filtered-sorted'
 
 export const loadMarketsByCategory = category => (dispatch, getState) => {
@@ -23,7 +23,7 @@ export const loadMarketsByCategory = category => (dispatch, getState) => {
       dispatch(updateHasLoadedCategory({ [category]: true }))
       dispatch(clearMarketsFilteredSorted())
       dispatch(updateMarketsFilteredSorted(marketIds))
-      dispatch(loadMarketsInfo(marketIds))
+      dispatch(loadMarketsInfoIfNotLoaded(marketIds))
     }
   })
 }

--- a/src/modules/markets/actions/load-markets-info-if-not-loaded.js
+++ b/src/modules/markets/actions/load-markets-info-if-not-loaded.js
@@ -5,7 +5,7 @@ import logError from 'utils/log-error'
 export const loadMarketsInfoIfNotLoaded = (marketIds, callback = logError) => (dispatch, getState) => {
   const { marketsData } = getState()
   const marketIdsToLoad = marketIds.filter(marketId => !isMarketLoaded(marketId, marketsData))
-  console.log('marketIdsToLoad:', marketIdsToLoad)
+
   if (marketIdsToLoad.length === 0) return callback(null)
   dispatch(loadMarketsInfo(marketIdsToLoad, callback))
 }

--- a/src/modules/markets/components/markets-list.jsx
+++ b/src/modules/markets/components/markets-list.jsx
@@ -17,7 +17,7 @@ export default class MarketsList extends Component {
     filteredMarkets: PropTypes.array.isRequired,
     location: PropTypes.object.isRequired,
     toggleFavorite: PropTypes.func.isRequired,
-    loadMarketsInfo: PropTypes.func.isRequired,
+    loadMarketsInfoIfNotLoaded: PropTypes.func.isRequired,
     paginationPageParam: PropTypes.string,
     linkType: PropTypes.string,
     showPagination: PropTypes.bool,
@@ -42,12 +42,12 @@ export default class MarketsList extends Component {
 
     this.setSegment = this.setSegment.bind(this)
     this.setMarketIDsMissingInfo = this.setMarketIDsMissingInfo.bind(this)
-    this.loadMarketsInfo = debounce(this.loadMarketsInfo.bind(this))
+    this.loadMarketsInfoIfNotLoaded = debounce(this.loadMarketsInfoIfNotLoaded.bind(this))
   }
 
   componentWillMount() {
     const { filteredMarkets } = this.props
-    this.loadMarketsInfo(filteredMarkets)
+    this.loadMarketsInfoIfNotLoaded(filteredMarkets)
   }
 
   componentWillUpdate(nextProps, nextState) {
@@ -60,7 +60,7 @@ export default class MarketsList extends Component {
       this.setMarketIDsMissingInfo(nextProps.markets, nextProps.filteredMarkets, nextState.lowerBound, nextState.boundedLength)
     }
 
-    if (!isEqual(this.state.marketIdsMissingInfo, nextState.marketIdsMissingInfo)) this.loadMarketsInfo(nextState.marketIdsMissingInfo)
+    if (!isEqual(this.state.marketIdsMissingInfo, nextState.marketIdsMissingInfo)) this.loadMarketsInfoIfNotLoaded(nextState.marketIdsMissingInfo)
   }
 
   setSegment(lowerBound, upperBound, boundedLength) {
@@ -81,9 +81,9 @@ export default class MarketsList extends Component {
   }
 
   // debounced call
-  loadMarketsInfo() {
-    const { loadMarketsInfo } = this.props
-    loadMarketsInfo(this.state.marketIdsMissingInfo)
+  loadMarketsInfoIfNotLoaded() {
+    const { loadMarketsInfoIfNotLoaded } = this.props
+    loadMarketsInfoIfNotLoaded(this.state.marketIdsMissingInfo)
   }
 
   // NOTE -- You'll notice the odd method used for rendering the previews, this is done for optimization reasons

--- a/src/modules/markets/components/markets-view.jsx
+++ b/src/modules/markets/components/markets-view.jsx
@@ -34,7 +34,7 @@ export default class MarketsView extends Component {
     updateMarketsFilteredSorted: PropTypes.func.isRequired,
     clearMarketsFilteredSorted: PropTypes.func.isRequired,
     toggleFavorite: PropTypes.func.isRequired,
-    loadMarketsInfo: PropTypes.func.isRequired,
+    loadMarketsInfoIfNotLoaded: PropTypes.func.isRequired,
     isMobile: PropTypes.bool,
   }
 
@@ -107,7 +107,7 @@ export default class MarketsView extends Component {
       history,
       isLogged,
       isMobile,
-      loadMarketsInfo,
+      loadMarketsInfoIfNotLoaded,
       location,
       markets,
       toggleFavorite,
@@ -129,7 +129,7 @@ export default class MarketsView extends Component {
           location={location}
           history={history}
           toggleFavorite={toggleFavorite}
-          loadMarketsInfo={loadMarketsInfo}
+          loadMarketsInfoIfNotLoaded={loadMarketsInfoIfNotLoaded}
           linkType={TYPE_TRADE}
           isMobile={isMobile}
         />

--- a/src/modules/markets/container.js
+++ b/src/modules/markets/container.js
@@ -10,7 +10,7 @@ import { toggleFavorite } from 'modules/markets/actions/update-favorites'
 
 import loadMarkets from 'modules/markets/actions/load-markets'
 import { loadMarketsByCategory } from 'modules/markets/actions/load-markets-by-category'
-import { loadMarketsInfo } from 'modules/markets/actions/load-markets-info'
+import { loadMarketsInfoIfNotLoaded } from 'modules/markets/actions/load-markets-info-if-not-loaded'
 
 import getValue from 'utils/get-value'
 
@@ -32,7 +32,7 @@ const mapDispatchToProps = dispatch => ({
   updateMarketsFilteredSorted: filteredMarkets => dispatch(updateMarketsFilteredSorted(filteredMarkets)),
   clearMarketsFilteredSorted: () => dispatch(clearMarketsFilteredSorted()),
   toggleFavorite: marketId => dispatch(toggleFavorite(marketId)),
-  loadMarketsInfo: marketIds => dispatch(loadMarketsInfo(marketIds)),
+  loadMarketsInfoIfNotLoaded: marketIds => dispatch(loadMarketsInfoIfNotLoaded(marketIds)),
 })
 
 const Markets = withRouter(connect(mapStateToProps, mapDispatchToProps)(MarketsView))

--- a/test/markets/actions/load-markets-by-category-test.js
+++ b/test/markets/actions/load-markets-by-category-test.js
@@ -21,7 +21,7 @@ describe('modules/markets/actions/load-markets-by-category.js', () => {
 
       const mockLoadMarketsInfo = {}
 
-      mockLoadMarketsInfo.loadMarketsInfo = sinon.stub().returns(() => {})
+      mockLoadMarketsInfo.loadMarketsInfoIfNotLoaded = sinon.stub().returns(() => {})
 
       AugurJS.augur.markets.getMarkets = sinon.stub()
       if (t.toTest === 'err') AugurJS.augur.markets.getMarkets.yields('failed with err', null)
@@ -31,12 +31,12 @@ describe('modules/markets/actions/load-markets-by-category.js', () => {
 
       const action = proxyquire('../../../src/modules/markets/actions/load-markets-by-category', {
         '../../../services/augurjs': AugurJS,
-        './load-markets-info': mockLoadMarketsInfo,
+        './load-markets-info-if-not-loaded': mockLoadMarketsInfo,
       })
 
       store.dispatch(action.loadMarketsByCategory())
 
-      t.assertions(store.getActions(), mockLoadMarketsInfo.loadMarketsInfo)
+      t.assertions(store.getActions(), mockLoadMarketsInfo.loadMarketsInfoIfNotLoaded)
     })
   }
 
@@ -81,7 +81,7 @@ describe('modules/markets/actions/load-markets-by-category.js', () => {
   test({
     description: 'should dispatch the expected actions with no error + array of returned marketIds',
     toTest: 'array',
-    assertions: (actions, loadMarketsInfo) => {
+    assertions: (actions, loadMarketsInfoIfNotLoaded) => {
       const expected = [
         {
           type: 'UPDATE_HAS_LOADED_CATEGORY',
@@ -90,14 +90,14 @@ describe('modules/markets/actions/load-markets-by-category.js', () => {
       ]
 
       assert(actions, expected, 'returned array was not handled as expected')
-      assert.isTrue(loadMarketsInfo.calledOnce)
+      assert.isTrue(loadMarketsInfoIfNotLoaded.calledOnce)
     },
   })
 
   test({
     description: 'should dispatch the expected actions with no error + an empty array of marketIds',
     toTest: 'empty-array',
-    assertions: (actions, loadMarketsInfo) => {
+    assertions: (actions, loadMarketsInfoIfNotLoaded) => {
       const expected = [
         {
           type: 'UPDATE_HAS_LOADED_CATEGORY',
@@ -106,7 +106,7 @@ describe('modules/markets/actions/load-markets-by-category.js', () => {
       ]
 
       assert(actions, expected, 'empty array was not handled as expected')
-      assert.isFalse(loadMarketsInfo.called)
+      assert.isFalse(loadMarketsInfoIfNotLoaded.called)
     },
   })
 })


### PR DESCRIPTION
Animation would get stuck if isLoading stayed true, it would not restart, needed to have a cycle of turning off animation in order to start it.

Also noticed we are reloading markets many many many times when we have already loaded them.
Changed to use new method load market if not loaded.

[Clubhouse Story](https://app.clubhouse.io/augur/story/8969)

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
