### PR TITLE
johndanz/ch6420/integrate-p-l-data-in-core-stats-bar

### DIFF
--- a/src/modules/account/selectors/core-stats.js
+++ b/src/modules/account/selectors/core-stats.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect'
 import store from 'src/store'
 import { selectAccountTradesState, selectCurrentTimestamp, selectBlockchainState, selectOutcomesDataState } from 'src/select-state'
 import { augur } from 'services/augurjs'
-import { dateToBlock } from 'utils/date-to-block-to-date'
+// import { dateToBlock } from 'utils/date-to-block-to-date'
 import { formatEther } from 'utils/format-number'
 import { ZERO } from 'modules/trade/constants/numbers'
 import { selectLoginAccount } from 'modules/auth/selectors/login-account'
@@ -29,15 +29,18 @@ export const createPeriodPLSelector = period => createSelector(
     if (!accountTrades || !blockchain) return null
 
     const periodDate = new Date(currentTimestamp - (period*24*60*60*1000))
-    const periodBlock = dateToBlock(periodDate, blockchain.currentBlockNumber, currentTimestamp)
+    const periodTime = (periodDate.getTime() / 1000)
+    // const periodBlock = dateToBlock(periodDate, blockchain.currentBlockNumber, currentTimestamp)
 
     return Object.keys(accountTrades).reduce((p, marketId) => { // Iterate over marketIds
       if (!outcomesData[marketId]) return p
 
       const accumulatedPL = Object.keys(accountTrades[marketId]).reduce((p, outcomeId) => { // Iterate over outcomes
-        const periodTrades = accountTrades[marketId][outcomeId].filter(trade => trade.blockNumber > periodBlock) // Filter out trades older than 30 days
+
+        const periodTrades = accountTrades[marketId][outcomeId].filter(trade => trade.timestamp > periodTime) // Filter out trades older than periodTime
         const lastPrice = selectOutcomeLastPrice(outcomesData[marketId], outcomeId)
         const { realized, unrealized } = augur.trading.calculateProfitLoss({ trades: periodTrades, lastPrice })
+
         return p.plus(createBigNumber(realized, 10).plus(createBigNumber(unrealized, 10)))
       }, ZERO)
 

--- a/src/modules/account/selectors/core-stats.js
+++ b/src/modules/account/selectors/core-stats.js
@@ -3,7 +3,6 @@ import { createSelector } from 'reselect'
 import store from 'src/store'
 import { selectAccountTradesState, selectCurrentTimestamp, selectBlockchainState, selectOutcomesDataState } from 'src/select-state'
 import { augur } from 'services/augurjs'
-// import { dateToBlock } from 'utils/date-to-block-to-date'
 import { formatEther } from 'utils/format-number'
 import { ZERO } from 'modules/trade/constants/numbers'
 import { selectLoginAccount } from 'modules/auth/selectors/login-account'
@@ -30,7 +29,6 @@ export const createPeriodPLSelector = period => createSelector(
 
     const periodDate = new Date(currentTimestamp - (period*24*60*60*1000))
     const periodTime = (periodDate.getTime() / 1000)
-    // const periodBlock = dateToBlock(periodDate, blockchain.currentBlockNumber, currentTimestamp)
 
     return Object.keys(accountTrades).reduce((p, marketId) => { // Iterate over marketIds
       if (!outcomesData[marketId]) return p

--- a/src/modules/app/components/top-bar/top-bar.jsx
+++ b/src/modules/app/components/top-bar/top-bar.jsx
@@ -34,7 +34,7 @@ const TopBar = props => (
               <span>{props.stats[1].totalPLMonth.label}</span>
             </div>
             <span className={Styles['TopBar__stat-value']}>
-              {props.stats[1].totalPLMonth.value.formatted}
+              {props.stats[1].totalPLMonth.value.formatted} ETH
             </span>
           </div>
           <div className={Styles.TopBar__stat}>
@@ -44,7 +44,7 @@ const TopBar = props => (
               <span>{props.stats[1].totalPLDay.label}</span>
             </div>
             <span className={Styles['TopBar__stat-value']}>
-              {props.stats[1].totalPLDay.value.formatted}
+              {props.stats[1].totalPLDay.value.formatted} ETH
             </span>
           </div>
         </div>

--- a/src/modules/portfolio/components/favorites/favorites.jsx
+++ b/src/modules/portfolio/components/favorites/favorites.jsx
@@ -29,6 +29,7 @@ const Favorites = p => (
       history={p.history}
       toggleFavorite={p.toggleFavorite}
       loadMarketsInfo={p.loadMarketsInfo}
+      loadMarketsInfoIfNotLoaded={p.loadMarketsInfoIfNotLoaded}
       linkType={TYPE_TRADE}
       isMobile={p.isMobile}
     />
@@ -45,6 +46,7 @@ Favorites.propTypes = {
   match: PropTypes.object.isRequired,
   toggleFavorite: PropTypes.func.isRequired,
   loadMarketsInfo: PropTypes.func.isRequired,
+  loadMarketsInfoIfNotLoaded: PropTypes.func.isRequired,
   isMobile: PropTypes.bool,
 }
 

--- a/src/modules/portfolio/components/markets/markets.jsx
+++ b/src/modules/portfolio/components/markets/markets.jsx
@@ -11,11 +11,11 @@ import PortfolioStyles from 'modules/portfolio/components/portfolio-view/portfol
 import { TYPE_TRADE, TYPE_REPORT, TYPE_CLOSED } from 'modules/market/constants/link-types'
 import { constants } from 'services/augurjs'
 import { CREATE_MARKET } from 'modules/routes/constants/views'
-import { BigNumber } from 'utils/create-big-number'
 
 class MyMarkets extends Component {
   static propTypes = {
-    collectMarketCreatorFees: PropTypes.instanceOf(BigNumber).isRequired,
+    collectMarketCreatorFees: PropTypes.func.isRequired,
+    loadMarketsInfoIfNotLoaded: PropTypes.func.isRequired,
     hasAllTransactionsLoaded: PropTypes.bool.isRequired,
     history: PropTypes.object.isRequired,
     isLogged: PropTypes.bool.isRequired,
@@ -107,6 +107,7 @@ class MyMarkets extends Component {
   render() {
     const {
       collectMarketCreatorFees,
+      loadMarketsInfoIfNotLoaded,
       history,
       isLogged,
       isMobile,
@@ -143,6 +144,7 @@ class MyMarkets extends Component {
             outstandingReturns
             paginationPageParam="open"
             collectMarketCreatorFees={collectMarketCreatorFees}
+            loadMarketsInfoIfNotLoaded={loadMarketsInfoIfNotLoaded}
             isMobile={isMobile}
           />
         }
@@ -171,6 +173,7 @@ class MyMarkets extends Component {
             outstandingReturns
             paginationPageParam="reporting"
             collectMarketCreatorFees={collectMarketCreatorFees}
+            loadMarketsInfoIfNotLoaded={loadMarketsInfoIfNotLoaded}
             isMobile={isMobile}
           />
         }
@@ -199,6 +202,7 @@ class MyMarkets extends Component {
             outstandingReturns
             paginationPageParam="final"
             collectMarketCreatorFees={collectMarketCreatorFees}
+            loadMarketsInfoIfNotLoaded={loadMarketsInfoIfNotLoaded}
             isMobile={isMobile}
           />
         }

--- a/src/modules/portfolio/containers/favorites.js
+++ b/src/modules/portfolio/containers/favorites.js
@@ -5,6 +5,7 @@ import Favorites from 'modules/portfolio/components/favorites/favorites'
 import { toggleFavorite } from 'modules/markets/actions/update-favorites'
 import { loadMarketsInfo } from 'modules/markets/actions/load-markets-info'
 import selectAllMarkets from 'modules/markets/selectors/markets-all'
+import { loadMarketsInfoIfNotLoaded } from 'modules/markets/actions/load-markets-info-if-not-loaded'
 
 const mapStateToProps = (state) => {
   // basically just create the filtered markets based on what IDs we find in the favorites object
@@ -31,6 +32,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = dispatch => ({
   loadMarketsInfo: marketIds => dispatch(loadMarketsInfo(marketIds)),
   toggleFavorite: marketId => dispatch(toggleFavorite(marketId)),
+  loadMarketsInfoIfNotLoaded: marketIds => dispatch(loadMarketsInfoIfNotLoaded(marketIds)),
 })
 
 const FavoritesContainer = withRouter(connect(mapStateToProps, mapDispatchToProps)(Favorites))

--- a/src/modules/portfolio/containers/markets.js
+++ b/src/modules/portfolio/containers/markets.js
@@ -11,7 +11,9 @@ import { loadUserMarkets } from 'modules/markets/actions/load-user-markets'
 import { loadUnclaimedFees } from 'modules/markets/actions/load-unclaimed-fees'
 import { loadMarketsInfo } from 'modules/markets/actions/load-markets-info'
 import { collectMarketCreatorFees } from 'modules/portfolio/actions/collect-market-creator-fees'
+import { loadMarketsInfoIfNotLoaded } from 'modules/markets/actions/load-markets-info-if-not-loaded'
 import logError from 'utils/log-error'
+
 
 const mapStateToProps = state =>
   // getMyMarkets or it's equivalent will need a way of calculating the outstanding returns for a market and attaching it to each market object. Currently I've just added a key/value pair to the market objects im using below.
@@ -33,6 +35,7 @@ const mapDispatchToProps = dispatch => ({
   collectMarketCreatorFees: (marketId, callback) => dispatch(collectMarketCreatorFees(marketId, callback)),
   loadMarketsInfo: marketIds => dispatch(loadMarketsInfo(marketIds)),
   toggleFavorite: marketId => dispatch(toggleFavorite(marketId)),
+  loadMarketsInfoIfNotLoaded: marketIds => dispatch(loadMarketsInfoIfNotLoaded(marketIds)),
 })
 
 const MyMarketsContainer = withRouter(connect(mapStateToProps, mapDispatchToProps)(MyMarkets))


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/6420/integrate-p-l-data-in-core-stats-bar)

fixed the PL values on the top bar. to reproduce, login with an account that should have some Profit/loss. Make sure to load the markets so you get your account trades. PL data should appear on the top bar now.

I also corrected some propType issues that arose due to oversight, so this also includes a little bit of that in the portfolio section of the site.

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
