### PR TITLE
missed changing market load method to market list in reporting resolved

### DIFF
--- a/src/modules/reporting/components/reporting-resolved/reporting-resolved.jsx
+++ b/src/modules/reporting/components/reporting-resolved/reporting-resolved.jsx
@@ -21,7 +21,7 @@ export default class ReportingResolved extends Component {
   static propTypes = {
     history: PropTypes.object,
     isLogged: PropTypes.bool,
-    loadMarketsInfo: PropTypes.func,
+    loadMarketsInfoIfNotLoaded: PropTypes.func,
     loadReporting: PropTypes.func.isRequired,
     location: PropTypes.object,
     markets: PropTypes.array.isRequired,
@@ -53,7 +53,7 @@ export default class ReportingResolved extends Component {
     const {
       history,
       isLogged,
-      loadMarketsInfo,
+      loadMarketsInfoIfNotLoaded,
       location,
       markets,
       toggleFavorite,
@@ -77,7 +77,7 @@ export default class ReportingResolved extends Component {
           history={history}
           linkType={TYPE_VIEW}
           toggleFavorite={toggleFavorite}
-          loadMarketsInfo={loadMarketsInfo}
+          loadMarketsInfoIfNotLoaded={loadMarketsInfoIfNotLoaded}
           paginationPageParam="reporting-resolved-page"
         />
       </section>

--- a/src/modules/reporting/containers/reporting-resolved.js
+++ b/src/modules/reporting/containers/reporting-resolved.js
@@ -6,7 +6,7 @@ import ReportingResolved from 'modules/reporting/components/reporting-resolved/r
 import { loadReporting } from 'src/modules/reporting/actions/load-reporting'
 import { selectMarketsToReport } from 'src/modules/reporting/selectors/select-markets-to-report'
 import { toggleFavorite } from 'modules/markets/actions/update-favorites'
-import { loadMarketsInfo } from 'modules/markets/actions/load-markets-info'
+import { loadMarketsInfoIfNotLoaded } from 'modules/markets/actions/load-markets-info-if-not-loaded'
 
 import getValue from 'utils/get-value'
 
@@ -17,7 +17,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   loadReporting: () => dispatch(loadReporting()),
-  loadMarketsInfo: marketIds => dispatch(loadMarketsInfo(marketIds)),
+  loadMarketsInfoIfNotLoaded: marketIds => dispatch(loadMarketsInfoIfNotLoaded(marketIds)),
   toggleFavorite: marketId => dispatch(toggleFavorite(marketId)),
 })
 


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/9102)

simple change, missed renaming `loadMarketsInfo` to `loadMarketsInfoIfNotLoaded` for reporting resolved

on master check that there isn't error when navigating to reporting->resolved


## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
