### PR TITLE
johndanz/ch9134/set-timeout-on-order-placed-notification

### DIFF
--- a/src/modules/trade/components/trading/trading.jsx
+++ b/src/modules/trade/components/trading/trading.jsx
@@ -70,6 +70,8 @@ class MarketTrading extends Component {
 
   showOrderPlaced() {
     this.setState({ showOrderPlaced: true })
+    // automatically close the order placed ribbon after 3 seconds.
+    setTimeout(() => this.setState({ showOrderPlaced: false }), 3000)
   }
 
   render() {


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/9134/set-timeout-on-order-placed-notification)
place a trade. wait 3 seconds, the `Your order has been placed` purple ribbon on the bottom of the trade form should automatically disappear.

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
