### PR TITLE
Update UI code to work with changes to input data for claimReportingFees

### DIFF
--- a/src/modules/modal/components/modal-claim-reporting-fees/modal-claim-reporting-fees.jsx
+++ b/src/modules/modal/components/modal-claim-reporting-fees/modal-claim-reporting-fees.jsx
@@ -13,7 +13,7 @@ export default class ModalClaimReportingFees extends Component {
     recipient: PropTypes.string.isRequired,
     feeWindows: PropTypes.array.isRequired,
     forkedMarket: PropTypes.object.isRequired,
-    nonForkedMarkets: PropTypes.array.isRequired,
+    nonforkedMarkets: PropTypes.array.isRequired,
     unclaimedEth: PropTypes.object.isRequired,
     unclaimedRep: PropTypes.object.isRequired,
   }
@@ -32,7 +32,7 @@ export default class ModalClaimReportingFees extends Component {
     const claimReportingFeesOptions = {
       feeWindows: this.props.feeWindows,
       forkedMarket: this.props.forkedMarket,
-      nonForkedMarkets: this.props.nonForkedMarkets,
+      nonforkedMarkets: this.props.nonforkedMarkets,
       estimateGas: true,
       onSent: () => {},
       onFailed: (err) => {
@@ -60,7 +60,7 @@ export default class ModalClaimReportingFees extends Component {
     const claimReportingFeesOptions = {
       feeWindows: this.props.feeWindows,
       forkedMarket: this.props.forkedMarket,
-      nonForkedMarkets: this.props.nonForkedMarkets,
+      nonforkedMarkets: this.props.nonforkedMarkets,
       estimateGas: false,
       onSent: () => {},
       onFailed: (err) => {

--- a/src/modules/modal/components/modal-claim-reporting-fees/modal-claim-reporting-fees.jsx
+++ b/src/modules/modal/components/modal-claim-reporting-fees/modal-claim-reporting-fees.jsx
@@ -12,8 +12,8 @@ export default class ModalClaimReportingFees extends Component {
     closeModal: PropTypes.func.isRequired,
     recipient: PropTypes.string.isRequired,
     feeWindows: PropTypes.array.isRequired,
-    crowdsourcers: PropTypes.array.isRequired,
-    initialReporters: PropTypes.array.isRequired,
+    forkedMarket: PropTypes.object.isRequired,
+    nonForkedMarkets: PropTypes.array.isRequired,
     unclaimedEth: PropTypes.object.isRequired,
     unclaimedRep: PropTypes.object.isRequired,
   }
@@ -31,8 +31,8 @@ export default class ModalClaimReportingFees extends Component {
   componentWillMount() {
     const claimReportingFeesOptions = {
       feeWindows: this.props.feeWindows,
-      crowdsourcers: this.props.crowdsourcers,
-      initialReporters: this.props.initialReporters,
+      forkedMarket: this.props.forkedMarket,
+      nonForkedMarkets: this.props.nonForkedMarkets,
       estimateGas: true,
       onSent: () => {},
       onFailed: (err) => {
@@ -59,8 +59,8 @@ export default class ModalClaimReportingFees extends Component {
     e.preventDefault()
     const claimReportingFeesOptions = {
       feeWindows: this.props.feeWindows,
-      crowdsourcers: this.props.crowdsourcers,
-      initialReporters: this.props.initialReporters,
+      forkedMarket: this.props.forkedMarket,
+      nonForkedMarkets: this.props.nonForkedMarkets,
       estimateGas: false,
       onSent: () => {},
       onFailed: (err) => {

--- a/src/modules/portfolio/components/portfolio-reports/portfolio-reports.jsx
+++ b/src/modules/portfolio/components/portfolio-reports/portfolio-reports.jsx
@@ -55,8 +55,8 @@ export default class PortfolioReports extends Component {
           unclaimedEth: formatEther(0, { decimals: 4, zeroStyled: true }),
           unclaimedRep: formatAttoRep(0, { decimals: 4, zeroStyled: true }),
           feeWindows: [],
-          crowdsourcers: [],
-          initialReporters: [],
+          forkedMarket: {},
+          nonforkedMarkets: {},
         })
         return
       }
@@ -65,8 +65,8 @@ export default class PortfolioReports extends Component {
         unclaimedEth: formatEther(result.total.unclaimedEth, { decimals: 4, zeroStyled: true }),
         unclaimedRep: formatAttoRep(result.total.unclaimedRepStaked, { decimals: 4, zeroStyled: true }),
         feeWindows: result.feeWindows,
-        crowdsourcers: result.crowdsourcers,
-        initialReporters: result.initialReporters,
+        forkedMarket: result.forkedMarket,
+        nonforkedMarkets: result.nonforkedMarkets,
       })
     })
   }
@@ -76,16 +76,16 @@ export default class PortfolioReports extends Component {
       unclaimedEth,
       unclaimedRep,
       feeWindows,
-      crowdsourcers,
-      initialReporters,
+      forkedMarket,
+      nonforkedMarkets,
     } = this.state
     this.props.updateModal({
       type: MODAL_CLAIM_REPORTING_FEES,
       unclaimedEth,
       unclaimedRep,
       feeWindows,
-      crowdsourcers,
-      initialReporters,
+      forkedMarket,
+      nonforkedMarkets,
       canClose: true,
     })
   }

--- a/src/modules/portfolio/components/portfolio-reports/portfolio-reports.jsx
+++ b/src/modules/portfolio/components/portfolio-reports/portfolio-reports.jsx
@@ -65,8 +65,10 @@ export default class PortfolioReports extends Component {
         unclaimedEth: formatEther(result.total.unclaimedEth, { decimals: 4, zeroStyled: true }),
         unclaimedRep: formatAttoRep(result.total.unclaimedRepStaked, { decimals: 4, zeroStyled: true }),
         feeWindows: result.feeWindows,
-        forkedMarket: result.forkedMarket,
-        nonforkedMarkets: result.nonforkedMarkets,
+        // TODO: Replace the hard-coded values below with result.forkedMarket and
+        // result.nonforkedMarkets once augur-node is returning these.
+        forkedMarket: {},
+        nonforkedMarkets: [],
       })
     })
   }

--- a/test/modal/components/modal-view/modal-claim-reporting-fees-test.jsx
+++ b/test/modal/components/modal-view/modal-claim-reporting-fees-test.jsx
@@ -23,8 +23,8 @@ describe('modal-claim-reporting-fees', () => {
           unclaimedEth={formatEther('0', { decimals: 4, zeroStyled: true })}
           unclaimedRep={formatAttoRep('0', { decimals: 4, zeroStyled: true })}
           feeWindows={['0x161c723cac007e4283cee4ba11b15277e46eec53']}
-          crowdsourcers={[]}
-          initialReporters={[]}
+          forkedMarket={{}}
+          nonforkedMarkets={[]}
         />)
       })
 
@@ -58,8 +58,8 @@ describe('modal-claim-reporting-fees', () => {
         it('should receive first argument that matches expected value', () => {
           const expected = {
             feeWindows: ['0x161c723cac007e4283cee4ba11b15277e46eec53'],
-            crowdsourcers: [],
-            initialReporters: [],
+            forkedMarket: {},
+            nonforkedMarkets: [],
             estimateGas: true,
             onSent: claimReportingFees.args[0][0].onSent,
             onFailed: claimReportingFees.args[0][0].onFailed,
@@ -94,8 +94,8 @@ describe('modal-claim-reporting-fees', () => {
           unclaimedEth={formatEther('0.123', { decimals: 4, zeroStyled: true })}
           unclaimedRep={formatAttoRep('0', { decimals: 4, zeroStyled: true })}
           feeWindows={['0x161c723cac007e4283cee4ba11b15277e46eec53']}
-          crowdsourcers={[]}
-          initialReporters={[]}
+          forkedMarket={{}}
+          nonforkedMarkets={[]}
         />)
       })
 
@@ -129,8 +129,8 @@ describe('modal-claim-reporting-fees', () => {
         it('should receive first argument that matches expected value', () => {
           const expected = {
             feeWindows: ['0x161c723cac007e4283cee4ba11b15277e46eec53'],
-            crowdsourcers: [],
-            initialReporters: [],
+            forkedMarket: {},
+            nonforkedMarkets: [],
             estimateGas: true,
             onSent: claimReportingFees.args[0][0].onSent,
             onFailed: claimReportingFees.args[0][0].onFailed,
@@ -165,8 +165,8 @@ describe('modal-claim-reporting-fees', () => {
           unclaimedEth={formatEther('0', { decimals: 4, zeroStyled: true })}
           unclaimedRep={formatAttoRep('2000000000000000000', { decimals: 4, zeroStyled: true })}
           feeWindows={['0x161c723cac007e4283cee4ba11b15277e46eec53']}
-          crowdsourcers={[]}
-          initialReporters={[]}
+          forkedMarket={{}}
+          nonforkedMarkets={[]}
         />)
       })
 
@@ -200,8 +200,8 @@ describe('modal-claim-reporting-fees', () => {
         it('should receive first argument that matches expected value', () => {
           const expected = {
             feeWindows: ['0x161c723cac007e4283cee4ba11b15277e46eec53'],
-            crowdsourcers: [],
-            initialReporters: [],
+            forkedMarket: {},
+            nonforkedMarkets: [],
             estimateGas: true,
             onSent: claimReportingFees.args[0][0].onSent,
             onFailed: claimReportingFees.args[0][0].onFailed,
@@ -236,8 +236,8 @@ describe('modal-claim-reporting-fees', () => {
           unclaimedEth={formatEther('0.123', { decimals: 4, zeroStyled: true })}
           unclaimedRep={formatAttoRep('2000000000000000000', { decimals: 4, zeroStyled: true })}
           feeWindows={['0x161c723cac007e4283cee4ba11b15277e46eec53']}
-          crowdsourcers={[]}
-          initialReporters={[]}
+          forkedMarket={{}}
+          nonforkedMarkets={[]}
         />)
       })
 
@@ -271,8 +271,8 @@ describe('modal-claim-reporting-fees', () => {
         it('should receive first argument that matches expected value', () => {
           const expected = {
             feeWindows: ['0x161c723cac007e4283cee4ba11b15277e46eec53'],
-            crowdsourcers: [],
-            initialReporters: [],
+            forkedMarket: {},
+            nonforkedMarkets: [],
             estimateGas: true,
             onSent: claimReportingFees.args[0][0].onSent,
             onFailed: claimReportingFees.args[0][0].onFailed,


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/9369/update-ui-code-to-work-with-changes-to-input-data-returned-data-for-claimreportingfees)

Note: For now, the `forkedMarket` and `nonforkedMarkets` properties are hard-coded to [] and {} until the getReportingFees function in augur-node is updated to return these properties.  To test this, simply go to the Portfolio: Reporting page and make sure no errors are showing. There should not be any claimable ETH/REP showing, and the Claim button should not be clickable.

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
