### PR TITLE
Tomhaile/ch9393/issue with dispute form max value rounding

### DIFF
--- a/src/modules/reporting/components/reporting-dispute-form/reporting-dispute-form.jsx
+++ b/src/modules/reporting/components/reporting-dispute-form/reporting-dispute-form.jsx
@@ -168,8 +168,8 @@ export default class ReportingDisputeForm extends Component {
 
     let stake = rawStake
 
-    if (stake !== '' && !(BigNumber.isBigNumber(stake))) {
-      stake = createBigNumber(rawStake).decimalPlaces(4)
+    if (stake !== '') {
+      stake = createBigNumber(formatNumber(createBigNumber(stake).toNumber(), { decimals: 4, roundUp: true }).formattedValue)
     }
 
     ReportingDisputeForm.checkStake(stake, updatedValidations, this.calculateMaxRep())

--- a/src/modules/reporting/components/reporting-dispute-form/reporting-dispute-form.jsx
+++ b/src/modules/reporting/components/reporting-dispute-form/reporting-dispute-form.jsx
@@ -3,7 +3,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import { BigNumber, createBigNumber } from 'utils/create-big-number'
+import { createBigNumber } from 'utils/create-big-number'
 
 import { SCALAR } from 'modules/markets/constants/market-types'
 import { formatAttoRep, formatNumber } from 'utils/format-number'


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/9393)

test:

Push market into dispute. The issue occured when Remaining REP needed to dispute rounds down, ends in xxx4, xxx3, xxx2, xxx1

click MAX in the deposit REP input. Then dispute the market and verify that the new tentative winner changes and there isn't dust left.

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
