### PR TITLE
add + sign for hours over UTC, - already existed

### DIFF
--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -29,15 +29,16 @@ export function formatDate(d) {
   const localAMPM = ampm(localTime[0])
   const localTimeTwelve = getTwelveHour(localTime)
   const localOffset = (date.getTimezoneOffset() / 60) * -1
+  const localOffsetFormatted = localOffset > 0 ? `+${localOffset}` : localOffset.toString()
 
   return {
     value: date,
     simpleDate: `${date.getUTCDate()} ${months[date.getUTCMonth()]}`,
     formatted: `${months[date.getUTCMonth()]} ${date.getUTCDate()}, ${date.getUTCFullYear()} ${utcTimeTwelve.join(':')} ${utcAMPM}`, // UTC time
     formattedShort: `${shortMonths[date.getUTCMonth()]} ${date.getUTCDate()}, ${date.getUTCFullYear()} ${utcTimeTwelve.join(':')} ${utcAMPM}`, // UTC time
-    formattedLocal: `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} ${localTimeTwelve.join(':')} ${localAMPM} (UTC ${localOffset})`, // local time
-    formattedLocalShort: `${shortMonths[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} (UTC ${localOffset})`, // local time
-    formattedLocalShortTime: `${shortMonths[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} ${localTimeTwelve.join(':')} ${localAMPM} (UTC ${localOffset})`, // local time
+    formattedLocal: `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} ${localTimeTwelve.join(':')} ${localAMPM} (UTC ${localOffsetFormatted})`, // local time
+    formattedLocalShort: `${shortMonths[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} (UTC ${localOffsetFormatted})`, // local time
+    formattedLocalShortTime: `${shortMonths[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} ${localTimeTwelve.join(':')} ${localAMPM} (UTC ${localOffsetFormatted})`, // local time
     full: date.toUTCString(),
     timestamp: date.getTime() / 1000,
     utcLocalOffset: localOffset,


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/9469)

Didn't find a way to stub out getTimezoneOffset so didn't update unit tests. To test change local timezone, need to kill browser tab to test after timezone change.

Verify in Markets list view

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
