### PR TITLE
remove middleware client hot thing

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -177,7 +177,6 @@ if (!process.env.DEBUG_BUILD && process.env.NODE_ENV === 'development') {
   config = merge(config, {
     entry: {
       main: [
-        'webpack-hot-middleware/client',
         `${PATHS.APP}/main`
       ]
     },


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/9773)

Chore, remove client hook into middleware compile in webpack.config.

To Test:

run dev env `yarn dev`
open up web console -> Network
click on websocket (ws) to make sure client has connected to augur-node
make a code change to `src/modules/app/actions/init-augur.js` connectAugur method
make sure webpack rebuilds.
Verify that the UI doesn't auto-refresh
Verify that there isn't 2 websocket connections to augur-node

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
