### PR TITLE
switch labels for position data, use direct call to finalize market

### DIFF
--- a/src/modules/market/actions/finalize-market.js
+++ b/src/modules/market/actions/finalize-market.js
@@ -6,7 +6,8 @@ export const sendFinalizeMarket = (marketId, callback = logError) => (dispatch, 
   console.log('finalize market called')
   const { loginAccount } = getState()
   if (!loginAccount.address) return callback(null)
-  augur.api.Market.finalize({ tx: { to: marketId },
+  augur.reporting.finalizeMarket({
+    market: marketId,
     onSent: noop,
     onSuccess: noop,
     onFailed: err => callback(err),

--- a/src/modules/market/actions/finalize-market.js
+++ b/src/modules/market/actions/finalize-market.js
@@ -6,8 +6,7 @@ export const sendFinalizeMarket = (marketId, callback = logError) => (dispatch, 
   console.log('finalize market called')
   const { loginAccount } = getState()
   if (!loginAccount.address) return callback(null)
-  augur.reporting.finalizeMarket({
-    market: marketId,
+  augur.api.Market.finalize({ tx: { to: marketId },
     onSent: noop,
     onSuccess: noop,
     onFailed: err => callback(err),

--- a/src/modules/market/components/market-positions-list--position/market-positions-list--position.jsx
+++ b/src/modules/market/components/market-positions-list--position/market-positions-list--position.jsx
@@ -101,8 +101,8 @@ export default class Position extends Component {
             {getValue(position, 'lastPrice.formatted') }
           </li>
         }
-        { !isMobile && <li>{ getValue(position, 'unrealizedNet.formatted') }</li>}
         { !isMobile && <li>{ getValue(position, 'realizedNet.formatted')} </li> }
+        { !isMobile && <li>{ getValue(position, 'unrealizedNet.formatted') }</li>}
         { isExtendedDisplay &&
           <li>
             {getValue(position, 'totalNet.formatted') }


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/9804)

labels were switched.

wanted to call finalize directly on Market contract to finalize. Meant for claim trading proceeds PR.

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
