### PR TITLE
make search case insensitive

### DIFF
--- a/src/modules/filter-sort/helpers/filter-by-search.js
+++ b/src/modules/filter-sort/helpers/filter-by-search.js
@@ -8,7 +8,7 @@ export default function (search, keys, items) {
 
   const searchArray = parseStringToArray(decodeURIComponent(search))
 
-  const checkStringMatch = (value, search) => value.toLowerCase().indexOf(search) !== -1
+  const checkStringMatch = (value, search) => value.toLowerCase().indexOf(search.toLowerCase()) !== -1
 
   const checkArrayMatch = (item, keys, search) => { // Accomodates n-1 key's value of either array or object && final key's value of type string or array
     let parentValue = getValue(item, keys.reduce((p, key, i) => i + 1 !== keys.length ? `${p}${i !== 0 ? '.' : ''}${key}` : p, '')) // eslint-disable-line no-confusing-arrow


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/9647)

make sure search string is case insensitive. example `Augur` should be same as `augur`

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
