### PR TITLE
Tomhaile/ch9802/transaction outcomes for binary markets need

### DIFF
--- a/src/modules/transactions/actions/add-transactions.js
+++ b/src/modules/transactions/actions/add-transactions.js
@@ -3,6 +3,7 @@ import { SUCCESS, PENDING } from 'modules/transactions/constants/statuses'
 import { updateTransactionsData } from 'modules/transactions/actions/update-transactions-data'
 import { eachOf, each, groupBy } from 'async'
 import { convertUnixToFormattedDate } from 'src/utils/format-date'
+import { BINARY } from 'modules/markets/constants/market-types'
 
 function groupByMethod(values, prop) {
   let grouped = {}
@@ -67,7 +68,7 @@ function buildTradeTransaction(trade, marketsData) {
   const header = buildHeader(transaction, TRADE)
   const meta = {}
   meta.type = TRADE
-  meta.outcome = transaction.outcome
+  meta.outcome = thisMarketDataId.marketType === BINARY ? 'Yes' : transaction.outcome
   meta.price = transaction.price
   meta.fee = transaction.settlementFees
   // TODO include .reportingFees and .marketCreatorFees separately?

--- a/src/modules/transactions/actions/add-transactions.js
+++ b/src/modules/transactions/actions/add-transactions.js
@@ -69,12 +69,8 @@ function buildTradeTransaction(trade, marketsData) {
   const header = buildHeader(transaction, TRADE)
   const meta = {}
   meta.type = TRADE
-
-  if (market.marketType === BINARY) {
-    meta.outcome = 'Yes'
-  } else if (market.marketType === CATEGORICAL) {
-    meta.outcome = market.outcomes[transaction.outcome].description
-  }
+  const outcomeName = getOutcome(market, transaction.outcome)
+  if (outcomeName) meta.outcome = outcomeName
   meta.price = transaction.price
   meta.fee = transaction.settlementFees
   // TODO include .reportingFees and .marketCreatorFees separately?
@@ -205,7 +201,8 @@ export function addOpenOrderTransactions(openOrders) {
             creationTime = convertUnixToFormattedDate(transaction.creationTime)
             meta.txhash = transaction.transactionHash
             meta.timestamp = creationTime.full
-            meta.outcome = market.marketType === BINARY ? 'Yes' : outcomeId
+            const outcomeName = getOutcome(market, transaction.outcome)
+            if (outcomeName) meta.outcome = outcomeName
             meta.status = transaction.orderState
             meta.amount = transaction.fullPrecisionAmount
             meta.price = transaction.fullPrecisionPrice
@@ -264,6 +261,15 @@ export function addReportingTransactions(reports) {
   }
 }
 
+function getOutcome(market, outcome) {
+  let value = null
+  if (market.marketType === BINARY) {
+    value = 'Yes'
+  } else if (market.marketType === CATEGORICAL) {
+    value = market.outcomes[outcome].description
+  }
+  return value
+}
 function buildHeader(item, type, status) {
   const header = {}
   header.status = status


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/9802)

convert outcome from 1...n to human readable values for binary and categorical, scalar outcome is same as price. Binary we only trade on 'Yes' outcome.

format shares, noticed using old value for amount and price. 

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
