### PR TITLE
don't show claim proceeds button in market properties

### DIFF
--- a/src/modules/market/components/market-properties/market-properties.jsx
+++ b/src/modules/market/components/market-properties/market-properties.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import MarketLink from 'modules/market/components/market-link/market-link'
 import ValueDenomination from 'modules/common/components/value-denomination/value-denomination'
 
-import { TYPE_CLOSED, TYPE_DISPUTE, TYPE_VIEW } from 'modules/market/constants/link-types'
+import { TYPE_CLOSED, TYPE_DISPUTE, TYPE_VIEW, TYPE_CLAIM_PROCEEDS } from 'modules/market/constants/link-types'
 import { SCALAR } from 'modules/markets/constants/market-types'
 
 import getValue from 'utils/get-value'
@@ -67,7 +67,7 @@ const MarketProperties = (p) => {
               }
             </button>
           }
-          { (linkType === undefined || (linkType && linkType !== TYPE_CLOSED)) &&
+          { (linkType === undefined || (linkType && linkType !== TYPE_CLOSED && linkType !== TYPE_CLAIM_PROCEEDS)) &&
             <MarketLink
               className={classNames(Styles.MarketProperties__trade, { [Styles.disabled]: disableDispute })}
               id={p.id}


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/9890)

don't show button in market properties, claim proceeds has moved to other place. 

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
