### PR TITLE
hide outcome on trade confirm if scalar market

### DIFF
--- a/src/modules/trade/components/trading--confirm/trading--confirm.jsx
+++ b/src/modules/trade/components/trading--confirm/trading--confirm.jsx
@@ -5,7 +5,7 @@ import { CreateMarketEdit } from 'modules/common/components/icons'
 import ValueDenomination from 'modules/common/components/value-denomination/value-denomination'
 
 import getValue from 'utils/get-value'
-
+import { SCALAR } from 'modules/markets/constants/market-types'
 import { MARKET, LIMIT } from 'modules/transactions/constants/types'
 
 import Styles from 'modules/trade/components/trading--confirm/trading--confirm.styles'
@@ -28,7 +28,7 @@ const MarketTradingConfirm = (p) => {
         <button onClick={p.prevPage}>{ CreateMarketEdit }</button>
       </div>
       <ul className={Styles.TradingConfirm__details}>
-        { !p.isMobile &&
+        { !p.isMobile && p.market.marketType !== SCALAR &&
           <li>
             <span>Outcome</span>
             <span>{ p.selectedOutcome.name }</span>


### PR DESCRIPTION
Saw regression of `outcome` showing up on trade confirmation of scalar markets.

Verify `outcome` doesn't show up for scalar market trade confirmations. Should still show for Binary and Categorical market trades.

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
