### PR TITLE
johndanz/ch9937/log-in-with-uport-something-went-wrong-error

### DIFF
--- a/src/modules/auth/actions/login-with-ledger.js
+++ b/src/modules/auth/actions/login-with-ledger.js
@@ -1,6 +1,7 @@
 import { augur } from 'services/augurjs'
 import { updateIsLogged } from 'modules/auth/actions/update-is-logged'
 import { loadAccountData } from 'modules/auth/actions/load-account-data'
+import { toChecksumAddress } from 'ethereumjs-util'
 import ledgerSigner from 'modules/auth/helpers/ledger-signer'
 
 export default function loginWithLedger(address, ledgerLib) {
@@ -9,6 +10,7 @@ export default function loginWithLedger(address, ledgerLib) {
     dispatch(loadAccountData({
       address,
       ledgerLib,
+      displayAddress: toChecksumAddress(address),
       meta: {
         address,
         signer: async (...args) => {

--- a/src/modules/auth/actions/login-with-uport.js
+++ b/src/modules/auth/actions/login-with-uport.js
@@ -2,11 +2,13 @@ import { augur } from 'services/augurjs'
 import { updateIsLogged } from 'modules/auth/actions/update-is-logged'
 import { loadAccountData } from 'modules/auth/actions/load-account-data'
 import { uPortSigner } from 'modules/auth/helpers/uport-signer'
+import { toChecksumAddress } from 'ethereumjs-util'
 
 export const loginWithUport = account => (dispatch) => {
   dispatch(updateIsLogged(true))
   dispatch(loadAccountData({
     ...account,
+    displayAddress: toChecksumAddress(account.address),
     meta: {
       address: account.address,
       signer: transaction => dispatch(uPortSigner(transaction)),


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/9937/log-in-with-uport-something-went-wrong-error-when-clicking-on-account)

introduced cuz of the checksum address stuff, should be cleared up now.

To Test:

spin up augur.
spin up augur-node with this command `RINKEBY_PRIVATE_KEY="" yarn clean-start -- rinkeby`
Navigate to localhost, make sure to have metamask enabled and pointing to rinkeby BUT NOT LOGGED IN
proceed to login with uport/ledger to test.

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
