### PR TITLE
use local variables to stop errors from tags being the same

### DIFF
--- a/src/modules/create-market/components/create-market-form-define/create-market-form-define.jsx
+++ b/src/modules/create-market/components/create-market-form-define/create-market-form-define.jsx
@@ -27,12 +27,15 @@ export default class CreateMarketDefine extends Component {
   constructor(props) {
     super(props)
 
+    const localValue = {}
+    localValue.tag1 = props.newMarket.tag1
+    localValue.tag2 = props.newMarket.tag2
+    localValue.category = props.newMarket.category
     this.state = {
       suggestedCategories: this.filterCategories(this.props.newMarket.category),
       shownSuggestions: 2,
-      // suggestedCatClicked: false,
+      localValue,
     }
-
     this.filterCategories = this.filterCategories.bind(this)
     this.updateFilteredCategories = this.updateFilteredCategories.bind(this)
     this.validateTag = this.validateTag.bind(this)
@@ -89,8 +92,15 @@ export default class CreateMarketDefine extends Component {
       default:
         updatedMarket.validations[currentStep][fieldName] = true
     }
+    const { localValue } = this.state
+    localValue[fieldName] = value
+    this.setState({
+      localValue,
+    })
 
-    updatedMarket[fieldName] = value
+    if (updatedMarket.validations[currentStep][fieldName] === true) {
+      updatedMarket[fieldName] = value
+    }
     updatedMarket.isValid = isValid(currentStep)
 
     updateNewMarket(updatedMarket)
@@ -104,6 +114,13 @@ export default class CreateMarketDefine extends Component {
       keyPressed,
     } = this.props
     const s = this.state
+
+    let tagMessage = null
+    if (newMarket.validations[newMarket.currentStep].tag1.length) {
+      tagMessage = newMarket.validations[newMarket.currentStep].tag1
+    } else if (newMarket.validations[newMarket.currentStep].tag2.length) {
+      tagMessage = newMarket.validations[newMarket.currentStep].tag2
+    }
 
     return (
       <ul className={StylesForm.CreateMarketForm__fields}>
@@ -142,7 +159,7 @@ export default class CreateMarketDefine extends Component {
             id="cm__input--cat"
             className={classNames({ [`${StylesForm['CreateMarketForm__error--field']}`]: newMarket.validations[newMarket.currentStep].category.length })}
             type="text"
-            value={newMarket.category}
+            value={s.localValue.category}
             maxLength={TAGS_MAX_LENGTH}
             placeholder="Help users find your market by defining its category"
             onChange={(e) => { this.updateFilteredCategories(e.target.value); this.validateTag('category', e.target.value, TAGS_MAX_LENGTH) }}
@@ -179,15 +196,15 @@ export default class CreateMarketDefine extends Component {
         <li className={Styles.CreateMarketDefine__tags}>
           <label htmlFor="cm__input--tag1">
             <span>Tags</span>
-            { (newMarket.validations[newMarket.currentStep].tag1.length || newMarket.validations[newMarket.currentStep].tag2.length) &&
-              <span className={StylesForm.CreateMarketForm__error}>{InputErrorIcon}{ newMarket.validations[newMarket.currentStep].tag1 }</span>
+            { (tagMessage) &&
+              <span className={StylesForm['CreateMarketForm__error--abs']}>{InputErrorIcon}{ tagMessage }</span>
             }
           </label>
           <input
             id="cm__input--tag1"
             type="text"
             className={classNames({ [`${StylesForm['CreateMarketForm__error--field']}`]: newMarket.validations[newMarket.currentStep].tag1.length })}
-            value={newMarket.tag1}
+            value={s.localValue.tag1}
             maxLength={TAGS_MAX_LENGTH}
             placeholder="Tag 1"
             onChange={e => this.validateTag('tag1', e.target.value, TAGS_MAX_LENGTH, false)}
@@ -197,7 +214,7 @@ export default class CreateMarketDefine extends Component {
             id="cm__input--tag2"
             type="text"
             className={classNames({ [`${StylesForm['CreateMarketForm__error--field']}`]: newMarket.validations[newMarket.currentStep].tag2.length })}
-            value={newMarket.tag2}
+            value={s.localValue.tag2}
             maxLength={TAGS_MAX_LENGTH}
             placeholder="Tag 2"
             onChange={e => this.validateTag('tag2', e.target.value, TAGS_MAX_LENGTH, false)}

--- a/src/modules/create-market/components/create-market-form-define/create-market-form-define.jsx
+++ b/src/modules/create-market/components/create-market-form-define/create-market-form-define.jsx
@@ -4,7 +4,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-
+import { uniq, isEmpty } from 'lodash'
 import { DESCRIPTION_MAX_LENGTH, TAGS_MAX_LENGTH } from 'modules/create-market/constants/new-market-constraints'
 
 import { ExclamationCircle as InputErrorIcon } from 'modules/common/components/icons'
@@ -27,14 +27,14 @@ export default class CreateMarketDefine extends Component {
   constructor(props) {
     super(props)
 
-    const localValue = {}
-    localValue.tag1 = props.newMarket.tag1
-    localValue.tag2 = props.newMarket.tag2
-    localValue.category = props.newMarket.category
+    const localValues = {}
+    localValues.tag1 = props.newMarket.tag1
+    localValues.tag2 = props.newMarket.tag2
+    localValues.category = props.newMarket.category
     this.state = {
       suggestedCategories: this.filterCategories(this.props.newMarket.category),
       shownSuggestions: 2,
-      localValue,
+      localValues,
     }
     this.filterCategories = this.filterCategories.bind(this)
     this.updateFilteredCategories = this.updateFilteredCategories.bind(this)
@@ -67,17 +67,17 @@ export default class CreateMarketDefine extends Component {
       updateNewMarket,
     } = this.props
     const { currentStep } = newMarket
-
+    const { localValues } = this.state
     const updatedMarket = { ...newMarket }
 
-    const compareFields = ['tag1', 'tag2', 'category']
-    const compareValues = []
-
-    compareFields.indexOf(fieldName) !== -1 && compareFields.splice(compareFields.indexOf(fieldName), 1)
-
-    compareFields.forEach((value) => {
-      if (newMarket[value] !== '') compareValues.push(newMarket[value])
+    localValues[fieldName] = value
+    this.setState({
+      localValues,
     })
+
+    // compare unquiness remove empty values
+    const localValuesLen = Object.values(localValues).filter(x => !isEmpty(x)).length
+    const isUnique = uniq(Object.values(localValues).filter(x => !isEmpty(x))).length === localValuesLen
 
     switch (true) {
       case typeof value === 'string' && !value.length && isRequired:
@@ -86,20 +86,19 @@ export default class CreateMarketDefine extends Component {
       case maxLength && value.length > maxLength:
         updatedMarket.validations[currentStep][fieldName] = `Maximum length is ${maxLength}.`
         break
-      case compareValues.indexOf(value) !== -1:
+      case !isUnique:
         updatedMarket.validations[currentStep][fieldName] = 'Tag and category names must be unique.'
         break
       default:
-        updatedMarket.validations[currentStep][fieldName] = true
+        Object.keys(localValues).forEach((fieldName) => {
+          updatedMarket.validations[currentStep][fieldName] = true
+        })
     }
-    const { localValue } = this.state
-    localValue[fieldName] = value
-    this.setState({
-      localValue,
-    })
 
     if (updatedMarket.validations[currentStep][fieldName] === true) {
-      updatedMarket[fieldName] = value
+      Object.keys(localValues).forEach((fieldName) => {
+        updatedMarket[fieldName] = localValues[fieldName]
+      })
     }
     updatedMarket.isValid = isValid(currentStep)
 
@@ -159,7 +158,7 @@ export default class CreateMarketDefine extends Component {
             id="cm__input--cat"
             className={classNames({ [`${StylesForm['CreateMarketForm__error--field']}`]: newMarket.validations[newMarket.currentStep].category.length })}
             type="text"
-            value={s.localValue.category}
+            value={s.localValues.category}
             maxLength={TAGS_MAX_LENGTH}
             placeholder="Help users find your market by defining its category"
             onChange={(e) => { this.updateFilteredCategories(e.target.value); this.validateTag('category', e.target.value, TAGS_MAX_LENGTH) }}
@@ -204,7 +203,7 @@ export default class CreateMarketDefine extends Component {
             id="cm__input--tag1"
             type="text"
             className={classNames({ [`${StylesForm['CreateMarketForm__error--field']}`]: newMarket.validations[newMarket.currentStep].tag1.length })}
-            value={s.localValue.tag1}
+            value={s.localValues.tag1}
             maxLength={TAGS_MAX_LENGTH}
             placeholder="Tag 1"
             onChange={e => this.validateTag('tag1', e.target.value, TAGS_MAX_LENGTH, false)}
@@ -214,7 +213,7 @@ export default class CreateMarketDefine extends Component {
             id="cm__input--tag2"
             type="text"
             className={classNames({ [`${StylesForm['CreateMarketForm__error--field']}`]: newMarket.validations[newMarket.currentStep].tag2.length })}
-            value={s.localValue.tag2}
+            value={s.localValues.tag2}
             maxLength={TAGS_MAX_LENGTH}
             placeholder="Tag 2"
             onChange={e => this.validateTag('tag2', e.target.value, TAGS_MAX_LENGTH, false)}

--- a/src/modules/create-market/components/create-market-form/create-market-form.styles.less
+++ b/src/modules/create-market/components/create-market-form/create-market-form.styles.less
@@ -26,6 +26,12 @@
   white-space: nowrap;
 }
 
+.CreateMarketForm__error--abs {
+  &:extend(.CreateMarketForm__error);
+
+  position: absolute;
+}
+
 .CreateMarketForm__error--bottom {
   &:extend(.CreateMarketForm__error);
 
@@ -34,6 +40,7 @@
 }
 
 .CreateMarketForm__error > svg,
+.CreateMarketForm__error--abs > svg,
 .CreateMarketForm__error--bottom > svg,
 .CreateMarketForm__error--field-50 > svg,
 .CreateMarketForm__error--insufficient-funds > svg {

--- a/src/modules/reporting/components/reporting-report-form/reporting-report-form.jsx
+++ b/src/modules/reporting/components/reporting-report-form/reporting-report-form.jsx
@@ -94,7 +94,7 @@ export default class ReportingReportForm extends Component {
     const minValue = parseFloat(min)
     const maxValue = parseFloat(max)
     const valueValue = parseFloat(value)
-    const bnValue = createBigNumber(value)
+    const bnValue = createBigNumber(value || 0)
     const bnTickSize = createBigNumber(tickSize)
 
     if (value === '') {

--- a/src/modules/transactions/actions/add-transactions.js
+++ b/src/modules/transactions/actions/add-transactions.js
@@ -152,6 +152,7 @@ export function addMarketCreationTransactions(marketsCreated) {
       transaction.timestamp = (market || {}).creationTime
       const meta = {}
       meta.market = transaction.marketId
+      meta['creation fee'] = market.creationFee
       meta['market type'] = market.marketType
       transaction.meta = meta
       const header = buildHeader(transaction, MARKET_CREATION, SUCCESS)

--- a/src/modules/transactions/actions/add-transactions.js
+++ b/src/modules/transactions/actions/add-transactions.js
@@ -152,7 +152,6 @@ export function addMarketCreationTransactions(marketsCreated) {
       transaction.timestamp = (market || {}).creationTime
       const meta = {}
       meta.market = transaction.marketId
-      meta['creation fee'] = market.creationFee
       meta['market type'] = market.marketType
       transaction.meta = meta
       const header = buildHeader(transaction, MARKET_CREATION, SUCCESS)


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/9837)
[Clubhouse Story](https://app.clubhouse.io/augur/story/9835) (also fixed)

Fixed errors when category and/or tags are the same. Fixed tripple tag showing in create market define when same tags error occurs.

Also saw very small issue with initial report on scalar market by clicking on radio button first.

## Submitter checklist
- [x] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
