### PR TITLE
add quantity to fill trade form when user clicks row in order book

### DIFF
--- a/src/modules/market/components/market-outcome-charts--orders/market-outcome-charts--orders.jsx
+++ b/src/modules/market/components/market-outcome-charts--orders/market-outcome-charts--orders.jsx
@@ -129,6 +129,7 @@ export default class MarketOutcomeOrderbook extends Component {
                 className={Styles.MarketOutcomeOrderBook__RowItem}
                 onClick={() => updateSeletedOrderProperties({
                   orderPrice: order.price.value.toString(),
+                  orderQuantity: order.cumulativeShares.toString(),
                   selectedNav: BUY,
                 })}
               >
@@ -191,6 +192,7 @@ export default class MarketOutcomeOrderbook extends Component {
                 className={Styles.MarketOutcomeOrderBook__RowItem}
                 onClick={() => updateSeletedOrderProperties({
                   orderPrice: order.price.value.toString(),
+                  orderQuantity: order.cumulativeShares.toString(),
                   selectedNav: SELL,
                 })}
               >


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/10424)

Verify clicking any clickable portion of the row in the order book populates the trading form, both bids and asks.


## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
