### PR TITLE
added finalized dateTime to resloved markets that have been finalized…

### DIFF
--- a/src/modules/market/components/market-properties/market-properties.jsx
+++ b/src/modules/market/components/market-properties/market-properties.jsx
@@ -10,7 +10,7 @@ import { SCALAR } from 'modules/markets/constants/market-types'
 
 import getValue from 'utils/get-value'
 import shareDenominationLabel from 'utils/share-denomination-label'
-import { dateHasPassed } from 'utils/format-date'
+import { dateHasPassed, convertUnixToFormattedDate } from 'utils/format-date'
 import Styles from 'modules/market/components/market-properties/market-properties.styles'
 import ChevronFlip from 'modules/common/components/chevron-flip/chevron-flip'
 import { MODAL_MIGRATE_MARKET } from 'modules/modal/constants/modal-types'
@@ -22,6 +22,7 @@ const MarketProperties = (p) => {
   const consensus = getValue(p, isScalar ? 'consensus.winningOutcome' : 'consensus.outcomeName')
   const linkType = (p.isForking && p.linkType === TYPE_DISPUTE) ? TYPE_VIEW : p.linkType
   const disableDispute = p.loginAccount.rep === '0' && p.linkType === TYPE_DISPUTE
+  const finalTime = p.finalizationTime ? convertUnixToFormattedDate(p.finalizationTime) : null
 
   return (
     <article>
@@ -53,6 +54,12 @@ const MarketProperties = (p) => {
             <span>Winning Outcome</span>
             {consensus}
           </li>
+          }
+          { finalTime &&
+            <li>
+              <span>Finalized</span>
+              <span>{ p.isMobile ? finalTime.formattedLocalShort : finalTime.formattedLocalShortTime }</span>
+            </li>
           }
         </ul>
         <div className={Styles.MarketProperties__actions}>

--- a/src/modules/market/components/market-properties/market-properties.jsx
+++ b/src/modules/market/components/market-properties/market-properties.jsx
@@ -10,7 +10,7 @@ import { SCALAR } from 'modules/markets/constants/market-types'
 
 import getValue from 'utils/get-value'
 import shareDenominationLabel from 'utils/share-denomination-label'
-import { dateHasPassed, convertUnixToFormattedDate } from 'utils/format-date'
+import { dateHasPassed } from 'utils/format-date'
 import Styles from 'modules/market/components/market-properties/market-properties.styles'
 import ChevronFlip from 'modules/common/components/chevron-flip/chevron-flip'
 import { MODAL_MIGRATE_MARKET } from 'modules/modal/constants/modal-types'

--- a/src/modules/market/components/market-properties/market-properties.jsx
+++ b/src/modules/market/components/market-properties/market-properties.jsx
@@ -22,7 +22,6 @@ const MarketProperties = (p) => {
   const consensus = getValue(p, isScalar ? 'consensus.winningOutcome' : 'consensus.outcomeName')
   const linkType = (p.isForking && p.linkType === TYPE_DISPUTE) ? TYPE_VIEW : p.linkType
   const disableDispute = p.loginAccount.rep === '0' && p.linkType === TYPE_DISPUTE
-  const finalTime = p.finalizationTime ? convertUnixToFormattedDate(p.finalizationTime) : null
 
   return (
     <article>
@@ -54,12 +53,6 @@ const MarketProperties = (p) => {
             <span>Winning Outcome</span>
             {consensus}
           </li>
-          }
-          { finalTime &&
-            <li>
-              <span>Finalized</span>
-              <span>{ p.isMobile ? finalTime.formattedLocalShort : finalTime.formattedLocalShortTime }</span>
-            </li>
           }
         </ul>
         <div className={Styles.MarketProperties__actions}>

--- a/src/modules/reporting/actions/load-reporting.js
+++ b/src/modules/reporting/actions/load-reporting.js
@@ -80,7 +80,8 @@ export const loadReporting = (callback = logError) => (dispatch, getState) => {
     'getMarkets',
     {
       reportingState: constants.REPORTING_STATE.FINALIZED,
-      sortBy: 'endTime',
+      sortBy: 'finalizationBlockNumber',
+      isSortDescending: true,
       universe: universe.id,
     },
     (err, finalizedMarketIds) => {
@@ -91,6 +92,7 @@ export const loadReporting = (callback = logError) => (dispatch, getState) => {
         {
           reportingState: constants.REPORTING_STATE.AWAITING_FINALIZATION,
           sortBy: 'endTime',
+          isSortDescending: true,
           universe: universe.id,
         },
         (err, awaitingFinalizationMarketIds) => {


### PR DESCRIPTION
…, added sort by finaliztion block number, b/c it's in the markets table in augur-node

[Clubhouse Story](https://app.clubhouse.io/augur/story/10356)

@sharkcrayon see if you like the added `finalized` date on the resolved market card. Same card as My-Market's card.


## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [x] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
