### PR TITLE
johndanz/ch10845/fix-ticks-for-portfolio-charts

### DIFF
--- a/src/modules/app/actions/update-is-animating.js
+++ b/src/modules/app/actions/update-is-animating.js
@@ -1,0 +1,10 @@
+export const UPDATE_IS_ANIMATING = 'UPDATE_IS_ANIMATING'
+
+export function updateIsAnimating(isAnimating) {
+  return {
+    type: UPDATE_IS_ANIMATING,
+    data: {
+      isAnimating,
+    },
+  }
+}

--- a/src/modules/app/components/app/app.jsx
+++ b/src/modules/app/components/app/app.jsx
@@ -94,6 +94,7 @@ export default class AppView extends Component {
     updateIsMobile: PropTypes.func.isRequired,
     updateIsMobileSmall: PropTypes.func.isRequired,
     updateModal: PropTypes.func.isRequired,
+    updateIsAnimating: PropTypes.func.isRequired,
     url: PropTypes.string,
     isLoading: PropTypes.bool,
   }
@@ -320,6 +321,7 @@ export default class AppView extends Component {
                           (nowOpen && (this.state[menuKey].scalar === 1)))
     if (alreadyDone) {
       if (cb && (typeof cb) === 'function') cb()
+      this.props.updateIsAnimating(false)
     } else {
       const baseMenuState = { open: nowOpen }
       const currentTween = tween({
@@ -331,9 +333,11 @@ export default class AppView extends Component {
           setMenuState(Object.assign({}, baseMenuState, { scalar: newState.value }))
         },
       }).then(() => {
+        this.props.updateIsAnimating(false)
         if (cb && (typeof cb) === 'function') cb()
         setMenuState({ locked: false, currentTween: null })
       })
+      this.props.updateIsAnimating(true)
       setMenuState({ currentTween })
     }
   }

--- a/src/modules/app/containers/app.js
+++ b/src/modules/app/containers/app.js
@@ -13,12 +13,14 @@ import getAllMarkets from 'modules/markets/selectors/markets-all'
 import { initAugur } from 'modules/app/actions/init-augur'
 import { updateModal } from 'modules/modal/actions/update-modal'
 import { isLoading } from 'modules/app/selectors/is-loading'
+import { updateIsAnimating } from 'modules/app/actions/update-is-animating'
 import {
   selectBlockchainState,
   selectConnectionState,
   selectIsLogged,
   selectIsMobile,
   selectIsMobileSmall,
+  selectIsAnimating,
   selectLoginAccountState,
   selectModal,
   selectUniverseState,
@@ -34,6 +36,7 @@ const mapStateToProps = state => ({
   isLogged: selectIsLogged(state),
   isMobile: selectIsMobile(state),
   isMobileSmall: selectIsMobileSmall(state),
+  isAnimating: selectIsAnimating(state),
   loginAccount: selectLoginAccountState(state),
   markets: getAllMarkets(),
   marketsHeader: selectMarketsHeader(state),
@@ -48,6 +51,7 @@ const mapDispatchToProps = dispatch => ({
   initAugur: (history, cb) => dispatch(initAugur(history, cb)),
   updateIsMobile: isMobile => dispatch(updateIsMobile(isMobile)),
   updateIsMobileSmall: isMobileSmall => dispatch(updateIsMobileSmall(isMobileSmall)),
+  updateIsAnimating: isAnimating => dispatch(updateIsAnimating(isAnimating)),
   updateModal: modal => dispatch(updateModal(modal)),
 })
 

--- a/src/modules/app/reducers/is-animating.js
+++ b/src/modules/app/reducers/is-animating.js
@@ -1,0 +1,15 @@
+import { UPDATE_IS_ANIMATING } from 'modules/app/actions/update-is-animating'
+import { RESET_STATE } from 'modules/app/actions/reset-state'
+
+const DEFAULT_STATE = false
+
+export default function (isAnimating = DEFAULT_STATE, action) {
+  switch (action.type) {
+    case UPDATE_IS_ANIMATING:
+      return action.data.isAnimating
+    case RESET_STATE:
+      return DEFAULT_STATE
+    default:
+      return isAnimating
+  }
+}

--- a/src/modules/portfolio/components/performance-graph/performance-graph.jsx
+++ b/src/modules/portfolio/components/performance-graph/performance-graph.jsx
@@ -166,13 +166,21 @@ class PerformanceGraph extends Component {
         },
         tickPositioner() {
           // default
-          let positions = [this.dataMin, (this.dataMax / 2), Math.ceil(this.dataMax) + (this.dataMax * 0.05)]
-
-          if (this.series[0] && this.series[0].length > 0) {
-            const { data } = this.series[0]
-            const i = data.length / 2
-            const median = i % 1 === 0 ? (data[i - 1] + data[i]) / 2 : data[Math.floor(i)]
-            positions = [this.dataMin, median, Math.ceil(this.dataMax) + (this.dataMax * 0.05)]
+          let positions = [-0.15, 0, 0.5, 1]
+          if (this.series[0]) {
+            positions = []
+            const minData = this.dataMin === 0 ? -0.15 : (this.dataMin - 0.15)
+            const maxData = this.dataMax === 0 ? 0.15 : (Math.ceil(this.dataMax) + (this.dataMax * 0.05))
+            const median = ((minData + maxData) / 2)
+            positions.push(minData)
+            if (this.dataMin === 0) {
+              positions.push(0)
+            }
+            positions.push(median)
+            if (this.dataMax === 0) {
+              positions.push(0)
+            }
+            positions.push(maxData)
           }
           return positions
         },

--- a/src/modules/portfolio/containers/performance-graph.js
+++ b/src/modules/portfolio/containers/performance-graph.js
@@ -2,10 +2,12 @@ import { connect } from 'react-redux'
 
 import PerformanceGraph from 'modules/portfolio/components/performance-graph/performance-graph'
 import getProfitLoss from 'modules/portfolio/actions/get-profit-loss'
+import { selectIsAnimating } from 'src/select-state'
 
 const mapStateToProps = state => ({
   universe: state.universe.id,
   currentAugurTimestamp: state.blockchain.currentAugurTimestamp,
+  isAnimating: selectIsAnimating(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -4,6 +4,7 @@ import universe from 'modules/universe/reducers/universe'
 import connection from 'modules/app/reducers/connection'
 import isMobile from 'modules/app/reducers/is-mobile'
 import isMobileSmall from 'modules/app/reducers/is-mobile-small'
+import isAnimating from 'modules/app/reducers/is-animating'
 import loginAccount from 'modules/auth/reducers/login-account'
 import isLogged from 'modules/auth/reducers/is-logged'
 import ledgerStatus from 'modules/auth/reducers/ledger-status'
@@ -52,6 +53,7 @@ export function createReducer() {
     connection,
     isMobile,
     isMobileSmall,
+    isAnimating,
     loginAccount,
     isLogged,
     ledgerStatus,

--- a/src/select-state.js
+++ b/src/select-state.js
@@ -18,6 +18,7 @@ export const selectHasLoadedMarketsState = state => state.hasLoadedMarkets
 export const selectInitialReporters = state => state.initialReporters
 export const selectIsLogged = state => state.isLogged
 export const selectIsMobile = state => state.isMobile
+export const selectIsAnimating = state => state.isAnimating
 export const selectIsMobileSmall = state => state.isMobileSmall
 export const selectLoginAccountState = state => state.loginAccount
 export const selectMarketCreatorFeesState = state => state.marketCreatorFees


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/10845/fix-ticks-for-portfolio-charts)

all visual changes. Should notice a difference on a flat PL chart and on one that has any kinds of Trades.

Best way to test is pick a market, login with account 2, take an entire side of the order book, close your position, buy 10 shares for like .1.

Login to account 1 (the one that makes all the markets) and fill the open order to buy 10 shares at .1

Login to account 2, sell 10 shares at .95

Login with account 1, take that order on the book to close your position (or just hit close position)

Account 1 should have lost a good amount of ETH, Account 2should have gained, check chart on both to see examples of what it might look like. 

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
