### PR TITLE
give price for markets that don't ahve outcome name, aka scalars

### DIFF
--- a/src/modules/market/components/market-positions-list--position/market-positions-list--position.jsx
+++ b/src/modules/market/components/market-positions-list--position/market-positions-list--position.jsx
@@ -128,7 +128,7 @@ export default class MarketPositionsListPosition extends Component {
         }
       >
         <li>
-          { outcomeName }
+          { outcomeName || getValue(position, 'purchasePrice.formatted')}
         </li>
         <li>
           { positionShares }


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/11145)

Use price as outcome name for user's scalar positions. 

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
