### PR TITLE
achapman/ch11272/market-in-dispute-state-pre-fork-retains

### DIFF
--- a/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets.jsx
+++ b/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets.jsx
@@ -135,7 +135,7 @@ export default class ReportingDisputeMarkets extends Component {
                 outcomes={outcomes}
               />))
         }
-        { upcomingMarketsCount === 0 &&
+        { upcomingMarketsCount === 0 && nonForkingMarkets === 0 &&
           <NullStateMessage
             message="There are currently no markets slated for the upcoming dispute window."
           />

--- a/src/modules/reporting/selectors/select-dispute-markets.js
+++ b/src/modules/reporting/selectors/select-dispute-markets.js
@@ -18,7 +18,7 @@ export const selectMarketsInDispute = createSelector(
     if (isEmpty(markets)) {
       return []
     }
-    const filteredMarkets = markets.filter(market => market.reportingState === constants.REPORTING_STATE.CROWDSOURCING_DISPUTE || market.id === universe.forkingMarket)
+    const filteredMarkets = markets.filter(market => market.reportingState === constants.REPORTING_STATE.AWAITING_FORK_MIGRATION || market.reportingState === constants.REPORTING_STATE.CROWDSOURCING_DISPUTE || market.id === universe.forkingMarket)
     // Potentially forking or forking markets come first
     const potentialForkingMarkets = []
     const nonPotentialForkingMarkets = []

--- a/src/modules/reporting/selectors/select-market-dispute-outcomes.js
+++ b/src/modules/reporting/selectors/select-market-dispute-outcomes.js
@@ -19,7 +19,7 @@ export const selectMarketDisputeOutcomes = createSelector(
     if (isEmpty(markets)) {
       return {}
     }
-    const disputeMarkets = markets.filter(market => market.reportingState === constants.REPORTING_STATE.CROWDSOURCING_DISPUTE || market.reportingState === constants.REPORTING_STATE.AWAITING_NEXT_WINDOW)
+    const disputeMarkets = markets.filter(market => market.reportingState === constants.REPORTING_STATE.AWAITING_FORK_MIGRATION || market.reportingState === constants.REPORTING_STATE.CROWDSOURCING_DISPUTE || market.reportingState === constants.REPORTING_STATE.AWAITING_NEXT_WINDOW)
     const disputeOutcomes = {}
     const outcomes = disputeMarkets.reduce((p, m) => {
       if (m.disputeInfo) {


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/11272)

Simplify Instructions:

1. Cause a market to get close to forking `npx flash force-dispute -m 0x32d4d03600cf8432fda9a22c548b1f8b6ac92728 -r 19`
Report on another market that is in Open Reporting.

2. push time 1 week `npx flash push-timestamp -c 1 -w`
3. Partially fill a dispute bond on the non-forking market (the one open reported on).
4. Cause the other market to fork.
5. Verify the non-forking market is in Dispute Paused. 

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [x] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
