### PR TITLE
getting error on dispute market view, when user has no rep

### DIFF
--- a/src/modules/reporting/containers/reporting-header.js
+++ b/src/modules/reporting/containers/reporting-header.js
@@ -9,7 +9,7 @@ import { updateModal } from 'modules/modal/actions/update-modal'
 const mapStateToProps = state => ({
   reportingWindowStats: state.reportingWindowStats,
   isMobile: state.isMobile,
-  repBalance: state.loginAccount.rep || 0,
+  repBalance: state.loginAccount.rep || '0',
   forkingMarket: state.universe.forkingMarket,
   currentTime: state.blockchain.currentAugurTimestamp,
   doesUserHaveRep: state.loginAccount.rep > 0,


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/11500)

missed having rep as a string, PropType needs to be string.

testing:
navigate to reporting dispute markets page with user with 0 rep.

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
