### PR TITLE
fix-dust-on-cat-3

### DIFF
--- a/src/modules/market/components/market-outcome-charts--orders/market-outcome-charts--orders.jsx
+++ b/src/modules/market/components/market-outcome-charts--orders/market-outcome-charts--orders.jsx
@@ -121,6 +121,7 @@ export default class MarketOutcomeOrderbook extends Component {
                     orderPrice: order.price.value.toString(),
                     orderQuantity: order.cumulativeShares.toString(),
                     selectedNav: BUY,
+                    doNotCreateOrders: true,
                   })}
                 >
                   <span>{order.shares.value.toFixed(fixedPrecision).toString()}</span>
@@ -131,6 +132,7 @@ export default class MarketOutcomeOrderbook extends Component {
                     orderPrice: order.price.value.toString(),
                     orderQuantity: order.cumulativeShares.toString(),
                     selectedNav: BUY,
+                    doNotCreateOrders: true,
                   })}
                 >
                   <span>{order.price.value.toFixed(fixedPrecision).toString()}</span>
@@ -141,6 +143,7 @@ export default class MarketOutcomeOrderbook extends Component {
                     orderPrice: order.price.value.toString(),
                     orderQuantity: order.cumulativeShares.toString(),
                     selectedNav: BUY,
+                    doNotCreateOrders: true,
                   })}
                 >
                   <span>{order.cumulativeShares.toFixed(fixedPrecision).toString()}</span>

--- a/src/modules/market/components/market-view/market-view.jsx
+++ b/src/modules/market/components/market-view/market-view.jsx
@@ -33,6 +33,7 @@ export default class MarketView extends Component {
       orderPrice: '',
       orderQuantity: '',
       selectedNav: BUY,
+      doNotCreateOrders: false,
     }
 
     this.state = {

--- a/src/modules/portfolio/components/performance-graph/performance-graph.jsx
+++ b/src/modules/portfolio/components/performance-graph/performance-graph.jsx
@@ -185,7 +185,7 @@ class PerformanceGraph extends Component {
           x: 5,
           format: '{value} ETH',
           formatter() {
-            return formatEther(this.value).formattedValue
+            return `${formatEther(this.value).formattedValue} ETH`
           },
           style: {
             color: '#a7a2b2',

--- a/src/modules/trade/components/trading--confirm/trading--confirm.jsx
+++ b/src/modules/trade/components/trading--confirm/trading--confirm.jsx
@@ -19,6 +19,7 @@ const MarketTradingConfirm = (p) => {
   const potentialEthLoss = getValue(p, 'trade.potentialEthLoss')
   const potentialLossPercent = getValue(p, 'trade.potentialLossPercent')
   const totalCost = getValue(p, 'trade.totalCost')
+  const { doNotCreateOrders } = p
 
   return (
     <section className={Styles.TradingConfirm}>
@@ -98,7 +99,7 @@ const MarketTradingConfirm = (p) => {
               }
             }, (res) => {
               // onComplete CB
-            })
+            }, doNotCreateOrders)
             p.prevPage()
           }}
         >Confirm

--- a/src/modules/trade/components/trading--form/trading--form.jsx
+++ b/src/modules/trade/components/trading--form/trading--form.jsx
@@ -185,6 +185,8 @@ class MarketTradingForm extends Component {
 
   validateForm(property, rawValue) {
     const { updateState } = this.props
+    // since the order changed by user action, make sure we can place orders.
+    updateState('doNotCreateOrders', false)
     let value = rawValue
     if (!(BigNumber.isBigNumber(value)) && value !== '') value = createBigNumber(value)
     const updatedState = {

--- a/src/modules/trade/components/trading--wrapper/trading--wrapper.jsx
+++ b/src/modules/trade/components/trading--wrapper/trading--wrapper.jsx
@@ -45,6 +45,7 @@ class MarketTradingWrapper extends Component {
       marketQuantity: '',
       selectedNav: BUY,
       currentPage: 0,
+      doNotCreateOrders: false,
     }
 
     this.prevPage = this.prevPage.bind(this)
@@ -96,6 +97,7 @@ class MarketTradingWrapper extends Component {
       marketOrderTotal: '',
       marketQuantity: '',
       currentPage: 0,
+      doNotCreateOrders: false,
     })
   }
 
@@ -163,6 +165,7 @@ class MarketTradingWrapper extends Component {
                 orderEstimate={s.orderEstimate}
                 marketOrderTotal={s.marketOrderTotal}
                 marketQuantity={s.marketQuantity}
+                doNotCreateOrders={s.doNotCreateOrders}
                 selectedOutcome={selectedOutcome}
                 nextPage={this.nextPage}
                 updateState={this.updateState}
@@ -181,6 +184,7 @@ class MarketTradingWrapper extends Component {
             orderEstimate={s.orderEstimate}
             marketOrderTotal={s.marketOrderTotal}
             marketQuantity={s.marketQuantity}
+            doNotCreateOrders={s.doNotCreateOrders}
             selectedOutcome={selectedOutcome}
             prevPage={this.prevPage}
             trade={selectedOutcome.trade}


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/11502/fix-dust-orders-on-cat-3-type-markets)

To test, use master everything (except this). Login with Account 2 (the non marketcreator/initial liquidity account) and navigate to Markets > Politics > Electoral College cat 3 market.

If you select a outcome, then click on the order book and DO NOT TOUCH the trade form and just hit review and confirm, you should see `tradeAmountUntilZero` params with `doNotCreateOrders: true`. make the trade, you shouldn't get a dust order created.

2nd thing to confirm.
If you click on orders to take, then modify the price or quantity that was autofilled from clicking the book, then go and review/confirm  `tradeAmountUntilZero` should now show `doNotCreateOrders:false`. 

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
