### PR TITLE
UI will send failing tx for create scalar market If numTicks is odd

### DIFF
--- a/src/modules/create-market/components/create-market-form-outcome/create-market-form-outcome.jsx
+++ b/src/modules/create-market/components/create-market-form-outcome/create-market-form-outcome.jsx
@@ -153,6 +153,7 @@ export default class CreateMarketOutcome extends Component {
     // reset errors
     updatedMarket.validations[currentStep].scalarBigNum = true
     updatedMarket.validations[currentStep].scalarSmallNum = true
+    updatedMarket.validations[currentStep].tickSize = true
 
     switch (true) {
       case scalarSmallNum === '':
@@ -207,6 +208,11 @@ export default class CreateMarketOutcome extends Component {
           updatedMarket.validations[currentStep].tickSize = true
       }
       updatedMarket.tickSize = value
+    }
+
+    // Always check if (maxPrice - minPrice) / precision is an even number
+    if (((scalarBigNum - scalarSmallNum) / numTicksBigNum) % 2 !== 0) {
+      updatedMarket.validations[currentStep].tickSize =`Total ticks must be even.`
     }
 
     updatedMarket.isValid = isValid(currentStep)

--- a/src/modules/create-market/components/create-market-form-outcome/create-market-form-outcome.jsx
+++ b/src/modules/create-market/components/create-market-form-outcome/create-market-form-outcome.jsx
@@ -214,7 +214,7 @@ export default class CreateMarketOutcome extends Component {
     if (BigNumber.isBigNumber(scalarBigNum) && BigNumber.isBigNumber(scalarSmallNum) && BigNumber.isBigNumber(numTicksBigNum)) {
       // Always check if (maxPrice - minPrice) / precision is an even number
       if ((scalarBigNum.minus(scalarSmallNum).div(numTicksBigNum)).mod(2).toString() !== '0') {
-        updatedMarket.validations[currentStep].tickSize =`Total ticks must be even.`
+        updatedMarket.validations[currentStep].tickSize =`Increase range or precision.`
       }
     }
 

--- a/src/modules/create-market/components/create-market-form-outcome/create-market-form-outcome.jsx
+++ b/src/modules/create-market/components/create-market-form-outcome/create-market-form-outcome.jsx
@@ -211,7 +211,7 @@ export default class CreateMarketOutcome extends Component {
     }
 
     // Make sure scalarBigNum, scalarSmallNum, & numTicksBigNum are all BigNumbers
-    if (typeof scalarBigNum === 'object' && typeof scalarSmallNum === 'object' && typeof numTicksBigNum === 'object') {
+    if (BigNumber.isBigNumber(scalarBigNum) && BigNumber.isBigNumber(scalarSmallNum) && BigNumber.isBigNumber(numTicksBigNum)) {
       // Always check if (maxPrice - minPrice) / precision is an even number
       if ((scalarBigNum.minus(scalarSmallNum).div(numTicksBigNum)).mod(2).toString() !== '0') {
         updatedMarket.validations[currentStep].tickSize =`Total ticks must be even.`

--- a/src/modules/create-market/components/create-market-form-outcome/create-market-form-outcome.jsx
+++ b/src/modules/create-market/components/create-market-form-outcome/create-market-form-outcome.jsx
@@ -210,9 +210,12 @@ export default class CreateMarketOutcome extends Component {
       updatedMarket.tickSize = value
     }
 
-    // Always check if (maxPrice - minPrice) / precision is an even number
-    if (((scalarBigNum - scalarSmallNum) / numTicksBigNum) % 2 !== 0) {
-      updatedMarket.validations[currentStep].tickSize =`Total ticks must be even.`
+    // Make sure scalarBigNum, scalarSmallNum, & numTicksBigNum are all BigNumbers
+    if (typeof scalarBigNum === 'object' && typeof scalarSmallNum === 'object' && typeof numTicksBigNum === 'object') {
+      // Always check if (maxPrice - minPrice) / precision is an even number
+      if ((scalarBigNum.minus(scalarSmallNum).div(numTicksBigNum)).mod(2).toString() !== '0') {
+        updatedMarket.validations[currentStep].tickSize =`Total ticks must be even.`
+      }
     }
 
     updatedMarket.isValid = isValid(currentStep)

--- a/test/modules/create-market/components/create-market-form-outcome/create-market-form-outcome-test.jsx
+++ b/test/modules/create-market/components/create-market-form-outcome/create-market-form-outcome-test.jsx
@@ -114,7 +114,7 @@ describe('create-market-form-outcome', () => {
         })
 
         it('should set validation message to true', () => {
-          assert.equal(newMarketObj.validations[newMarketObj.currentStep].tickSize, 'Tick size is required.')
+          assert.equal(newMarketObj.validations[newMarketObj.currentStep].tickSize, 'Tick size must be even.')
         })
       })
 

--- a/test/modules/create-market/components/create-market-form-outcome/create-market-form-outcome-test.jsx
+++ b/test/modules/create-market/components/create-market-form-outcome/create-market-form-outcome-test.jsx
@@ -114,7 +114,7 @@ describe('create-market-form-outcome', () => {
         })
 
         it('should set validation message to true', () => {
-          assert.equal(newMarketObj.validations[newMarketObj.currentStep].tickSize, 'Tick size must be even.')
+          assert.equal(newMarketObj.validations[newMarketObj.currentStep].tickSize, 'Total ticks must be even.')
         })
       })
 

--- a/test/modules/create-market/components/create-market-form-outcome/create-market-form-outcome-test.jsx
+++ b/test/modules/create-market/components/create-market-form-outcome/create-market-form-outcome-test.jsx
@@ -114,7 +114,7 @@ describe('create-market-form-outcome', () => {
         })
 
         it('should set validation message to true', () => {
-          assert.equal(newMarketObj.validations[newMarketObj.currentStep].tickSize, 'Total ticks must be even.')
+          assert.equal(newMarketObj.validations[newMarketObj.currentStep].tickSize, 'Tick size is required.')
         })
       })
 


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/11536/ui-will-send-failing-tx-for-create-scalar-market-if-numticks-is-odd)

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
