### PR TITLE
Cannot create a market with creator fee < 0.1

### DIFF
--- a/src/modules/create-market/components/create-market-form-liquidity/create-market-form-liquidity.jsx
+++ b/src/modules/create-market/components/create-market-form-liquidity/create-market-form-liquidity.jsx
@@ -428,7 +428,7 @@ export default class CreateMarketLiquidity extends Component {
               type="number"
               value={newMarket.settlementFee}
               placeholder="0%"
-              onChange={e => validateNumber('settlementFee', e.target.value, 'settlement fee', 0, 100, 1)}
+              onChange={e => validateNumber('settlementFee', e.target.value, 'settlement fee', 0, 100, 2)}
               onKeyPress={e => keyPressed(e)}
             />
             <span className={Styles.CreateMarketLiquidity__settlementFeePercent}>%</span>

--- a/src/modules/create-market/components/create-market-form/create-market-form.jsx
+++ b/src/modules/create-market/components/create-market-form/create-market-form.jsx
@@ -139,7 +139,8 @@ export default class CreateMarketForm extends Component {
 
     let value = rawValue
 
-    if (value !== '' && value !== '0.0') {
+    const regExp = new RegExp('^[0-9]+\\.[0]{0,' + decimals + '}$')
+    if (value !== '' && !regExp.test(value)) {
       value = parseFloat(value)
       value = parseFloat(value.toFixed(decimals))
     }

--- a/src/modules/create-market/components/create-market-form/create-market-form.jsx
+++ b/src/modules/create-market/components/create-market-form/create-market-form.jsx
@@ -139,7 +139,7 @@ export default class CreateMarketForm extends Component {
 
     let value = rawValue
 
-    if (value !== '') {
+    if (value !== '' && value !== '0.0') {
       value = parseFloat(value)
       value = parseFloat(value.toFixed(decimals))
     }


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/11537/cannot-create-a-market-with-creator-fee-of-less-than-0-1)

Attempting to enter a creator fee < 0.1 was not being allowed by the UI. (It was just being converted to the number 0.)

The reasons for this were:
1. The number of decimal places being passed into `validateNumber` was 1
2. When `value` was set to a string ending in ".0", the ".0" was getting removed from the resulting number, which was preventing further decimal numbers from being added.

This also allows the creator fee to be set to 0 (which is now permitted by in the contract code).

NOTE: The UI calls this field the Settlement Fee, but isn't this technically the Creator Fee?

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
