### PR TITLE
johndanz/ch11618/in-scalar-market-my-positions-on-trade-page

### DIFF
--- a/src/modules/trade/components/trading--form/trading--form.jsx
+++ b/src/modules/trade/components/trading--form/trading--form.jsx
@@ -128,8 +128,9 @@ class MarketTradingForm extends Component {
     const {
       maxPrice,
       minPrice,
+      market,
     } = this.props
-    // const tickSize = createBigNumber(market.tickSize)
+    const tickSize = createBigNumber(market.tickSize)
     let errorCount = 0
     let passedTest = !!isOrderValid
     if (isNaN(value)) return { isOrderValid: false, errors, errorCount }
@@ -139,11 +140,11 @@ class MarketTradingForm extends Component {
       errors[this.INPUT_TYPES.PRICE].push(`Price must be between ${minPrice} - ${maxPrice}`)
     }
     // removed this validation for now, let's let augur.js handle this.
-    // if (value && value.mod(tickSize).gt('0')) {
-    //   errorCount += 1
-    //   passedTest = false
-    //   errors[this.INPUT_TYPES.PRICE].push(`Price must be a multiple of ${tickSize}`)
-    // }
+    if (value && value.mod(tickSize).gt('0')) {
+      errorCount += 1
+      passedTest = false
+      errors[this.INPUT_TYPES.PRICE].push(`Price must be a multiple of ${tickSize}`)
+    }
     return { isOrderValid: passedTest, errors, errorCount }
   }
 


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/11618/in-scalar-market-my-positions-on-trade-page-price-does-not-match-price-used-in-order-ticket)

So what was going on here was actually valid. the market being traded on in the above CH issue has a tickSize of 0.1. We had removed the validation that warned you that the price needed to be a multiple of tickSize because of the way we planned to handle cat 3 markets. Since that plan has now changed and cat 3s have 10k numTicks and 0.0001 tickSize like everyone else, we can re-enable this validation. This would cause Jack's trade to be flagged as a not-valid price since -1.25 is not a multiple of  0.1. Previously Augur.js was rounding that to the nearest tick, in this case -1.3, which is why we saw that valid saved to Augur Node.

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
