### PR TITLE
johndanz/ch11553/pl-scale-adjustment

### DIFF
--- a/src/modules/portfolio/components/performance-graph/performance-graph.jsx
+++ b/src/modules/portfolio/components/performance-graph/performance-graph.jsx
@@ -199,8 +199,8 @@ class PerformanceGraph extends Component {
           let positions = [-0.15, 0, 0.5, 1]
           if (this.series[0]) {
             positions = []
-            let minTickValue = this.dataMin === 0 ? -0.25 : (this.dataMin - (Math.abs(this.dataMin) * 0.25))
-            let maxTickValue = this.dataMax === 0 ? 0.25 : (Math.ceil(this.dataMax) + (this.dataMax * 0.05))
+            let minTickValue = this.dataMin >= 0 ? -0.25 : (this.dataMin - (Math.abs(this.dataMin) * 0.25))
+            let maxTickValue = this.dataMax <= 0 ? 0.25 : (this.dataMax + (this.dataMax * 0.25))
             if (this.dataMin === 0 && this.dataMax > 0) {
               minTickValue = ((Math.abs(this.dataMax) * 0.25) * -1)
             }


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/11553/pl-scale-adjustment)

see ticket for reproduction instructions. this should fix all instances though as i erroneously was rounding up on the max value, which is why the scale was so off. (showing 1+ ETH top end even if our value was 0.00019, while making 0 the bottom end...)

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
