### PR TITLE
Add data point to complete line from depth line to y-axis

### DIFF
--- a/src/modules/market/helpers/order-for-market-depth.js
+++ b/src/modules/market/helpers/order-for-market-depth.js
@@ -2,7 +2,7 @@ import memoize from 'memoizee'
 
 import { BIDS, ASKS } from 'modules/order-book/constants/order-book-order-types'
 
-const orderForMarketDepth = memoize((orderBook) => {
+const orderForMarketDepth = (orderBook) => {
   const rawBids = ((orderBook || {})[BIDS] || []).slice()
   const bids = rawBids
     .reduce((p, order) => [...p, [order.cumulativeShares, order.price.value, order.shares.value]], [])
@@ -11,10 +11,35 @@ const orderForMarketDepth = memoize((orderBook) => {
     .sort((a, b) => a.price.value - b.price.value)
     .reduce((p, order) => [...p, [order.cumulativeShares, order.price.value, order.shares.value]], [])
 
+  // no need to add an starting data point if one side is empty.
+  if (asks.length === 0 || bids.length === 0) {
+    return {
+      [BIDS]: bids,
+      [ASKS]: asks,
+    }
+  }
+
+  const minAsksDepthOrder = asks.reduce((lastValue, nextValue) => (lastValue[0].lte(nextValue[0]) ? lastValue : nextValue), asks[0])
+  const minBidDepthOrder = bids.reduce((lastValue, nextValue) => (lastValue[0].lte(nextValue[0]) ? lastValue : nextValue), bids[0])
+
+  // depth is the same.
+  switch (true) {
+    // need to add a starting bid order
+    case minAsksDepthOrder[0].lt(minBidDepthOrder[0]):
+      bids.unshift([minAsksDepthOrder[0], minBidDepthOrder[1], minBidDepthOrder[2]])
+      break
+    // need to add a starting ask order
+    case minAsksDepthOrder[0].gt(minBidDepthOrder[0]):
+      asks.unshift([minBidDepthOrder[0], minAsksDepthOrder[1], minAsksDepthOrder[2]])
+      break
+    default:
+      // do nothing
+  }
+
   return {
     [BIDS]: bids,
     [ASKS]: asks,
   }
-})
+}
 
-export default orderForMarketDepth
+export default memoize(orderForMarketDepth)

--- a/test/modules/market/helpers/order-for-market-depth-test.js
+++ b/test/modules/market/helpers/order-for-market-depth-test.js
@@ -1,0 +1,128 @@
+import { formatEther, formatShares } from 'src/utils/format-number'
+import orderForMarketDepth from 'src/modules/market/helpers/order-for-market-depth'
+import { createBigNumber } from 'src/utils/create-big-number'
+
+describe('src/modules/market/helpers/order-for-market-depth.js', () => {
+  let exampleOrderBook
+  describe('when min asks depth is greater than bids', () => {
+    beforeEach(() => {
+      exampleOrderBook = {
+        bids: [
+          {
+            shares: formatShares(0.001),
+            price: formatEther(0.28),
+            cumulativeShares: createBigNumber('0.001'),
+          },
+          {
+            shares: formatShares(0.003),
+            price: formatEther(0.4),
+            cumulativeShares: createBigNumber('0.006'),
+          },
+        ],
+        asks: [
+          {
+            shares: formatShares(0.002),
+            price: formatEther(0.35),
+            cumulativeShares: createBigNumber('0.003'),
+          },
+          {
+            shares: formatShares(0.003),
+            price: formatEther(0.4),
+            cumulativeShares: createBigNumber('0.006'),
+          },
+        ],
+      }
+    })
+
+    it('should add a starting point to asks', () => {
+      const result = orderForMarketDepth(exampleOrderBook)
+
+      assert.lengthOf(result.asks, 3)
+      assert.lengthOf(result.bids, 2)
+
+      assert.equal('0.001', result.asks[0][0].toString())
+      assert.equal('0.35', result.asks[0][1])
+      assert.equal('0.002', result.asks[0][2])
+    })
+  })
+
+  describe('when min bid depth is greater than asks', () => {
+    beforeEach(() => {
+      exampleOrderBook = {
+        bids: [
+          {
+            shares: formatShares(0.002),
+            price: formatEther(0.25),
+            cumulativeShares: createBigNumber('0.003'),
+          },
+          {
+            shares: formatShares(0.003),
+            price: formatEther(0.4),
+            cumulativeShares: createBigNumber('0.006'),
+          },
+        ],
+        asks: [
+          {
+            shares: formatShares(0.001),
+            price: formatEther(0.31),
+            cumulativeShares: createBigNumber('0.001'),
+          },
+          {
+            shares: formatShares(0.003),
+            price: formatEther(0.4),
+            cumulativeShares: createBigNumber('0.006'),
+          },
+        ],
+      }
+    })
+
+    it('should add a starting point to bids', () => {
+      const result = orderForMarketDepth(exampleOrderBook)
+
+      assert.lengthOf(result.asks, 2)
+      assert.lengthOf(result.bids, 3)
+
+      assert.equal('0.001', result.bids[0][0].toString())
+      assert.equal('0.25', result.bids[0][1])
+      assert.equal('0.002', result.bids[0][2])
+    })
+  })
+
+  describe('when min bid depth is the same for bids and ask', () => {
+    beforeEach(() => {
+      exampleOrderBook = {
+        bids: [
+          {
+            shares: formatShares(0.002),
+            price: formatEther(0.25),
+            cumulativeShares: createBigNumber('0.003'),
+          },
+          {
+            shares: formatShares(0.003),
+            price: formatEther(0.4),
+            cumulativeShares: createBigNumber('0.006'),
+          },
+        ],
+        asks: [
+          {
+            shares: formatShares(0.002),
+            price: formatEther(0.35),
+            cumulativeShares: createBigNumber('0.003'),
+          },
+          {
+            shares: formatShares(0.003),
+            price: formatEther(0.4),
+            cumulativeShares: createBigNumber('0.006'),
+          },
+        ],
+      }
+    })
+
+    it('should not add data points', () => {
+      const result = orderForMarketDepth(exampleOrderBook)
+
+      assert.lengthOf(result.asks, 2)
+      assert.lengthOf(result.bids, 2)
+    })
+  })
+})


### PR DESCRIPTION
This fixes the "Depth chart lines do not extend all the way to the left" problem.

[Clubhouse Story](https://app.clubhouse.io/augur/story/11605)

## Submitter checklist
- [ ] Test covering functionality added/fixed in

## Reviewer Checklist
- [ ] Test/lint pass 
