### PR TITLE
0.0000 is the lowest price to show in depth range, move MIN over b/c …

### DIFF
--- a/src/modules/market/components/market-outcome-charts--depth/market-outcome-charts--depth.jsx
+++ b/src/modules/market/components/market-outcome-charts--depth/market-outcome-charts--depth.jsx
@@ -475,7 +475,10 @@ function drawTicks(options) {
 
   //  Offset Ticks
   const offsetTicks = drawParams.yDomain.map((d, i) => { // Assumes yDomain is [min, max]
-    if (i === 0) return d + (drawParams.boundDiff / 4)
+    if (i === 0) {
+      const value = d + (drawParams.boundDiff / 4)
+      if (value < 0) return 0
+    }
     return d - (drawParams.boundDiff / 4)
   })
 
@@ -518,7 +521,7 @@ function drawTicks(options) {
       .attr('class', 'tick-value')
       .attr('x', 0)
       .attr('y', d => drawParams.yScale(orderBookKeys.min))
-      .attr('dx', 0)
+      .attr('dx', 50)
       .attr('dy', drawParams.chartDim.tickOffset)
       .text('min')
 
@@ -541,7 +544,7 @@ function drawTicks(options) {
       .attr('class', 'tick-value')
       .attr('x', 0)
       .attr('y', d => drawParams.yScale(orderBookKeys.max))
-      .attr('dx', 0)
+      .attr('dx', 50)
       .attr('dy', drawParams.chartDim.tickOffset)
       .text('max')
 


### PR DESCRIPTION
…it can be rendered over the lower range price

[Clubhouse Story](https://app.clubhouse.io/augur/story/11584)

See if you can get the depth chart to show negative number in lower range. Not sure if we want to use BigNumber math for depth chart.


## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [x] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
