### PR TITLE
Tomhaile/ch12151/price history chart with no price history

### DIFF
--- a/src/modules/events/actions/log-handlers.js
+++ b/src/modules/events/actions/log-handlers.js
@@ -102,7 +102,7 @@ export const handleOrderCanceledLog = log => (dispatch, getState) => {
 }
 
 export const handleOrderFilledLog = log => (dispatch, getState) => {
-  dispatch(loadMarketsInfoIfNotLoaded([log.marketId]))
+  dispatch(loadMarketsInfo([log.marketId]))
   const { address } = getState().loginAccount
   const isStoredTransaction = log.filler === address || log.creator === address
   const popularity = log.removed ? new BigNumber(log.amount, 10).negated().toFixed() : log.amount

--- a/src/modules/market/components/market-outcomes-chart/market-outcomes-chart.jsx
+++ b/src/modules/market/components/market-outcomes-chart/market-outcomes-chart.jsx
@@ -103,39 +103,39 @@ export default class MarketOutcomesChart extends Component {
         .attr('width', drawParams.width)
         .attr('height', drawParams.height)
 
+      drawTicks({
+        drawParams,
+        chart,
+        fixedPrecision,
+      })
+
+      drawXAxisLabels({
+        drawParams,
+        chart,
+      })
+
+      drawSeries({
+        chart,
+        creationTime,
+        estimatedInitialPrice,
+        outcomes,
+        drawParams,
+      })
+
+      drawCrosshairs({
+        chart,
+      })
+
+      attachHoverHandler({
+        drawParams,
+        chart,
+        updateHoveredLocation: this.updateHoveredLocation,
+      })
+
       if (!hasPriceHistory) {
         drawNullState({
           drawParams,
           chart,
-        })
-      } else {
-        drawTicks({
-          drawParams,
-          chart,
-          fixedPrecision,
-        })
-
-        drawXAxisLabels({
-          drawParams,
-          chart,
-        })
-
-        drawSeries({
-          chart,
-          creationTime,
-          estimatedInitialPrice,
-          outcomes,
-          drawParams,
-        })
-
-        drawCrosshairs({
-          chart,
-        })
-
-        attachHoverHandler({
-          drawParams,
-          chart,
-          updateHoveredLocation: this.updateHoveredLocation,
         })
       }
 

--- a/src/modules/market/components/market-outcomes-chart/market-outcomes-chart.jsx
+++ b/src/modules/market/components/market-outcomes-chart/market-outcomes-chart.jsx
@@ -20,6 +20,7 @@ export default class MarketOutcomesChart extends Component {
     outcomes: PropTypes.array.isRequired,
     updateSelectedOutcome: PropTypes.func.isRequired,
     fixedPrecision: PropTypes.number.isRequired,
+    hasPriceHistory: PropTypes.bool.isRequired,
     selectedOutcome: PropTypes.any, // NOTE -- There is a PR in the prop-types lib to handle null values, but until then..
   }
 
@@ -83,6 +84,7 @@ export default class MarketOutcomesChart extends Component {
     maxPrice,
     minPrice,
     outcomes,
+    hasPriceHistory,
   }) {
     if (this.outcomesChart) {
       const drawParams = determineDrawParams({
@@ -93,15 +95,15 @@ export default class MarketOutcomesChart extends Component {
         maxPrice,
         minPrice,
         outcomes,
+        hasPriceHistory,
       })
-
       const fauxDiv = new ReactFauxDOM.Element('div')
       const chart = d3.select(fauxDiv).append('svg')
         .attr('id', 'priceTimeSeries_chart')
         .attr('width', drawParams.width)
         .attr('height', drawParams.height)
 
-      if (drawParams.yDomain.length === 0) {
+      if (!hasPriceHistory) {
         drawNullState({
           drawParams,
           chart,
@@ -305,7 +307,6 @@ function drawXAxisLabels(options) {
 
 function drawSeries(options) {
   const {
-
     creationTime,
     drawParams,
     estimatedInitialPrice,
@@ -412,5 +413,5 @@ function drawNullState(options) {
     .attr('y', drawParams.containerHeight / 2)
     .attr('text-anchor', 'middle')
     .attr('dominant-baseline', 'central')
-    .text('No Price History')
+    .text('No Completed Trades')
 }

--- a/src/modules/market/containers/market-outcomes-chart.js
+++ b/src/modules/market/containers/market-outcomes-chart.js
@@ -12,6 +12,7 @@ const mapStateToProps = (state, ownProps) => {
     maxPrice = createBigNumber(1),
     minPrice = createBigNumber(0),
     outcomes = [],
+    volume = { formatted: '0' },
   } = selectMarket(ownProps.marketId)
 
 
@@ -26,6 +27,7 @@ const mapStateToProps = (state, ownProps) => {
     maxPrice: maxPrice.toNumber(),
     minPrice: minPrice.toNumber(),
     outcomes,
+    hasPriceHistory: volume.formatted !== '0',
   }
 }
 


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/augur/story/12151)

noticed volume doesn't update so changed `loadMarketsInfoIfNotLoaded` to `loadMarketsInfo` instead of having to update outcome volume and market volume on local state, I think it would take lots of code to update both, since volume comes from augur-node on market info.


## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [x] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
