### PR TITLE
johndanz/ch12576/trade-page-does-not-populate-if-directly

### DIFF
--- a/src/modules/market/components/market-view/market-view.jsx
+++ b/src/modules/market/components/market-view/market-view.jsx
@@ -79,7 +79,7 @@ export default class MarketView extends Component {
         nextProps.isConnected &&
         nextProps.loadingState === null &&
         !!nextProps.marketId &&
-          nextProps.marketId !== marketId
+          (nextProps.marketId !== marketId || nextProps.marketType === undefined)
       )
     ) {
       nextProps.loadFullMarket(nextProps.marketId)


### PR DESCRIPTION
This fixes an issue where navigating directly to the market page would fail to load the market sometimes. Just added a check to also load market details if the marketType is undefined, which would indicate we don't have the market data loaded properly yet. 

https://app.clubhouse.io/augur/story/12576/trade-page-does-not-populate-if-directly-navigated-to-without-logging-in