### PR TITLE
integrate AirSwap widget

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -98,6 +98,9 @@
         new google.translate.TranslateElement({pageLanguage: 'en', layout: google.translate.TranslateElement.FloatPosition.TOP_LEFT, multilanguagePage: true}, 'google_translate_element');}</script>
     <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
+    <!-- AirSwap Widget -->
+    <script src="//cdn.airswap.io/gallery/airswap-trader.js" defer=""></script>
+
     <!-- Google Analytics -->
     <script src="//www.google-analytics.com/analytics.js" defer=""></script>
 

--- a/src/modules/account/components/account-deposit/account-deposit.jsx
+++ b/src/modules/account/components/account-deposit/account-deposit.jsx
@@ -9,6 +9,20 @@ import { Deposit as DepositIcon, Copy as CopyIcon } from 'modules/common/compone
 
 import Styles from 'modules/account/components/account-deposit/account-deposit.styles'
 
+function airSwapOnClick(e) {
+  e.preventDefault()
+  window.AirSwap.Trader.render({
+    mode: 'buy',
+    token: '0xe94327d07fc17907b4db788e5adf2ed424addff6',
+    onCancel() {
+      console.info('AirSwap trade cancelled')
+    },
+    onComplete(txid) {
+      console.info('AirSwap complete', txid)
+    },
+  }, document.getElementById('app'))
+}
+
 function shapeShiftOnClick(e) {
   e.preventDefault()
   const link=e.target.value
@@ -26,11 +40,13 @@ export default class AccountDeposit extends Component {
 
   render() {
     const { address } = this.props
+    const noFeeTextStyle = { 'font-weight': '400' }
     const styleQR = {
       height: 'auto',
       width: '100%',
     }
-    let shapeShiftConverter = <a href="https://shapeshift.io">Use Shapeshift</a>
+    let airSwapConverter = <a href="" onClick={e => airSwapOnClick(e)}> Use AirSwap <span style={noFeeTextStyle}>(no fees)</span> </a>
+    let shapeShiftConverter = <a href="https://shapeshift.io" rel="noopener noreferrer" target="_blank">Use Shapeshift</a>
     if (parseInt(augur.rpc.getNetworkID(), 10) === 1) {
       shapeShiftConverter = (
         <div className={Styles.AccountDeposit__shapeShiftButton}>
@@ -48,6 +64,16 @@ export default class AccountDeposit extends Component {
           </button>
         </div>
       )
+      airSwapConverter = (
+        <div className={Styles.AccountDeposit__shapeShiftButton}>
+          <button
+            onClick={e => airSwapOnClick(e)}
+            value={'https://shapeshift.io/shifty.html?destination=' + address + '&output=REP'}
+          >
+            AirSwap to REP <span style={noFeeTextStyle}>(no fees)</span>
+          </button>
+        </div>
+      )
     }
 
     return (
@@ -61,6 +87,8 @@ export default class AccountDeposit extends Component {
             <p>
               DO NOT send real ETH or REP to this account. Augur is currently on Ethereum&#39;s Rinkeby testnet.
             </p>
+            {airSwapConverter}
+            <div />
             {shapeShiftConverter}
           </div>
           <div className={Styles.AccountDeposit__address}>

--- a/src/modules/account/components/account-deposit/account-deposit.jsx
+++ b/src/modules/account/components/account-deposit/account-deposit.jsx
@@ -68,7 +68,6 @@ export default class AccountDeposit extends Component {
         <div className={Styles.AccountDeposit__shapeShiftButton}>
           <button
             onClick={e => airSwapOnClick(e)}
-            value={'https://shapeshift.io/shifty.html?destination=' + address + '&output=REP'}
           >
             AirSwap to REP <span style={noFeeTextStyle}>(no fees)</span>
           </button>

--- a/src/modules/account/components/account-deposit/account-deposit.jsx
+++ b/src/modules/account/components/account-deposit/account-deposit.jsx
@@ -10,7 +10,7 @@ import { Deposit as DepositIcon, Copy as CopyIcon } from 'modules/common/compone
 import Styles from 'modules/account/components/account-deposit/account-deposit.styles'
 
 function airSwapOnClick(e) {
-  const env = parseInt(augur.rpc.getNetworkID(), 10) === 1 ? 'mainnet' : 'sandbox'
+  const env = parseInt(augur.rpc.getNetworkID(), 10) === 1 ? 'production' : 'sandbox'
   e.preventDefault()
 
   // The widget will offer swaps for REP <-> ETH on mainnet
@@ -18,7 +18,7 @@ function airSwapOnClick(e) {
   window.AirSwap.Trader.render({
     env,
     mode: 'buy',
-    token: env === 'mainnet' ? '0xe94327d07fc17907b4db788e5adf2ed424addff6' : '0xcc1cbd4f67cceb7c001bd4adf98451237a193ff8',
+    token: env === 'production' ? '0xe94327d07fc17907b4db788e5adf2ed424addff6' : '0xcc1cbd4f67cceb7c001bd4adf98451237a193ff8',
     onCancel() {
       console.info('AirSwap trade cancelled')
     },

--- a/src/modules/account/components/account-deposit/account-deposit.jsx
+++ b/src/modules/account/components/account-deposit/account-deposit.jsx
@@ -10,10 +10,15 @@ import { Deposit as DepositIcon, Copy as CopyIcon } from 'modules/common/compone
 import Styles from 'modules/account/components/account-deposit/account-deposit.styles'
 
 function airSwapOnClick(e) {
+  const env = parseInt(augur.rpc.getNetworkID(), 10) === 1 ? 'mainnet' : 'sandbox'
   e.preventDefault()
+
+  // The widget will offer swaps for REP <-> ETH on mainnet
+  // It can still be tested on rinkeby, but only AST <-> ETH is offered
   window.AirSwap.Trader.render({
+    env,
     mode: 'buy',
-    token: '0xe94327d07fc17907b4db788e5adf2ed424addff6',
+    token: env === 'mainnet' ? '0xe94327d07fc17907b4db788e5adf2ed424addff6' : '0xcc1cbd4f67cceb7c001bd4adf98451237a193ff8',
     onCancel() {
       console.info('AirSwap trade cancelled')
     },

--- a/src/modules/account/components/account-deposit/account-deposit.styles.less
+++ b/src/modules/account/components/account-deposit/account-deposit.styles.less
@@ -74,6 +74,7 @@
     color: @color-purple;
     font-weight: 500;
     margin-bottom: 15px;
+    text-align: left;
   }
 }
 


### PR DESCRIPTION
This PR implements the AirSwap widget, which allows users to swap ETH for REP atomically with zero fees. Users just pay the gas cost of the transaction. 

I built Augur locally for development, but I also tested the integration by performing a swap on the Ethereum main net. I accomplished this by doing a little DOM hacking with the Chrome inspector. You can see how I tested it in this short screencast:

https://streamable.com/c99ay

Please let me know if there are any adjustments you'd like on this PR. We are big fans of Augur, and very excited for the main net launch! AirSwap also has some [developer resources](https://github.com/airswap/developers) if you're interested in further collaboration down the road.