### PR TITLE
don't need to call updateLoggedTransactions here, we get order inform…

### DIFF
--- a/src/modules/events/actions/log-handlers.js
+++ b/src/modules/events/actions/log-handlers.js
@@ -22,6 +22,7 @@ import { getReportingFees } from 'modules/portfolio/actions/get-reporting-fees'
 import { loadMarketsInfoIfNotLoaded } from 'src/modules/markets/actions/load-markets-info-if-not-loaded'
 import { loadMarketsInfo } from 'src/modules/markets/actions/load-markets-info'
 import { loadUnclaimedFees } from 'modules/markets/actions/load-unclaimed-fees'
+import { loadFundingHistory } from 'modules/account/actions/load-funding-history'
 
 export const handleMarketStateLog = log => (dispatch) => {
   dispatch(loadMarketsInfo([log.marketId], () => {
@@ -56,7 +57,7 @@ export const handleTokensTransferredLog = log => (dispatch, getState) => {
   const { address } = getState().loginAccount
   const isStoredTransaction = log.from === address || log.to === address
   if (isStoredTransaction) {
-    dispatch(updateLoggedTransactions(log))
+    dispatch(loadFundingHistory())
   }
 }
 

--- a/src/modules/events/actions/log-handlers.js
+++ b/src/modules/events/actions/log-handlers.js
@@ -80,7 +80,6 @@ export const handleOrderCreatedLog = log => (dispatch, getState) => {
   dispatch(loadMarketsInfoIfNotLoaded([log.marketId]))
   const isStoredTransaction = log.orderCreator === getState().loginAccount.address
   if (isStoredTransaction) {
-    dispatch(updateLoggedTransactions(log))
     dispatch(updateOrder(log, true))
     dispatch(loadAccountTrades({ marketId: log.marketId }))
   }
@@ -95,7 +94,6 @@ export const handleOrderCanceledLog = log => (dispatch, getState) => {
   if (escapeHatchModalShowing) return
   if (isStoredTransaction) {
     if (!log.removed) dispatch(removeCanceledOrder(log.orderId))
-    dispatch(updateLoggedTransactions(log))
     dispatch(updateOrder(log, false))
     dispatch(loadAccountTrades({ marketId: log.marketId }))
   }
@@ -108,7 +106,6 @@ export const handleOrderFilledLog = log => (dispatch, getState) => {
   const isStoredTransaction = log.filler === address || log.creator === address
   const popularity = log.removed ? new BigNumber(log.amount, 10).negated().toFixed() : log.amount
   if (isStoredTransaction) {
-    dispatch(updateLoggedTransactions(log))
     dispatch(updateOutcomePrice(log.marketId, log.outcome, new BigNumber(log.price, 10)))
     dispatch(updateMarketCategoryPopularity(log.market, popularity))
     dispatch(updateOrder(log, false))


### PR DESCRIPTION
…ation from augur-node getters which are called as part of loadAccountTrades


[ch task for timestamp](https://app.clubhouse.io/augur/story/12842/timestamp-on-tx-pg-showing-random-date)

[ch task for dup orders](https://app.clubhouse.io/augur/story/12843/orders-showing-duped-on-tx-pg-see-screenshot)