### PR TITLE
Tomhaile/ch12948/depth chart not rendering correctly for scalar

### DIFF
--- a/src/modules/market/components/market-outcome-charts--depth/market-outcome-charts--depth.jsx
+++ b/src/modules/market/components/market-outcome-charts--depth/market-outcome-charts--depth.jsx
@@ -575,26 +575,17 @@ function drawLines(options) {
       .attr('d', depthLine)
   })
 
-  const areaBid = d3.area()
-    .curve(d3.curveStepBefore)
-    .x0(d => drawParams.xScale(d[1]))
-    .x1(d => d3.extent(drawParams.xDomain)[0])
-    .y(d => drawParams.yScale(d[0]))
-
-  const areaAsk = d3.area()
+  const area = d3.area()
     .curve(d3.curveStepBefore)
     .y0(d => drawParams.yScale(drawParams.yDomain[0]))
     .y1(d => drawParams.yScale(d[0]))
     .x(d => drawParams.xScale(d[1]))
 
-
   Object.keys(marketDepth).forEach((side) => {
-    let func = areaAsk
-    if (side === 'bids') func = areaBid
     depthChart.append('path')
       .data([marketDepth[side]])
       .classed(`filled-subtle-${side}`, true)
-      .attr('d', func)
+      .attr('d', area)
   })
 }
 

--- a/src/modules/market/components/market-outcome-charts--depth/market-outcome-charts--depth.jsx
+++ b/src/modules/market/components/market-outcome-charts--depth/market-outcome-charts--depth.jsx
@@ -662,7 +662,7 @@ function attachHoverClickHandlers(options) {
         createBigNumber(orderPrice).lte(marketMax)
       ) {
         updateSelectedOrderProperties({
-          selectedNav: orderPrice > orderBookKeys.mid ? BUY : SELL,
+          selectedNav: createBigNumber(orderPrice).gt(orderBookKeys.mid) ? BUY : SELL,
           orderPrice: nearestFillingOrder[1],
           orderQuantity: nearestFillingOrder[0],
         })

--- a/src/modules/market/components/market-outcome-charts--depth/market-outcome-charts--depth.jsx
+++ b/src/modules/market/components/market-outcome-charts--depth/market-outcome-charts--depth.jsx
@@ -282,8 +282,8 @@ export default class MarketOutcomeDepth extends Component {
         d3.select('#crosshairs').style('display', null)
 
         if (
-          hoveredPrice > marketMin &&
-          hoveredPrice < marketMax
+          createBigNumber(hoveredPrice).gte(marketMin) &&
+          createBigNumber(hoveredPrice).lte(marketMax)
         ) {
           d3.select('#crosshairX')
             .attr('x1', xScale(nearestFillingOrder[1]))
@@ -653,13 +653,13 @@ function attachHoverClickHandlers(options) {
     })
     .on('click', () => {
       const mouse = d3.mouse(d3.select('#depth_chart').node())
-      const orderPrice = drawParams.yScale.invert(mouse[1]).toFixed(fixedPrecision)
+      const orderPrice = drawParams.xScale.invert(mouse[1]).toFixed(fixedPrecision)
       const nearestFillingOrder = nearestCompletelyFillingOrder(orderPrice, marketDepth)
 
       if (
         nearestFillingOrder != null &&
-        orderPrice > marketMin &&
-        orderPrice < marketMax
+        createBigNumber(orderPrice).gte(marketMin) &&
+        createBigNumber(orderPrice).lte(marketMax)
       ) {
         updateSelectedOrderProperties({
           selectedNav: orderPrice > orderBookKeys.mid ? BUY : SELL,


### PR DESCRIPTION
(depth chart weirdness)[https://app.clubhouse.io/augur/story/12948/depth-chart-not-rendering-correctly-for-scalar]


Create scalar market with range of 2018 to 10000
create bid orders and verify the shading is correct.

Also click on order in depth chart, verify it populates trading chart.