### PR TITLE
Pgebheim/ch13192/have augur ui build before npm publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "augur-ui",
-  "version": "3.39.3",
+  "version": "3.39.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "augur-ui",
-  "version": "3.39.2",
+  "version": "3.39.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "augur-ui",
-  "version": "3.39.4",
+  "version": "3.39.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "augur-ui",
-  "version": "3.39.3",
+  "version": "3.39.4",
   "description": "Augur UI",
   "author": "The Augur Developers <team@augur.net>",
   "license": "AAL",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "docker:spin-up": "npm run docker:pull && npm run docker:start",
     "docker:start": "AUGUR_CORE_VERSION=$(npm explore augur.js -- npm run --silent core:version) docker-compose up",
     "docker:pull": "AUGUR_CORE_VERSION=$(npm explore augur.js -- npm run --silent core:version) docker-compose pull",
-    "docker:spin-down": "AUGUR_CORE_VERSION=$(npm explore augur.js -- npm run --silent core:version) docker-compose down"
+    "docker:spin-down": "AUGUR_CORE_VERSION=$(npm explore augur.js -- npm run --silent core:version) docker-compose down",
+    "version": "npm run build"
   },
   "dependencies": {
     "async": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "augur-ui",
-  "version": "3.39.2",
+  "version": "3.39.3",
   "description": "Augur UI",
   "author": "The Augur Developers <team@augur.net>",
   "license": "AAL",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "augur-ui",
-  "version": "3.39.4",
+  "version": "3.39.5",
   "description": "Augur UI",
   "author": "The Augur Developers <team@augur.net>",
   "license": "AAL",


### PR DESCRIPTION
[added `npm run build` for when we bump npm version](https://app.clubhouse.io/augur/story/13192/have-augur-ui-build-before-npm-publishing)

fixed version should be `3.39.5`

https://www.npmjs.com/package/augur-ui