### PR TITLE
johndanz/ch13423/create-new-market-form-allows-user-to-create

### DIFF
--- a/src/modules/create-market/components/create-market-form-define/create-market-form-define.jsx
+++ b/src/modules/create-market/components/create-market-form-define/create-market-form-define.jsx
@@ -16,7 +16,6 @@ export default class CreateMarketDefine extends Component {
 
   static propTypes = {
     categories: PropTypes.array.isRequired,
-    isBugBounty: PropTypes.bool.isRequired,
     isValid: PropTypes.func.isRequired,
     newMarket: PropTypes.object.isRequired,
     updateNewMarket: PropTypes.func.isRequired,
@@ -112,7 +111,6 @@ export default class CreateMarketDefine extends Component {
 
   render() {
     const {
-      isBugBounty,
       newMarket,
       validateField,
       keyPressed,
@@ -128,11 +126,6 @@ export default class CreateMarketDefine extends Component {
 
     return (
       <ul className={StylesForm.CreateMarketForm__fields}>
-        {isBugBounty &&
-        <div className={Styles.CreateMarketDefine_bugBountyDisclaimer}>
-          Augur is currently in the bug bounty phase. Market creation is disabled, but this page is available for users to test out up until the final step.
-        </div>
-        }
         <li className={Styles.CreateMarketDefine__question}>
           <label htmlFor="cm__input--desc">
             <span>Market Question</span>

--- a/src/modules/create-market/components/create-market-form-review/create-market-form-review.jsx
+++ b/src/modules/create-market/components/create-market-form-review/create-market-form-review.jsx
@@ -76,7 +76,6 @@ export default class CreateMarketReview extends Component {
           validityBond: formatEtherEstimate(marketCreationCostBreakdown.validityBond),
         }, () => {
           const s = this.state
-
           let insufficientFundsString = ''
 
           if (s.validityBond) {
@@ -84,11 +83,10 @@ export default class CreateMarketReview extends Component {
             const gasCost = getValue(s, 'gasCost.formattedValue')
             const designatedReportNoShowReputationBond = getValue(s, 'designatedReportNoShowReputationBond.formattedValue')
             insufficientFundsString = insufficientFunds(validityBond, gasCost, designatedReportNoShowReputationBond, createBigNumber(availableEth, 10), createBigNumber(availableRep, 10))
+            updateStateValue('insufficientFunds', (insufficientFundsString !== ''))
+
+            this.setState({ insufficientFundsString })
           }
-
-          updateStateValue('insufficientFunds', (insufficientFundsString !== ''))
-
-          this.setState({ insufficientFundsString })
         })
       })
     })
@@ -97,8 +95,24 @@ export default class CreateMarketReview extends Component {
   render() {
     const {
       newMarket,
+      availableEth,
+      availableRep,
+      updateStateValue,
     } = this.props
     const s = this.state
+
+    if (s.validityBond) {
+      const validityBond = getValue(s, 'validityBond.formattedValue')
+      const gasCost = getValue(s, 'gasCost.formattedValue')
+      const designatedReportNoShowReputationBond = getValue(s, 'designatedReportNoShowReputationBond.formattedValue')
+      const insufficientFundsString = insufficientFunds(validityBond, gasCost, designatedReportNoShowReputationBond, createBigNumber(availableEth, 10), createBigNumber(availableRep, 10))
+
+      if (s.insufficientFundsString !== insufficientFundsString) {
+        updateStateValue('insufficientFunds', (insufficientFundsString !== ''))
+        this.setState({ insufficientFundsString })
+      }
+    }
+
 
     return (
       <article className={StylesForm.CreateMarketForm__fields}>

--- a/src/modules/create-market/components/create-market-form/create-market-form.jsx
+++ b/src/modules/create-market/components/create-market-form/create-market-form.jsx
@@ -40,6 +40,7 @@ export default class CreateMarketForm extends Component {
       pages: ['Define', 'Outcome', 'Resolution', 'Liquidity', 'Review'],
       liquidityState: {},
       awaitingSignature: false,
+      insufficientFunds: false,
     }
 
     this.prevPage = this.prevPage.bind(this)
@@ -49,6 +50,7 @@ export default class CreateMarketForm extends Component {
     this.isValid = this.isValid.bind(this)
     this.keyPressed = this.keyPressed.bind(this)
     this.updateState = this.updateState.bind(this)
+    this.updateStateValue = this.updateStateValue.bind(this)
   }
 
   componentWillReceiveProps(nextProps) {
@@ -89,6 +91,10 @@ export default class CreateMarketForm extends Component {
 
   updateState(newState) {
     this.setState(newState)
+  }
+
+  updateStateValue(property, value) {
+    this.setState({ [property]: value })
   }
 
   validateField(fieldName, value, maxLength) {
@@ -259,6 +265,7 @@ export default class CreateMarketForm extends Component {
                 availableEth={availableEth}
                 availableRep={availableRep}
                 universe={universe}
+                updateStateValue={this.updateStateValue}
                 keyPressed={this.keyPressed}
               />
             }
@@ -282,7 +289,7 @@ export default class CreateMarketForm extends Component {
                 { newMarket.currentStep === 4 &&
                   <button
                     className={Styles.CreateMarketForm__submit}
-                    disabled={isBugBounty || s.awaitingSignature}
+                    disabled={isBugBounty || s.insufficientFunds || s.awaitingSignature}
                     onClick={(e) => {
                       this.setState({ awaitingSignature: true }, () => {
                         submitNewMarket(newMarket, history, (err, market) => {

--- a/src/modules/create-market/components/create-market-form/create-market-form.jsx
+++ b/src/modules/create-market/components/create-market-form/create-market-form.jsx
@@ -22,7 +22,6 @@ export default class CreateMarketForm extends Component {
     categories: PropTypes.array.isRequired,
     currentTimestamp: PropTypes.number.isRequired,
     history: PropTypes.object.isRequired,
-    isBugBounty: PropTypes.bool.isRequired,
     isMobileSmall: PropTypes.bool.isRequired,
     meta: PropTypes.object,
     newMarket: PropTypes.object.isRequired,
@@ -40,7 +39,7 @@ export default class CreateMarketForm extends Component {
       pages: ['Define', 'Outcome', 'Resolution', 'Liquidity', 'Review'],
       liquidityState: {},
       awaitingSignature: false,
-      insufficientFunds: false,
+      insufficientFunds: true,
     }
 
     this.prevPage = this.prevPage.bind(this)
@@ -191,7 +190,6 @@ export default class CreateMarketForm extends Component {
       categories,
       currentTimestamp,
       history,
-      isBugBounty,
       isMobileSmall,
       meta,
       newMarket,
@@ -217,7 +215,6 @@ export default class CreateMarketForm extends Component {
                 validateField={this.validateField}
                 categories={categories}
                 isValid={this.isValid}
-                isBugBounty={isBugBounty}
                 keyPressed={this.keyPressed}
               />
             }
@@ -289,7 +286,7 @@ export default class CreateMarketForm extends Component {
                 { newMarket.currentStep === 4 &&
                   <button
                     className={Styles.CreateMarketForm__submit}
-                    disabled={isBugBounty || s.insufficientFunds || s.awaitingSignature}
+                    disabled={s.insufficientFunds || s.awaitingSignature}
                     onClick={(e) => {
                       this.setState({ awaitingSignature: true }, () => {
                         submitNewMarket(newMarket, history, (err, market) => {

--- a/src/modules/create-market/components/create-market-view/create-market-view.jsx
+++ b/src/modules/create-market/components/create-market-view/create-market-view.jsx
@@ -31,7 +31,6 @@ const CreateMarketView = p => (
         isMobileSmall={p.isMobileSmall}
         history={p.history}
         universe={p.universe}
-        isBugBounty={p.isBugBounty}
         currentTimestamp={p.currentTimestamp}
         estimateSubmitNewMarket={p.estimateSubmitNewMarket}
       />

--- a/src/modules/create-market/containers/create-market.js
+++ b/src/modules/create-market/containers/create-market.js
@@ -23,7 +23,6 @@ const mapStateToProps = state => ({
   footerHeight: state.footerHeight,
   categories: selectCategories(state),
   isMobileSmall: state.isMobileSmall,
-  isBugBounty: state.env['bug-bounty'],
   currentTimestamp: selectCurrentTimestamp(state),
 })
 


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/13423/create-new-market-form-allows-user-to-create-tx-even-though-they-don-t-have-rep

heads up, didn't test this cuz i just thought of it, but get to the review page with like no rep lets say. then use a 2nd account to transfer some rep to that first account (in another browser or something, don't leave the page with account 1) and confirm that if your balance updates the error also updates, goes away, and the button becomes clickable. 