### PR TITLE
added sorting to outcomes/open orders, sort by id

### DIFF
--- a/src/modules/market/selectors/market.js
+++ b/src/modules/market/selectors/market.js
@@ -298,7 +298,7 @@ export function assembleMarket(
         outcome.priceTimeSeries = selectPriceTimeSeries(outcome, marketPriceHistory)
 
         return outcome
-      })
+      }).sort((a, b) => (parseInt(a.id, 10) - parseInt(b.id, 10)))
 
       market.tags = (market.tags || []).filter(tag => !!tag)
 

--- a/src/modules/user-open-orders/selectors/open-orders.js
+++ b/src/modules/user-open-orders/selectors/open-orders.js
@@ -34,15 +34,6 @@ const hasOpenOrdersInMarket = (market) => {
   return false
 }
 
-
-function getHighestPrice(outcome) {
-  return outcome.userOpenOrders.reduce((p, order) => comparePrice(p, order), 0)
-}
-
-function comparePrice(p, order) {
-  return p > order.avgPrice.value ? p : order.avgPrice.value
-}
-
 export function sortOpenOrders(market) {
   if (!market) return market
   const numOutcomes = market.outcomes.length
@@ -50,7 +41,7 @@ export function sortOpenOrders(market) {
   const outcomes = market.outcomes.filter(outcome => outcome.userOpenOrders && outcome.userOpenOrders.length > 0)
   if (outcomes.length < 2) return market
 
-  market.outcomes = market.outcomes.sort((o1, o2) => getHighestPrice(o2) - getHighestPrice(o1))
+  market.outcomes = market.outcomes.sort((o1, o2) => (parseInt(o1.id, 10) - parseInt(o2.id, 10)))
   return market
 }
 


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/13405/in-portfolio-page-under-my-positions-order-of-outcome-reorders-itself

https://app.clubhouse.io/augur/story/13266/colors-of-categorial-outcomes-are-off

can see it reordering on master when you make orders and highest bids change