### PR TITLE
Moving the AirSwap JavaScript tag into document head

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -67,6 +67,10 @@
       }
     </script>
 
+    <!-- AirSwap Widget -->
+    <script src="//cdn.airswap.io/gallery/airswap-trader.js" defer=""></script>
+
+    <!-- TREZOR Connect API -->
     <script src="https://connect.trezor.io/4/connect.js"></script>
   </head>
   <body>
@@ -97,9 +101,6 @@
       function googleTranslateElementInit() {
         new google.translate.TranslateElement({pageLanguage: 'en', layout: google.translate.TranslateElement.FloatPosition.TOP_LEFT, multilanguagePage: true}, 'google_translate_element');}</script>
     <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
-
-    <!-- AirSwap Widget -->
-    <script src="//cdn.airswap.io/gallery/airswap-trader.js" defer=""></script>
 
     <!-- Google Analytics -->
     <script src="//www.google-analytics.com/analytics.js" defer=""></script>


### PR DESCRIPTION
Following up on #1888. The AirSwap Widget is not displaying in production because the JavaScript tag was placed within the conditional on line 80. This commit moves it into the document head above the TREZOR Connect API script.