### PR TITLE
store connection config passed in through args

### DIFF
--- a/src/modules/app/actions/init-augur.js
+++ b/src/modules/app/actions/init-augur.js
@@ -177,9 +177,22 @@ export function initAugur(history, overrides, callback = logError) {
     const env = networkConfig[`${process.env.ETHEREUM_NETWORK}`]
 
     env.useWeb3Transport = overrides.useWeb3Transport
+
+    if (windowRef.localStorage && windowRef.localStorage.getItem) {
+      env['augur-node'] = windowRef.localStorage.getItem('augur-node') || env['augur-node']
+      env['ethereum-node'].http = windowRef.localStorage.getItem('ethereum-node-http') || env['ethereum-node'].http
+      env['ethereum-node'].ws = windowRef.localStorage.getItem('ethereum-node-ws') || env['ethereum-node'].ws
+    }
+
     env['augur-node'] = overrides.augur_node === undefined ? env['augur-node'] : overrides.augur_node
     env['ethereum-node'].http = overrides.ethereum_node_http === undefined ? env['ethereum-node'].http : overrides.ethereum_node_http
     env['ethereum-node'].ws = overrides.ethereum_node_ws === undefined ? env['ethereum-node'].ws : overrides.ethereum_node_ws
+
+    if (windowRef.localStorage && windowRef.localStorage.setItem) {
+      windowRef.localStorage.setItem('augur-node', env['augur-node'])
+      windowRef.localStorage.setItem('ethereum-node-http', env['ethereum-node'].http)
+      windowRef.localStorage.setItem('ethereum-node-ws', env['ethereum-node'].ws)
+    }
 
     dispatch(updateEnv(env))
     connectAugur(history, env, true, callback)(dispatch, getState)


### PR DESCRIPTION
This is to prevent the issue that commonly occurs for a hosted variant of the UI where on refresh the baked in env config is used instead of what was originally passed when opening the UI