### PR TITLE
Mattbullock/ch13853/need to put blocks remaining and or highest

### DIFF
--- a/src/modules/app/actions/get-augur-node-network-id.js
+++ b/src/modules/app/actions/get-augur-node-network-id.js
@@ -5,7 +5,7 @@ import logError from 'utils/log-error'
 export const getAugurNodeNetworkId = (callback = logError) => (dispatch, getState) => {
   const { connection } = getState()
   if (connection.augurNodeNetworkId != null) return callback(null, connection.augurNodeNetworkId)
-  augur.augurNode.getContractAddresses((err, contractAddresses) => {
+  augur.augurNode.getSyncData((err, contractAddresses) => {
     if (err) return callback(err)
     const augurNodeNetworkId = contractAddresses.net_version
     dispatch(updateAugurNodeNetworkId(augurNodeNetworkId))

--- a/src/modules/auth/helpers/is-augurjs-versions-equal.js
+++ b/src/modules/auth/helpers/is-augurjs-versions-equal.js
@@ -2,7 +2,7 @@ import { augur } from 'services/augurjs'
 
 export default function isAugurJSVersionsEqual() {
   return new Promise((resolve) => {
-    augur.augurNode.getContractAddresses((err, res) => {
+    augur.augurNode.getSyncData((err, res) => {
       if (err || (res.version !== augur.version)) {
         resolve({
           isEqual: false,

--- a/src/modules/market/components/market-outcome-charts--depth/market-outcome-charts--depth.jsx
+++ b/src/modules/market/components/market-outcome-charts--depth/market-outcome-charts--depth.jsx
@@ -538,7 +538,7 @@ function drawLines(options) {
   //  Fills
   const subtleGradientBid = chartDefs.append('linearGradient')
     .attr('id', 'subtleGradientBid')
-    .attr('gradientTransform', 'rotate(90)')
+    .attr('gradientTransform', 'rotate(120)')
 
   subtleGradientBid.append('stop')
     .attr('class', 'stop-bottom')
@@ -550,7 +550,7 @@ function drawLines(options) {
 
   const subtleGradientAsk = chartDefs.append('linearGradient')
     .attr('id', 'subtleGradientAsk')
-    .attr('gradientTransform', 'rotate(90)')
+    .attr('gradientTransform', 'rotate(270)')
 
   subtleGradientAsk.append('stop')
     .attr('class', 'stop-bottom-ask')
@@ -583,7 +583,7 @@ function drawLines(options) {
 
   Object.keys(marketDepth).forEach((side) => {
     depthChart.append('path')
-      .data([marketDepth[side]])
+      .data([marketDepth[side]].reverse())
       .classed(`filled-subtle-${side}`, true)
       .attr('d', area)
   })

--- a/test/app/actions/get-augur-node-network-id.js
+++ b/test/app/actions/get-augur-node-network-id.js
@@ -26,7 +26,7 @@ describe('modules/app/actions/get-augur-node-network-id.js', () => {
     stub: {
       augur: {
         augurNode: {
-          getContractAddresses: () => assert.fail(),
+          getSyncData: () => assert.fail(),
         },
       },
     },
@@ -44,7 +44,7 @@ describe('modules/app/actions/get-augur-node-network-id.js', () => {
     stub: {
       augur: {
         augurNode: {
-          getContractAddresses: callback => callback(null, { net_version: '4' }),
+          getSyncData: callback => callback(null, { net_version: '4' }),
         },
       },
     },

--- a/test/auth/helpers/is-augurjs-versions-equal-test.js
+++ b/test/auth/helpers/is-augurjs-versions-equal-test.js
@@ -8,12 +8,12 @@ describe('modules/auth/helpers/is-augurjs-versions-equal', () => {
   })
 
   test({
-    description: `Should handle an error from augurNode.getContractAddresses, and return false`,
+    description: `Should handle an error from augurNode.getSyncData, and return false`,
     assertions: () => {
       isAugurJSVersionsEqualAPI.__Rewire__('augur', {
         version: 'helloWorld',
         augurNode: {
-          getContractAddresses: (cb) => {
+          getSyncData: (cb) => {
             cb({ error: 1000, message: 'Uh-Oh!' })
           },
         },
@@ -34,7 +34,7 @@ describe('modules/auth/helpers/is-augurjs-versions-equal', () => {
       isAugurJSVersionsEqualAPI.__Rewire__('augur', {
         version: 'helloWorld',
         augurNode: {
-          getContractAddresses: (cb) => {
+          getSyncData: (cb) => {
             cb(undefined, { version: 'goodbyeWorld' })
           },
         },
@@ -55,7 +55,7 @@ describe('modules/auth/helpers/is-augurjs-versions-equal', () => {
       isAugurJSVersionsEqualAPI.__Rewire__('augur', {
         version: 'helloWorld',
         augurNode: {
-          getContractAddresses: (cb) => {
+          getSyncData: (cb) => {
             cb(undefined, { version: 'helloWorld' })
           },
         },


### PR DESCRIPTION
CI will fail until augur.js is update to next version.

PR needs to be merged and we need a new version of augur.js

https://github.com/AugurProject/augur.js/pull/462


Need to use next augur.js version, current version is 
  "version": "5.0.0-15",


https://app.clubhouse.io/augur/story/13853/need-to-put-blocks-remaining-and-or-highest-block-in-augur-ui

