### PR TITLE
Remove signatures for unused functions

### DIFF
--- a/packages/augur-core/source/contracts/trading/ITrade.sol
+++ b/packages/augur-core/source/contracts/trading/ITrade.sol
@@ -6,8 +6,6 @@ import 'reporting/IMarket.sol';
 
 
 contract ITrade {
-    function publicBuy(IMarket _market, uint256 _outcome, uint256 _amount, uint256 _price, bytes32 _betterOrderId, bytes32 _worseOrderId, uint256 _tradeGroupID) external returns (bytes32);
-    function publicSell(IMarket _market, uint256 _outcome, uint256 _amount, uint256 _price, bytes32 _betterOrderId, bytes32 _worseOrderId, uint256 _tradeGroupID) external returns (bytes32);
     function publicTrade(Order.TradeDirections _direction, IMarket _market, uint256 _outcome, uint256 _amount, uint256 _price, bytes32 _betterOrderId, bytes32 _worseOrderId, uint256 _tradeGroupID) external returns (bytes32);
     function publicFillBestOrder(Order.TradeDirections _direction, IMarket _market, uint256 _outcome, uint256 _amount, uint256 _price, uint256 _tradeGroupID) external returns (uint256);
     function trade(address _sender, Order.TradeDirections _direction, IMarket _market, uint256 _outcome, uint256 _amount, uint256 _price, bytes32 _betterOrderId, bytes32 _worseOrderId, uint256 _tradeGroupID) internal returns (bytes32);


### PR DESCRIPTION
`publicBuy` & `publicSell` are removed in v2: https://github.com/AugurProject/augur-core/pull/745/files.