### PR TITLE
Fixes docker core tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,7 @@ jobs:
       - bash: |
           set -euo pipefail
           echo "Build SourceBranch: $(Build.SourceBranch)"
+          echo "##vso[task.setVariable variable=AUGUR_CORE]true";
           for f in $(git whatchanged --name-only --pretty="" origin/master..HEAD);
             do
               echo "$f"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,6 +90,7 @@ jobs:
           versionSpec: '10.x'
       - bash: |
           set -euo pipefail
+          echo "##vso[task.setVariable variable=AUGUR_CORE]true";
           for f in $(git whatchanged --name-only --pretty="" origin/master..HEAD);
             do
               echo "$f"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,6 @@ jobs:
       - bash: |
           set -euo pipefail
           echo "Build SourceBranch: $(Build.SourceBranch)"
-          echo "##vso[task.setVariable variable=AUGUR_CORE]true";
           for f in $(git whatchanged --name-only --pretty="" origin/master..HEAD);
             do
               echo "$f"
@@ -90,7 +89,6 @@ jobs:
           versionSpec: '10.x'
       - bash: |
           set -euo pipefail
-          echo "##vso[task.setVariable variable=AUGUR_CORE]true";
           for f in $(git whatchanged --name-only --pretty="" origin/master..HEAD);
             do
               echo "$f"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,8 @@
 variables:
     SOLC_VERSION: v0.4.24
     SOLC_MD5: dc791cd7db87b7df5e47975d222dc5fe
-    CORE_IMAGE_BUILD: augurproject/augur-core:monorepobuild.$(Build.BuildID)
+    AUGUR_CORE_TAG: monorepo.$(Build.BuildID)
+    CORE_IMAGE_BUILD: augurproject/augur-core:$(AUGUR_CORE_TAG)
     CORE_IMAGE_LATEST: augurproject/augur-core:latest
 
 
@@ -100,6 +101,8 @@ jobs:
           set -euo pipefail
           which node
           node --version
+          docker pull $CORE_IMAGE_BUILD
+          docker tag $CORE_IMAGE_BUILD $CORE_IMAGE_LATEST
           if [[ "$TESTS" == "integration:geth" ]]; then
             yarn workspace augur-core docker:run:test:integration:geth;
           elif [[ "$TESTS" == "integration:parity" ]]; then


### PR DESCRIPTION
pulls the augur-core docker tag based on the CI build, then locally tags it as latest as a hack to make sure all the tests run the correct image.