### PR TITLE
remove paranoia code. Easily confirmable post launch (and needs to be)

### DIFF
--- a/packages/augur-core/source/contracts/LegacyReputationToken.sol
+++ b/packages/augur-core/source/contracts/LegacyReputationToken.sol
@@ -1,24 +1,15 @@
 pragma solidity 0.5.4;
 
 import 'ROOT/libraries/IERC820Registry.sol';
-import 'ROOT/libraries/ContractExists.sol';
 import 'ROOT/legacy_reputation/OldLegacyRepToken.sol';
 
 
 contract LegacyReputationToken is OldLegacyReputationToken {
-    using ContractExists for address;
     event FundedAccount(address indexed _universe, address indexed _sender, uint256 _repBalance, uint256 _timestamp);
-
-    address private constant FOUNDATION_REP_ADDRESS = address(0x1985365e9f78359a9B6AD760e32412f4a445E862);
 
     string public constant name = "Reputation";
     string public constant symbol = "REP";
     uint256 public constant decimals = 18;
-
-    constructor() public OldLegacyReputationToken() {
-        // This is to confirm we are not on foundation network
-        require(!FOUNDATION_REP_ADDRESS.exists());
-    }
 
     function initializeERC820(IAugur _augur) public returns (bool) {
         erc820Registry = IERC820Registry(_augur.lookup("ERC820Registry"));

--- a/packages/augur-core/source/contracts/TestNetReputationToken.sol
+++ b/packages/augur-core/source/contracts/TestNetReputationToken.sol
@@ -1,20 +1,14 @@
 pragma solidity 0.5.4;
 
-import 'ROOT/libraries/ContractExists.sol';
 import 'ROOT/reporting/ReputationToken.sol';
 import 'ROOT/IAugur.sol';
 import 'ROOT/reporting/IUniverse.sol';
 
 
 contract TestNetReputationToken is ReputationToken {
-    using ContractExists for address;
-
     uint256 private constant DEFAULT_FAUCET_AMOUNT = 47 ether;
-    address private constant FOUNDATION_REP_ADDRESS = address(0x1985365e9f78359a9B6AD760e32412f4a445E862);
 
     constructor(IAugur _augur, IUniverse _universe, IUniverse _parentUniverse, address _erc820RegistryAddress) ReputationToken(_augur, _universe, _parentUniverse, _erc820RegistryAddress) public {
-        // This is to confirm we are not on foundation network
-        require(!FOUNDATION_REP_ADDRESS.exists());
     }
 
     function faucet(uint256 _amount) public returns (bool) {

--- a/packages/augur-core/source/contracts/TimeControlled.sol
+++ b/packages/augur-core/source/contracts/TimeControlled.sol
@@ -1,21 +1,15 @@
 pragma solidity 0.5.4;
 
 import 'ROOT/ITime.sol';
-import 'ROOT/libraries/ContractExists.sol';
 import 'ROOT/IAugur.sol';
 
 
 contract TimeControlled is ITime {
-    using ContractExists for address;
-
     uint256 private timestamp = 1;
-    address private constant FOUNDATION_REP_ADDRESS = address(0x1985365e9f78359a9B6AD760e32412f4a445E862);
 
     IAugur public augur;
 
     constructor() public {
-        // This is to confirm we are not on foundation network
-        require(!FOUNDATION_REP_ADDRESS.exists());
         timestamp = block.timestamp;
     }
 


### PR DESCRIPTION
This is all we really need to do to support mainnet testing as it turns out.