### PR TITLE
remove `from` before sending transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 ## UI development
 Run the following 4 commands, each in a separate terminal session from the root of the project.
 
-`yarn build -w`
+`yarn; yarn build -w`
 
 ### docker images available
  * `yarn workspace @augurproject/tools docker:geth:pop-15`

--- a/packages/contract-dependencies-ethers/src/ContractDependenciesEthers.ts
+++ b/packages/contract-dependencies-ethers/src/ContractDependenciesEthers.ts
@@ -56,6 +56,8 @@ export class ContractDependenciesEthers implements Dependencies<ethers.utils.Big
     public async submitTransaction(transaction: Transaction<ethers.utils.BigNumber>): Promise<TransactionReceipt> {
         if (!this.signer) throw new Error("Attempting to sign a transaction while not providing a signer");
         // TODO: figure out a way to propagate a warning up to the user in this scenario, we don't currently have a mechanism for error propagation, so will require infrastructure work
+        // TODO: https://github.com/ethers-io/ethers.js/issues/321
+        delete transaction.from;
         const receipt = await (await this.signer.sendTransaction(transaction)).wait();
         // ethers has `status` on the receipt as optional, even though it isn't and never will be undefined if using a modern network (which this is designed for)
         return <TransactionReceipt>receipt


### PR DESCRIPTION
…dme to add yarn before running yarn build

minor doc change to remind devs to run `yarn` at root.

remove `from` before signing tx and sending tx with ethers.