### PR TITLE
removes deprecated npmrc file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-registry=https://pkgs.dev.azure.com/augurproject/_packaging/npmPackages/npm/registry/
-always-auth=true


### PR DESCRIPTION
fixes #2185 

the npmrc was needed for a CI npm task, but that task has been removed.