### PR TITLE
Update sdk login flow for MM/injected web3

### DIFF
--- a/packages/augur-ui/src/assets/styles/_typography_redesign.less
+++ b/packages/augur-ui/src/assets/styles/_typography_redesign.less
@@ -7,6 +7,7 @@
 @roboto-mono: 'roboto mono', sans-serif;
 
 // sizes
+@size-3: 0.1875rem; // 3px
 @size-4: 0.25rem; // 4px
 @size-5: 0.3125rem; // 5px
 @size-6: 0.375rem; // 6px

--- a/packages/augur-ui/src/modules/auth/actions/login-with-injected-web3.ts
+++ b/packages/augur-ui/src/modules/auth/actions/login-with-injected-web3.ts
@@ -1,0 +1,41 @@
+import logError from "utils/log-error";
+import { useUnlockedAccount } from "modules/auth/actions/use-unlocked-account";
+import { windowRef } from "utils/window-ref";
+import { updateSdk } from "modules/auth/actions/update-sdk";
+import { toChecksumAddress } from "ethereumjs-util";
+import { ThunkDispatch } from "redux-thunk";
+import { Action } from "redux";
+import { NodeStyleCallback } from "modules/types";
+import { Web3Provider } from "ethers/providers";
+
+// MetaMask, dapper, Mobile wallets
+export const loginWithInjectedWeb3 = (callback: NodeStyleCallback = logError) => (
+  dispatch: ThunkDispatch<void, any, Action>,
+) => {
+  const failure = () => callback("NOT_SIGNED_IN");
+  const success = async (account: string) => {
+    if (!account) return failure();
+
+    const provider = new Web3Provider(window.web3.currentProvider);
+    const isWeb3 = true;
+
+    const accountObject = {
+      address: account,
+      displayAddress: toChecksumAddress(account),
+      meta: {
+        address: account,
+        signer: provider.getSigner(),
+        accountType: "metaMask", // TODO replace reference with something more general
+        isWeb3,
+      },
+    };
+
+    await dispatch(updateSdk(accountObject, provider));
+    dispatch(useUnlockedAccount(account));
+    callback(null, account);
+  };
+
+  windowRef.ethereum
+    .enable()
+    .then((resolve: Array<string>) => success(resolve[0]), failure);
+};

--- a/packages/augur-ui/src/modules/auth/actions/update-sdk.ts
+++ b/packages/augur-ui/src/modules/auth/actions/update-sdk.ts
@@ -1,0 +1,30 @@
+import logError from "utils/log-error";
+import { LoginAccount } from "modules/types";
+import { augurSdk } from "services/augursdk";
+import { JsonRpcProvider } from "ethers/providers";
+
+export function updateSdk(loginAccount: LoginAccount, injectedProvider: JsonRpcProvider) {
+  return async () => {
+    const { address, meta }  = loginAccount;
+    if (!meta || !address) return;
+
+    if (!augurSdk.sdk) return;
+
+    let { provider } = augurSdk.sdk.dependencies;
+
+    if (injectedProvider) {
+      provider = injectedProvider;
+    }
+
+    try {
+      await augurSdk.makeApi(
+        provider,
+        address,
+        meta.signer,
+        meta.isWeb3,
+      );
+    } catch (error) {
+      logError(error);
+    }
+  };
+}

--- a/packages/augur-ui/src/modules/auth/actions/update-sdk.ts
+++ b/packages/augur-ui/src/modules/auth/actions/update-sdk.ts
@@ -17,6 +17,7 @@ export function updateSdk(loginAccount: LoginAccount, injectedProvider: JsonRpcP
     }
 
     try {
+      await augurSdk.destroy();
       await augurSdk.makeApi(
         provider,
         address,

--- a/packages/augur-ui/src/modules/auth/containers/connect-dropdown.ts
+++ b/packages/augur-ui/src/modules/auth/containers/connect-dropdown.ts
@@ -1,25 +1,25 @@
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
 import ConnectDropdown from "modules/auth/components/connect-dropdown/connect-dropdown";
-import { loginWithMetaMask } from "modules/auth/actions/login-with-metamask";
+import { loginWithInjectedWeb3 } from "modules/auth/actions/login-with-injected-web3";
 import { logout } from "modules/auth/actions/logout";
 import { showEdgeLogin } from "modules/auth/actions/show-edge-login";
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   isMobile: state.appStatus.isMobile,
   isLogged: state.authStatus.isLogged,
   edgeLoading: state.authStatus.edgeLoading,
 });
 
 const mapDispatchToProps = (dispatch, { history }) => ({
-  connectMetaMask: cb => dispatch(loginWithMetaMask(cb)),
+  connectMetaMask: (cb) => dispatch(loginWithInjectedWeb3(cb)),
   logout: () => dispatch(logout()),
-  edgeLoginLink: history => dispatch(showEdgeLogin(history))
+  edgeLoginLink: (history) => dispatch(showEdgeLogin(history)),
 });
 
 export default withRouter(
   connect(
     mapStateToProps,
-    mapDispatchToProps
-  )(ConnectDropdown)
+    mapDispatchToProps,
+  )(ConnectDropdown),
 );

--- a/packages/augur-ui/src/services/augurjs.ts
+++ b/packages/augur-ui/src/services/augurjs.ts
@@ -2,38 +2,62 @@ import Augur from "@augurproject/augur.js";
 import logError from "utils/log-error";
 import { augurSdk } from "services/augursdk";
 import { JsonRpcProvider, Web3Provider } from "ethers/providers";
-import { LoginAccount, NodeStyleCallback, WindowApp, Connection } from "modules/types";
+import { LoginAccount, NodeStyleCallback, Connection, EnvObject } from "modules/types";
+import { windowRef } from "utils/window-ref";
 
-export const connect = async (env: any, loginAccount: LoginAccount, callback: NodeStyleCallback = logError) => {
+// Access a User’s MetaMask/Dapper Account
+async function initInjectedWeb3() {
+  if (typeof window.ethereum === "undefined") {
+    // Handle case where user hasn't installed MetaMask/Dapper.
+    return false;
+  }
+  try {
+    // If a user is logged in to MetaMask/Dapper and has previously approved the dapp,
+    // `ethereum.enable` will return the result of `eth_accounts`.
+    const accounts = await window.ethereum.enable();
+    return accounts;
+  } catch (error) {
+    // Handle error. If the user rejects the request for access, then
+    // `ethereum.enable` will throw an error.
+    return false;
+  }
+}
+
+export const connect = async (env: EnvObject, loginAccount: LoginAccount, callback: NodeStyleCallback = logError) => {
   const connectOptions = {
     augurNode: env["augur-node"],
     ethereumNode: env["ethereum-node"],
     useWeb3Transport: env.useWeb3Transport,
   };
 
-  let provider;
+  let provider = new JsonRpcProvider(env["ethereum-node"].http);;
   let isWeb3 = false;
-  let account;
-  const win: WindowApp = window as WindowApp;
-  if (win.web3 && win.web3.currentProvider) {
-    provider = new Web3Provider(win.web3.currentProvider);
-    account = win.web3.currentProvider.selectedAddress
+  let account = "";
+
+  const bootstrap = async (provider, account, isWeb3) => {
+    await augurSdk.makeApi(provider, account, provider.getSigner(), isWeb3);
+
+    augur.connect(
+      connectOptions,
+      (err: any, connectionInfo: Connection) => {
+        if (err) return callback(err);
+        console.log("connected:", connectionInfo);
+        callback(null, connectionInfo);
+      },
+    );
+  };
+
+  const injectedAccount = await initInjectedWeb3();
+  const loggedInAccount = windowRef.localStorage.getItem("loggedInAccount");
+
+  // Use injected provider if returning User has a unlocked injected account that matches the current logged in account
+  if (injectedAccount && (loggedInAccount === injectedAccount[0])) {
+    provider = new Web3Provider(windowRef.web3.currentProvider);
+    account = windowRef.web3.currentProvider.selectedAddress,
     isWeb3 = true;
-  } else {
-    provider = new JsonRpcProvider(env["ethereum-node"].http);
-    account = loginAccount.address;
   }
 
-  await augurSdk.makeApi(provider, account, provider.getSigner(), isWeb3);
-
-  augur.connect(
-    connectOptions,
-    (err: any, connectionInfo: Connection) => {
-      if (err) return callback(err);
-      console.log("connected:", connectionInfo);
-      callback(null, connectionInfo);
-    },
-  );
+  await bootstrap(provider, account, isWeb3);
 };
 
 export const augur = new Augur();

--- a/packages/augur-ui/src/services/augurjs.ts
+++ b/packages/augur-ui/src/services/augurjs.ts
@@ -4,24 +4,7 @@ import { augurSdk } from "services/augursdk";
 import { JsonRpcProvider, Web3Provider } from "ethers/providers";
 import { LoginAccount, NodeStyleCallback, Connection, EnvObject } from "modules/types";
 import { windowRef } from "utils/window-ref";
-
-// Access a User’s MetaMask/Dapper Account
-async function initInjectedWeb3() {
-  if (typeof window.ethereum === "undefined") {
-    // Handle case where user hasn't installed MetaMask/Dapper.
-    return false;
-  }
-  try {
-    // If a user is logged in to MetaMask/Dapper and has previously approved the dapp,
-    // `ethereum.enable` will return the result of `eth_accounts`.
-    const accounts = await window.ethereum.enable();
-    return accounts;
-  } catch (error) {
-    // Handle error. If the user rejects the request for access, then
-    // `ethereum.enable` will throw an error.
-    return false;
-  }
-}
+import getInjectedWeb3Accounts from "utils/get-injected-web3-accounts";
 
 export const connect = async (env: EnvObject, loginAccount: LoginAccount, callback: NodeStyleCallback = logError) => {
   const connectOptions = {
@@ -47,7 +30,7 @@ export const connect = async (env: EnvObject, loginAccount: LoginAccount, callba
     );
   };
 
-  const injectedAccount = await initInjectedWeb3();
+  const injectedAccount = await getInjectedWeb3Accounts();
   const loggedInAccount = windowRef.localStorage.getItem("loggedInAccount");
 
   // Use injected provider if returning User has a unlocked injected account that matches the current logged in account

--- a/packages/augur-ui/src/utils/get-injected-web3-accounts.ts
+++ b/packages/augur-ui/src/utils/get-injected-web3-accounts.ts
@@ -1,0 +1,17 @@
+// Access a User’s MetaMask/Dapper Account
+export default async function getInjectedWeb3Accounts(): Promise<boolean | Array<string>> {
+  if (typeof window.ethereum === "undefined") {
+    // Handle case where user hasn't installed MetaMask/Dapper.
+    return false;
+  }
+  try {
+    // If a user is logged in to MetaMask/Dapper and has previously approved the dapp,
+    // `ethereum.enable` will return the result of `eth_accounts`.
+    const accounts = await window.ethereum.enable();
+    return accounts;
+  } catch (error) {
+    // Handle error. If the user rejects the request for access, then
+    // `ethereum.enable` will throw an error.
+    return false;
+  }
+}

--- a/packages/augur-ui/src/utils/window-ref.ts
+++ b/packages/augur-ui/src/utils/window-ref.ts
@@ -1,1 +1,3 @@
-export const windowRef = typeof window === "undefined" ? {} : window;
+import { WindowApp } from "modules/types";
+
+export const windowRef: WindowApp = window as WindowApp;


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/2112

- init sdk with the injected provider only if its unlocked and logged in.
- changes around using window.ethereum to retrieve users account so we can respond correctly to locked / disabled wallets
- provide action to update sdk
- wired it up for injected web3 login flow
- tested with MM and dapper