### PR TITLE
add approval modal and call to get approval amount

### DIFF
--- a/packages/augur-ui/src/modules/account/components/transactions.tsx
+++ b/packages/augur-ui/src/modules/account/components/transactions.tsx
@@ -1,14 +1,15 @@
-import React from "react";
+import React from 'react';
 
-import QuadBox from "modules/portfolio/components/common/quad-box";
+import QuadBox from 'modules/portfolio/components/common/quad-box';
 import {
   DepositButton,
   WithdrawButton,
   ViewTransactionsButton,
   REPFaucetButton,
   DAIFaucetButton,
-} from "modules/common/buttons";
-import Styles from "modules/account/components/transactions.styles.less";
+  ApprovalButton,
+} from 'modules/common/buttons';
+import Styles from 'modules/account/components/transactions.styles.less';
 
 interface TransactionsProps {
   isMainnet: boolean;
@@ -17,6 +18,7 @@ interface TransactionsProps {
   deposit: Function;
   withdraw: Function;
   transactions: Function;
+  approval: Function;
 }
 
 export const Transactions = ({
@@ -26,6 +28,7 @@ export const Transactions = ({
   isMainnet,
   repFaucet,
   daiFaucet,
+  approval,
 }: TransactionsProps) => (
   <QuadBox
     title="Transactions"
@@ -48,6 +51,10 @@ export const Transactions = ({
             <DAIFaucetButton action={daiFaucet} />
           </div>
         )}
+        <div>
+          <p>Approve for trading</p>
+          <ApprovalButton action={approval} />
+        </div>
       </div>
     }
   />

--- a/packages/augur-ui/src/modules/account/containers/transactions.ts
+++ b/packages/augur-ui/src/modules/account/containers/transactions.ts
@@ -8,6 +8,7 @@ import {
   MODAL_DAI_FAUCET,
   MODAL_DEPOSIT,
   MODAL_TRANSACTIONS,
+  MODAL_ACCOUNT_APPROVAL
 } from "modules/common/constants";
 import { AppState } from "store";
 import { ThunkDispatch } from "redux-thunk";
@@ -23,6 +24,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({
   deposit: () => dispatch(updateModal({ type: MODAL_DEPOSIT })),
   withdraw: () => dispatch(updateModal({ type: MODAL_WITHDRAW })),
   transactions: () => dispatch(updateModal({ type: MODAL_TRANSACTIONS })),
+  approval: () => dispatch(updateModal({ type: MODAL_ACCOUNT_APPROVAL }))
 });
 
 const TransactionsContainer = connect(

--- a/packages/augur-ui/src/modules/auth/actions/approve-account.ts
+++ b/packages/augur-ui/src/modules/auth/actions/approve-account.ts
@@ -39,6 +39,6 @@ export function approveAccount() {
     const { address, meta } = loginAccount;
     // TODO: when we get design this number will come from modal
     const allowance = createBigNumber(1000000).times(TEN_TO_THE_EIGHTEENTH_POWER);
-    approveToTrade(address, allowance);
+    approveToTrade(allowance);
   };
 }

--- a/packages/augur-ui/src/modules/auth/actions/approve-account.ts
+++ b/packages/augur-ui/src/modules/auth/actions/approve-account.ts
@@ -8,6 +8,9 @@ import { AppState } from "store";
 import { NodeStyleCallback } from "modules/types";
 import { ThunkDispatch, ThunkAction } from "redux-thunk";
 import { Action } from "redux";
+import { approveToTrade } from "modules/contracts/actions/contractCalls";
+import { createBigNumber } from "utils/create-big-number";
+import { TEN_TO_THE_EIGHTEENTH_POWER } from "modules/common/constants";
 
 export function checkAccountAllowance(callback: NodeStyleCallback = logError): ThunkAction<any, any, any, any> {
   return (dispatch: ThunkDispatch<void, any, Action>, getState: () => AppState) => {
@@ -30,31 +33,12 @@ export function checkAccountAllowance(callback: NodeStyleCallback = logError): T
   };
 }
 
-export function approveAccount(
-  onSent: Function = logError,
-  onSuccess: Function = logError
-) {
+export function approveAccount() {
   return (dispatch, getState) => {
     const { loginAccount } = getState();
     const { address, meta } = loginAccount;
-    augur.accounts.approveAugur({
-      meta,
-      address,
-      onSent,
-      onSuccess: res => {
-        dispatch(checkAccountAllowance());
-        onSuccess(null, res);
-      },
-      onFailed: res => {
-        dispatch(
-          updateAlert(res.hash, {
-            id: res.hash,
-            status: "Failed",
-            timestamp: selectCurrentTimestampInSeconds(getState())
-          })
-        );
-        logError(res);
-      }
-    });
+    // TODO: when we get design this number will come from modal
+    const allowance = createBigNumber(1000000).times(TEN_TO_THE_EIGHTEENTH_POWER);
+    approveToTrade(address, allowance);
   };
 }

--- a/packages/augur-ui/src/modules/auth/actions/load-account-data.ts
+++ b/packages/augur-ui/src/modules/auth/actions/load-account-data.ts
@@ -1,34 +1,38 @@
-import { loadAccountDataFromLocalStorage } from "modules/auth/actions/load-account-data-from-local-storage";
-import { updateLoginAccount } from "modules/account/actions/login-account";
-import { checkAccountAllowance } from "modules/auth/actions/approve-account";
-import { loadAccountHistory } from "modules/auth/actions/load-account-history";
-import { updateAssets } from "modules/auth/actions/update-assets";
-import { loadReportingWindowBounds } from "modules/reports/actions/load-reporting-window-bounds";
-import { windowRef } from "utils/window-ref";
-import getValue from "utils/get-value";
-import logError from "utils/log-error";
-import { loadDesignatedReporterMarkets } from "modules/reports/actions/load-designated-reporter-markets";
-import { loadDisputing } from "modules/reports/actions/load-disputing";
-import { loadGasPriceInfo } from "modules/app/actions/load-gas-price-info";
-import { getReportingFees } from "modules/reports/actions/get-reporting-fees";
-import { ACCOUNT_TYPES } from "modules/common/constants";
-import { LoginAccount, NodeStyleCallback, WindowApp } from "modules/types";
-import { ThunkDispatch } from "redux-thunk";
-import { Action } from "redux";
+import { loadAccountDataFromLocalStorage } from 'modules/auth/actions/load-account-data-from-local-storage';
+import { updateLoginAccount } from 'modules/account/actions/login-account';
+import { checkAccountAllowance } from 'modules/auth/actions/approve-account';
+import { loadAccountHistory } from 'modules/auth/actions/load-account-history';
+import { updateAssets } from 'modules/auth/actions/update-assets';
+import { loadReportingWindowBounds } from 'modules/reports/actions/load-reporting-window-bounds';
+import { windowRef } from 'utils/window-ref';
+import getValue from 'utils/get-value';
+import logError from 'utils/log-error';
+import { loadDesignatedReporterMarkets } from 'modules/reports/actions/load-designated-reporter-markets';
+import { loadDisputing } from 'modules/reports/actions/load-disputing';
+import { loadGasPriceInfo } from 'modules/app/actions/load-gas-price-info';
+import { getReportingFees } from 'modules/reports/actions/get-reporting-fees';
+import { ACCOUNT_TYPES } from 'modules/common/constants';
+import { LoginAccount, NodeStyleCallback, WindowApp } from 'modules/types';
+import { ThunkDispatch } from 'redux-thunk';
+import { Action } from 'redux';
+import { getAllowance } from 'modules/contracts/actions/contractCalls';
+import { formatAttoDai } from 'utils/format-number';
 
 export const loadAccountData = (
   account: LoginAccount,
   callback: NodeStyleCallback = logError
-) => (dispatch: ThunkDispatch<void, any, Action>) => {
-  const address: string = getValue(account, "address");
-  if (!address) return callback("account address required");
+) => async (dispatch: ThunkDispatch<void, any, Action>) => {
+  const address: string = getValue(account, 'address');
+  if (!address) return callback('account address required');
   const windowApp = windowRef as WindowApp;
   if (
     windowApp &&
-    windowApp.localStorage.setItem && account && account.meta &&
+    windowApp.localStorage.setItem &&
+    account &&
+    account.meta &&
     account.meta.accountType === ACCOUNT_TYPES.METAMASK
   ) {
-    windowApp.localStorage.setItem("loggedInAccount", address);
+    windowApp.localStorage.setItem('loggedInAccount', address);
   }
   dispatch(loadAccountDataFromLocalStorage(address));
   dispatch(updateLoginAccount(account));
@@ -40,4 +44,7 @@ export const loadAccountData = (
   dispatch(loadDisputing());
   dispatch(loadGasPriceInfo());
   dispatch(getReportingFees());
+
+  const allowance = await getAllowance(address);
+  dispatch(updateLoginAccount({ allowanceFormatted: formatAttoDai(allowance) }));
 };

--- a/packages/augur-ui/src/modules/common/buttons.tsx
+++ b/packages/augur-ui/src/modules/common/buttons.tsx
@@ -248,6 +248,17 @@ export const DAIFaucetButton = (props: DefaultActionButtonProps) => (
   </button>
 );
 
+export const ApprovalButton = (props: DefaultActionButtonProps) => (
+  <button
+    onClick={e => props.action(e)}
+    className={Styles.DAIFaucetButton}
+    disabled={props.disabled}
+    title={props.title || "Approval"}
+  >
+    <span>Approval</span>
+  </button>
+);
+
 export const ExportButton = (props: DefaultActionButtonProps) => (
   <button
     onClick={e => props.action(e)}

--- a/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
+++ b/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
@@ -145,8 +145,20 @@ export async function isFinalized(marketId: string) {
 
 export function getDai() {
   const { contracts } = augurSdk.get();
-  return contracts.cash.faucet(new BigNumber('1000000000000000000000'));
+  return contracts.cash.faucet(new BigNumber("1000000000000000000000"));
 }
+
+export async function approveToTrade(account: string, amount: BigNumber) {
+  const { contracts } = augurSdk.get();
+  return contracts.cash.approve(account, amount);
+}
+
+export async function getAllowance(account: string): Promise<BigNumber>  {
+  const { contracts } = augurSdk.get();
+  const augurContract = contracts.augur.address;
+  return contracts.cash.allowance_(account, augurContract);
+}
+
 
 export async function placeTrade(
   direction: number,

--- a/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
+++ b/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
@@ -148,9 +148,10 @@ export function getDai() {
   return contracts.cash.faucet(new BigNumber("1000000000000000000000"));
 }
 
-export async function approveToTrade(account: string, amount: BigNumber) {
+export async function approveToTrade(amount: BigNumber) {
   const { contracts } = augurSdk.get();
-  return contracts.cash.approve(account, amount);
+  const augurContract = contracts.augur.address;
+  return contracts.cash.approve(augurContract, amount);
 }
 
 export async function getAllowance(account: string): Promise<BigNumber>  {

--- a/packages/augur-ui/src/modules/modal/containers/modal-approval.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-approval.ts
@@ -9,22 +9,23 @@ import { Action } from "redux";
 
 const mapStateToProps = (state: AppState) => ({
   modal: state.modal,
+  account: state.loginAccount,
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({
   closeModal: () => dispatch(closeModal()),
-  approveAccount: (onSent: Function, onSuccess: Function) =>
-    dispatch(approveAccount(onSent, onSuccess))
+  approveAccount: () =>
+    dispatch(approveAccount())
 });
 
 const mergeProps = (sP: any, dP: any, oP: any) => ({
   title: "Approve Augur",
   description: [
-    `In order to trade on Augur you must first approve the Augur Contracts to move Ether on your behalf. You will be unable to trade until approval has completed.`,
-    `After clicking "Approve" you will be asked to sign a transaction, followed by a second transaction to complete your requested trade.`
+    `Current approval is ${sP.account.allowanceFormatted.formatted} DAI`,
+    `In order to trade on Augur you must first approve the Augur Contracts to move DAI on your behalf. You will not be able to trade until approval has completed.`,
+    `After clicking "Approve" you will be asked to sign a transaction. This will approval for 1 million DAI.`
   ],
   closeAction: () => {
-    sP.modal.approveCallback("close_modal");
     dP.closeModal();
   },
   buttons: [

--- a/packages/augur-ui/src/modules/types.ts
+++ b/packages/augur-ui/src/modules/types.ts
@@ -509,7 +509,7 @@ export interface LoginAccount {
   totalFrozenFunds?: string;
   tradingPositionsTotal?: UnrealizedRevenue;
   timeframeData?: TimeframeData;
-  allowance?: string;
+  allowanceFormatted?: FormattedNumber;
   eth?: string;
   rep?: string;
   dai?: string;

--- a/packages/augur-ui/src/utils/format-number.ts
+++ b/packages/augur-ui/src/utils/format-number.ts
@@ -230,6 +230,10 @@ export function formatAttoRep(num: NumStrBigNumber, opts: FormattedNumberOptions
   );
 }
 
+export function formatAttoDai(num: NumStrBigNumber, opts: FormattedNumberOptions = optionsBlank()): FormattedNumber {
+  return formatAttoEth(num, opts);
+}
+
 // At some point potentially refactor all this to be more generic (e.g formatAttoAmount)
 export function formatAttoEth(num: NumStrBigNumber, opts: FormattedNumberOptions = optionsBlank()): FormattedNumber {
   if (!num) return formatBlank();


### PR DESCRIPTION
adding temporary approval modal so we can approve accounts to trade and test trading.


![Screen Shot 2019-06-20 at 10 42 16 AM](https://user-images.githubusercontent.com/3970376/59862381-4836f380-9348-11e9-84d6-b2ea5d00e214.png)

Added approval amount in modal, currently have an issue retrieving after approval tx is confirmed

![Screen Shot 2019-06-20 at 10 42 59 AM](https://user-images.githubusercontent.com/3970376/59862393-4ff69800-9348-11e9-8781-5dd7c20ecf2c.png)

![image](https://user-images.githubusercontent.com/3970376/59862373-45d49980-9348-11e9-9def-4b98af62de5d.png)

![Screen Shot 2019-06-20 at 10 52 32 AM](https://user-images.githubusercontent.com/3970376/59863073-a0bac080-9349-11e9-93c8-01999bce1b34.png)
