### PR TITLE
Order form updates

### DIFF
--- a/packages/augur-sdk/src/Augur.ts
+++ b/packages/augur-sdk/src/Augur.ts
@@ -231,4 +231,8 @@ export class Augur<TProvider extends Provider = Provider> {
   public async createScalarMarket(params: CreateScalarMarketParams): Promise<ContractInterfaces.Market> {
     return this.market.createScalarMarket(params);
   }
+
+  public async simulateTradeGasLimit(params: PlaceTradeDisplayParams): Promise<BigNumber> {
+    return this.trade.simulateTradeGasLimit(params);
+  }
 }

--- a/packages/augur-sdk/src/api/Trade.ts
+++ b/packages/augur-sdk/src/api/Trade.ts
@@ -81,6 +81,13 @@ export class Trade {
     return await this.placeOnChainTrade(onChainTradeParams);
   }
 
+
+  public async simulateTradeGasLimit(params: PlaceTradeDisplayParams): Promise<BigNumber> {
+    const onChainTradeParams = this.getOnChainTradeParams(params);
+    const { gasLimit } = await this.getTradeTransactionLimits(onChainTradeParams);
+    return gasLimit;
+  }
+
   public getOnChainTradeParams(params: PlaceTradeDisplayParams): PlaceTradeChainParams {
     const tickSize = numTicksToTickSizeWithDisplayPrices(params.numTicks, params.displayMinPrice, params.displayMaxPrice);
     const onChainAmount = convertDisplayAmountToOnChainAmount(params.displayAmount, tickSize);

--- a/packages/augur-ui/src/assets/styles/_colors_redesign.less
+++ b/packages/augur-ui/src/assets/styles/_colors_redesign.less
@@ -67,7 +67,7 @@
 @color-outcome-one: #fadca2;
 @color-outcome-two: #f3a2fa;
 @color-outcome-three: @color-secondary-text;
-@color-outcome-four: #fd6266;
+@color-outcome-four: #00EAFF;
 @color-outcome-five: #a5a5a5;
 @color-outcome-six: #665cdf;
 @color-outcome-seven: #09cfe1;

--- a/packages/augur-ui/src/modules/common/buttons.tsx
+++ b/packages/augur-ui/src/modules/common/buttons.tsx
@@ -26,12 +26,12 @@ import {
 } from "modules/common/icons";
 import classNames from "classnames";
 
-import Styles from "modules/common/buttons.styles";
+import Styles from "modules/common/buttons.styles.less";
 import { AppState } from "store";
 
 export interface DefaultButtonProps {
   id?: string;
-  text: string;
+  text?: string;
   action: Function;
   disabled?: boolean;
   title?: string;
@@ -275,7 +275,7 @@ export const DirectionButton = (props: DirectionButtonProps) => (
   <button
     onClick={e => props.action(e)}
     className={classNames(Styles.DirectionButton, {
-      [Styles.left]: props.left
+      [Styles.left]: props.left,
     })}
     disabled={props.disabled}
     title={props.title}
@@ -313,7 +313,7 @@ export const SortButton = (props: SortButtonProps) => (
     onClick={e => props.action(e)}
     className={classNames(Styles.SortButton, {
       [Styles.Ascending]: props.sortOption === ASCENDING,
-      [Styles.Descending]: props.sortOption === DESCENDING
+      [Styles.Descending]: props.sortOption === DESCENDING,
     })}
     disabled={props.disabled}
   >
@@ -337,14 +337,14 @@ interface EtherscanLinkTSXProps {
   baseUrl?: string | null;
   txhash: string;
   label: string;
-  showNonLink?: Boolean;
+  showNonLink?: boolean;
 }
 
 const EtherscanLinkTSX = ({
   baseUrl,
   txhash,
   label,
-  showNonLink
+  showNonLink,
 }: EtherscanLinkTSXProps) => (
   <span>
     {baseUrl && (
@@ -360,16 +360,21 @@ EtherscanLinkTSX.propTypes = {
   baseUrl: PropTypes.string,
   txhash: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
-  showNonLink: PropTypes.bool
+  showNonLink: PropTypes.bool,
 };
 
 EtherscanLinkTSX.defaultProps = {
   baseUrl: null,
-  showNonLink: false
+  showNonLink: false,
 };
 
 const mapStateToPropsEtherScanLink = (state: AppState) => {
   const networkId = state.connection.augurNodeNetworkId;
+
+  if (!networkId) {
+    return null;
+  }
+
   const networkLink = {
     1: "https://etherscan.io/tx/",
     3: "https://ropsten.etherscan.io/tx/",

--- a/packages/augur-ui/src/modules/common/selection.tsx
+++ b/packages/augur-ui/src/modules/common/selection.tsx
@@ -107,9 +107,10 @@ class Dropdown extends React.Component<DropdownProps, DropdownState> {
       stretchOutOnMobile,
       openTop,
       className,
-      activeClassName
+      activeClassName,
     } = this.props;
     const { selected, showList } = this.state;
+
     return (
       <div
         style={sortByStyles}
@@ -133,7 +134,7 @@ class Dropdown extends React.Component<DropdownProps, DropdownState> {
         </button>
         <div
           className={classNames(Styles.Dropdown_list, {
-            [`${Styles.active}`]: showList
+            [`${Styles.active}`]: showList,
           })}
         >
           {options.map(option => (

--- a/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
+++ b/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
@@ -234,5 +234,45 @@ export async function simulateTrade(
     displayPrice: createBigNumber(displayPrice),
     displayShares: createBigNumber(displayShares),
   };
+
   return Augur.simulateTrade(params);
+}
+
+export async function simulateTradeGasLimit(
+  direction: number,
+  marketId: string,
+  numOutcomes: number,
+  outcomeId: number,
+  ignoreShares: boolean,
+  affiliateAddress: string = NULL_ADDRESS,
+  kycToken: string = NULL_ADDRESS,
+  doNotCreateOrders: boolean,
+  numTicks: BigNumber | string,
+  minPrice: BigNumber | string,
+  maxPrice: BigNumber | string,
+  displayAmount: BigNumber | string,
+  displayPrice: BigNumber | string,
+  displayShares: BigNumber | string,
+): Promise<SimulateTradeData> {
+  const Augur = augurSdk.get();
+  const tradeGroupId = generateTradeGroupId();
+  const params: PlaceTradeDisplayParams = {
+    direction: direction as 0 | 1,
+    market: marketId,
+    numTicks: createBigNumber(numTicks),
+    numOutcomes: numOutcomes as 3 | 4 | 5 | 6 | 7 | 8,
+    outcome: outcomeId as 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7,
+    tradeGroupId,
+    ignoreShares,
+    affiliateAddress,
+    kycToken,
+    doNotCreateOrders,
+    displayMinPrice: createBigNumber(minPrice),
+    displayMaxPrice: createBigNumber(maxPrice),
+    displayAmount: createBigNumber(displayAmount),
+    displayPrice: createBigNumber(displayPrice),
+    displayShares: createBigNumber(displayShares),
+  };
+
+  return Augur.simulateTradeGasLimit(params);
 }

--- a/packages/augur-ui/src/modules/market/components/trading-form/trading-form.tsx
+++ b/packages/augur-ui/src/modules/market/components/trading-form/trading-form.tsx
@@ -11,13 +11,16 @@ import { MarketData, MarketOutcome } from 'modules/types';
 
 interface TradingFormProps {
   availableFunds: BigNumber;
+  availableDai: BigNumber;
   isLogged: boolean;
+  allowanceAmount: string;
   isConnectionTrayOpen: boolean;
   market: MarketData;
   marketReviewTradeSeen: boolean;
   marketReviewTradeModal: Function;
   selectedOrderProperties: Object;
   selectedOutcomeId: number;
+  sortedOutcomes: MarketOutcome[];
   updateSelectedOrderProperties: Function;
   handleFilledOnly: Function;
   gasPrice: number;
@@ -73,7 +76,9 @@ class TradingForm extends Component<TradingFormProps, TradingFormState> {
 
   render() {
     const {
+      allowanceAmount,
       availableFunds,
+      availableDai,
       isLogged,
       isConnectionTrayOpen,
       market,
@@ -87,6 +92,7 @@ class TradingForm extends Component<TradingFormProps, TradingFormState> {
       onSubmitPlaceTrade,
       marketReviewTradeSeen,
       marketReviewTradeModal,
+      sortedOutcomes,
     } = this.props;
     const s = this.state;
 
@@ -114,10 +120,13 @@ class TradingForm extends Component<TradingFormProps, TradingFormState> {
         <Wrapper
           market={market}
           isLogged={isLogged}
+          allowanceAmount={allowanceAmount}
           selectedOutcome={s.selectedOutcome}
           selectedOrderProperties={selectedOrderProperties}
+          sortedOutcomes={sortedOutcomes}
           toggleForm={this.toggleForm}
           availableFunds={availableFunds}
+          availableDai={availableDai}
           updateSelectedOrderProperties={
             this.props.updateSelectedOrderProperties
           }

--- a/packages/augur-ui/src/modules/market/components/trading-form/trading-form.tsx
+++ b/packages/augur-ui/src/modules/market/components/trading-form/trading-form.tsx
@@ -7,18 +7,18 @@ import makePath from 'modules/routes/helpers/make-path';
 import Styles from 'modules/market/components/trading-form/trading-form.styles.less';
 
 import { PrimaryButton } from 'modules/common/buttons';
-import { MarketData, MarketOutcome } from 'modules/types';
+import { MarketData, MarketOutcome, FormattedNumber } from 'modules/types';
 
 interface TradingFormProps {
   availableFunds: BigNumber;
   availableDai: BigNumber;
   isLogged: boolean;
-  allowanceAmount: string;
+  allowanceAmount: FormattedNumber;
   isConnectionTrayOpen: boolean;
   market: MarketData;
   marketReviewTradeSeen: boolean;
   marketReviewTradeModal: Function;
-  selectedOrderProperties: Object;
+  selectedOrderProperties: object;
   selectedOutcomeId: number;
   sortedOutcomes: MarketOutcome[];
   updateSelectedOrderProperties: Function;
@@ -119,12 +119,10 @@ class TradingForm extends Component<TradingFormProps, TradingFormState> {
       <section className={Styles.TradingForm}>
         <Wrapper
           market={market}
-          isLogged={isLogged}
           allowanceAmount={allowanceAmount}
           selectedOutcome={s.selectedOutcome}
           selectedOrderProperties={selectedOrderProperties}
           sortedOutcomes={sortedOutcomes}
-          toggleForm={this.toggleForm}
           availableFunds={availableFunds}
           availableDai={availableDai}
           updateSelectedOrderProperties={

--- a/packages/augur-ui/src/modules/market/containers/market-outcomes-list.ts
+++ b/packages/augur-ui/src/modules/market/containers/market-outcomes-list.ts
@@ -1,14 +1,14 @@
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
 import MarketOutcomesList from "modules/market/components/market-outcomes-list/market-outcomes-list";
-import { selectMarket } from "modules/markets/selectors/market";
+import { selectMarket, selectSortedMarketOutcomes } from "modules/markets/selectors/market";
 
 const mapStateToProps = (state, ownProps) => {
   const market = selectMarket(ownProps.marketId);
 
   return {
     scalarDenomination: market.scalarDenomination,
-    marketOutcomes: market.marketOutcomes,
+    marketOutcomes: selectSortedMarketOutcomes(market.marketType, market.marketOutcomes),
     marketType: market.marketType,
     minPriceBigNumber: market.minPriceBigNumber,
     maxPriceBigNumber: market.maxPriceBigNumber

--- a/packages/augur-ui/src/modules/market/containers/trading-form.ts
+++ b/packages/augur-ui/src/modules/market/containers/trading-form.ts
@@ -5,7 +5,7 @@ import { createBigNumber } from "utils/create-big-number";
 import { windowRef } from "utils/window-ref";
 import {
   MARKET_REVIEW_TRADE_SEEN,
-  MODAL_MARKET_REVIEW_TRADE
+  MODAL_MARKET_REVIEW_TRADE,
 } from "modules/common/constants";
 import { updateModal } from "modules/modal/actions/update-modal";
 import { getGasPrice } from "modules/auth/selectors/get-gas-price";
@@ -19,15 +19,20 @@ import {
   updateAuthStatus,
   IS_CONNECTION_TRAY_OPEN
 } from "modules/auth/actions/auth-status";
+import { selectSortedMarketOutcomes } from "modules/markets/selectors/market";
+
 
 const mapStateToProps = (state, ownProps) => {
-  const { authStatus, appStatus } = state;
+  const { authStatus, loginAccount } = state;
 
   return {
     gasPrice: getGasPrice(state),
     availableFunds: createBigNumber(state.loginAccount.eth || 0),
+    availableDai: createBigNumber(state.loginAccount.dai || 0),
     isLogged: authStatus.isLogged,
+    allowanceAmount: loginAccount.allowanceFormatted,
     isConnectionTrayOpen: authStatus.isConnectionTrayOpen,
+    sortedOutcomes: selectSortedMarketOutcomes(ownProps.market.marketType, ownProps.market.marketOutcomes),
   };
 };
 
@@ -43,7 +48,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     dispatch(
       updateModal({
         type: MODAL_MARKET_REVIEW_TRADE,
-        ...modal
+        ...modal,
       })
     ),
   onSubmitPlaceTrade: (
@@ -61,7 +66,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         tradeInProgress,
         doNotCreateOrders,
         callback,
-        onComplete
+        onComplete,
       })
     )
 });
@@ -76,7 +81,7 @@ const mergeProps = (sP, dP, oP) => {
     ...oP,
     ...sP,
     ...dP,
-    marketReviewTradeSeen: !!marketReviewTradeSeen
+    marketReviewTradeSeen: !!marketReviewTradeSeen,
   };
 };
 

--- a/packages/augur-ui/src/modules/markets/selectors/market.ts
+++ b/packages/augur-ui/src/modules/markets/selectors/market.ts
@@ -160,3 +160,23 @@ const assembleMarket = (
 
   return market;
 };
+
+export const selectSortedMarketOutcomes = (marketType, outcomes) => {
+  const sortedOutcomes = [...outcomes];
+
+  if (marketType === YES_NO) {
+    return sortedOutcomes
+      // Only keep Invalid [0] / Yes [2]
+      .filter(outcome => outcome.id !== 1)
+      // Only tradable
+      .filter(outcome => outcome.isTradable)
+       // Move invalid to the end
+      .reverse();
+  } else {
+    // Move invalid to the end
+    sortedOutcomes.push(sortedOutcomes.shift());
+    return sortedOutcomes
+      // Only tradable
+      .filter(outcome => outcome.isTradable);
+  }
+};

--- a/packages/augur-ui/src/modules/markets/selectors/market.ts
+++ b/packages/augur-ui/src/modules/markets/selectors/market.ts
@@ -7,6 +7,7 @@ import {
 } from "utils/format-number";
 import {
   ZERO,
+  YES_NO,
 } from "modules/common/constants";
 
 import { getOutcomeName } from "utils/get-outcome";

--- a/packages/augur-ui/src/modules/trades/actions/update-trade-cost-shares.ts
+++ b/packages/augur-ui/src/modules/trades/actions/update-trade-cost-shares.ts
@@ -1,5 +1,4 @@
 import { createBigNumber } from 'utils/create-big-number';
-import { augur } from 'services/augurjs';
 import { BUY, ZERO } from 'modules/common/constants';
 import logError from 'utils/log-error';
 import { generateTrade } from 'modules/trades/helpers/generate-trade';
@@ -8,7 +7,7 @@ import { AppState } from 'store';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
 import { NodeStyleCallback, MarketData } from 'modules/types';
-import { simulateTrade } from 'modules/contracts/actions/contractCalls';
+import { simulateTrade, simulateTradeGasLimit } from 'modules/contracts/actions/contractCalls';
 import { SimulateTradeData } from '@augurproject/sdk/build';
 import { MarketInfo } from '@augurproject/sdk/build/state/getter/Markets';
 
@@ -222,6 +221,23 @@ async function runSimulateTrade(
     userShares
   );
 
+  const gasLimit = await simulateTradeGasLimit(
+    orderType,
+    marketId,
+    market.numOutcomes,
+    parseInt(outcomeId, 10),
+    ignoreShares,
+    affiliateAddress,
+    kycToken,
+    doNotCreateOrders,
+    market.numTicks,
+    market.minPrice,
+    market.maxPrice,
+    newTradeDetails.numShares,
+    newTradeDetails.limitPrice,
+    userShares
+  );
+
   const totalFee = createBigNumber(simulateTradeValue.settlementFees, 10);
   newTradeDetails.totalFee = totalFee.toFixed();
   newTradeDetails.totalCost = simulateTradeValue.tokensDepleted;
@@ -251,5 +267,5 @@ async function runSimulateTrade(
     })
   );
 
-  if (callback) callback(null, { ...order, ...simulateTradeValue, displayTrade });
+  if (callback) callback(null, { ...order, ...simulateTradeValue, displayTrade, gasLimit });
 }

--- a/packages/augur-ui/src/modules/trading/components/confirm/confirm.tsx
+++ b/packages/augur-ui/src/modules/trading/components/confirm/confirm.tsx
@@ -1,13 +1,9 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
-import { augur } from "services/augurjs";
 import classNames from "classnames";
 import {
   SCALAR,
-  YES_NO,
   BUY,
   SELL,
-  ZERO,
   BUYING,
   SELLING,
   BUYING_BACK,
@@ -17,8 +13,8 @@ import {
   UPPER_FIXED_PRECISION_BOUND
 } from "modules/common/constants";
 import ReactTooltip from "react-tooltip";
-import TooltipStyles from "modules/common/tooltip.styles";
-import Styles from "modules/trading/components/confirm/confirm.styles";
+import TooltipStyles from "modules/common/tooltip.styles.less";
+import Styles from "modules/trading/components/confirm/confirm.styles.less";
 import {
   XIcon,
   ExclamationCircle,
@@ -27,37 +23,43 @@ import {
 import { formatGasCostToEther, formatShares } from "utils/format-number";
 import { BigNumber, createBigNumber } from "utils/create-big-number";
 import { LinearPropertyLabel } from "modules/common/labels";
+import { FormattedNumber, Trade } from "modules/types";
+import { MarketInfoOutcome } from "@augurproject/sdk/build/state/getter/Markets";
 
-class Confirm extends Component {
-  static propTypes = {
-    trade: PropTypes.shape({
-      numShares: PropTypes.string,
-      limitPrice: PropTypes.string,
-      potentialEthProfit: PropTypes.object,
-      potentialEthLoss: PropTypes.object,
-      totalCost: PropTypes.object,
-      shareCost: PropTypes.object,
-      orderShareProfit: PropTypes.object,
-      orderShareTradingFee: PropTypes.object
-    }).isRequired,
-    gasPrice: PropTypes.number.isRequired,
-    availableFunds: PropTypes.instanceOf(BigNumber).isRequired,
-    selectedOutcome: PropTypes.object.isRequired,
-    marketType: PropTypes.string.isRequired,
-    maxPrice: PropTypes.instanceOf(BigNumber).isRequired,
-    minPrice: PropTypes.instanceOf(BigNumber).isRequired,
-    scalarDenomination: PropTypes.string,
-    numOutcomes: PropTypes.number,
-  };
+interface Message {
+  header: string;
+  type: string;
+  message: string;
+}
 
+interface ConfirmProps {
+  allowanceAmount: FormattedNumber;
+  trade: Trade;
+  gasPrice: number;
+  gasLimit: number;
+  availableFunds: BigNumber;
+  availableDai: BigNumber;
+  selectedOutcome: MarketInfoOutcome;
+  marketType: string;
+  maxPrice: BigNumber;
+  minPrice: BigNumber;
+  scalarDenomination: string | null;
+  numOutcomes: number;
+}
+
+interface ConfirmState {
+  messages: Message | null;
+}
+
+class Confirm extends Component<ConfirmProps, ConfirmState> {
   static defaultProps = {
-    scalarDenomination: ""
+    scalarDenomination: "",
   };
 
   constructor(props) {
     super(props);
     this.state = {
-      messages: this.constructMessages(props)
+      messages: this.constructMessages(props),
     };
 
     this.constructMessages = this.constructMessages.bind(this);
@@ -72,61 +74,76 @@ class Confirm extends Component {
       availableFunds !== nextProps.availableFunds
     ) {
       this.setState({
-        messages: this.constructMessages(nextProps)
+        messages: this.constructMessages(nextProps),
       });
     }
   }
 
   constructMessages(props) {
-    const { trade, numOutcomes, gasPrice, availableFunds } =
+    const { trade, allowanceAmount, gasPrice, gasLimit, availableFunds, availableDai } =
       props || this.props;
 
-    const { totalCost, selfTrade } = trade;
+    const { totalCost, selfTrade, potentialEthLoss } = trade;
 
-    let messages = null;
-    const gasValues = {
-      fillGasLimit: augur.constants.WORST_CASE_FILL[numOutcomes],
-      placeOrderNoSharesGasLimit:
-        augur.constants.PLACE_ORDER_NO_SHARES[numOutcomes],
-      placeOrderWithSharesGasLimit:
-        augur.constants.PLACE_ORDER_WITH_SHARES[numOutcomes]
-    };
-    const gas =
-      trade.shareCost.fullPrecision > 0
-        ? gasValues.placeOrderWithSharesGasLimit
-        : gasValues.fillGasLimit;
-    const gasCost = formatGasCostToEther(gas, { decimalsRounded: 4 }, gasPrice);
+    let messages: Message | null = null;
     const tradeTotalCost = createBigNumber(totalCost.fullPrecision, 10);
+    const gasCost = formatGasCostToEther(gasLimit, { decimalsRounded: 4 }, gasPrice);
 
     if (selfTrade) {
       messages = {
         header: "CONSUMING OWN ORDER",
         type: WARNING,
-        message: "You are trading against one of your existing orders"
+        message: "You are trading against one of your existing orders",
       };
     }
 
+    // TODO remove for now since we don't have a way to convert gas cost of Order into DAI
+    // if (
+    //   tradeTotalCost.gt(ZERO) &&
+    //   createBigNumber(gasCost).gt(createBigNumber(tradeTotalCost))
+    // ) {
+    //   messages = {
+    //     header: "Gas Higher than Order",
+    //     type: WARNING,
+    //     message: `Est. gas cost ${gasCost} ETH, higher than order cost`,
+    //   };
+    // }
+
     if (
-      tradeTotalCost.gt(ZERO) &&
-      createBigNumber(gasCost).gt(createBigNumber(tradeTotalCost))
+      totalCost &&
+      createBigNumber(gasCost, 10).gte(
+        createBigNumber(availableFunds, 10)
+      )
     ) {
       messages = {
-        header: "Gas Higher than Order",
-        type: WARNING,
-        message: `Est. gas cost ${gasCost} ETH, higher than order cost`
+        header: "Insufficient ETH",
+        type: ERROR,
+        message: `You do not have enough funds to place this order. ${gasCost} ETH required for gas.`,
       };
     }
 
     if (
       totalCost &&
-      createBigNumber(totalCost.fullPrecision, 10).gte(
-        createBigNumber(availableFunds, 10)
+      createBigNumber(potentialEthLoss.fullPrecision, 10).gt(
+        createBigNumber(availableDai, 10)
       )
     ) {
       messages = {
-        header: "Insufficient Funds",
+        header: "Insufficient DAI",
         type: ERROR,
-        message: "You do not have enough funds to place this order"
+        message: "You do not have enough DAI to place this order",
+      };
+    }
+
+    if (totalCost &&
+      allowanceAmount &&
+      createBigNumber(potentialEthLoss.fullPrecision, 10).gt(
+        createBigNumber(allowanceAmount.fullPrecision, 10)
+      )) {
+        messages = {
+        header: "Insufficient Approved Funds",
+        type: ERROR,
+        message: "You do not have enough approved funds to place this order.",
       };
     }
 
@@ -144,7 +161,7 @@ class Confirm extends Component {
       marketType,
       maxPrice,
       minPrice,
-      scalarDenomination
+      scalarDenomination,
     } = this.props;
 
     const {
@@ -156,13 +173,12 @@ class Confirm extends Component {
       shareCost,
       side,
       orderShareProfit,
-      orderShareTradingFee
+      orderShareTradingFee,
     } = trade;
 
     const { messages } = this.state;
 
-    const outcomeName =
-      marketType === YES_NO ? "this event" : selectedOutcome.name;
+    const outcomeName = selectedOutcome.description;
     const greaterLess = side === BUY ? "greater" : "less";
     const higherLower = side === BUY ? "higher" : "lower";
 
@@ -188,7 +204,7 @@ class Confirm extends Component {
       newOrderAmount = formatShares(
         createBigNumber(numShares).minus(shareCost.fullPrecision),
         {
-          decimalsRounded: UPPER_FIXED_PRECISION_BOUND
+          decimalsRounded: UPPER_FIXED_PRECISION_BOUND,
         }
       ).rounded;
     }
@@ -215,7 +231,7 @@ class Confirm extends Component {
                 <span
                   className={classNames({
                     [Styles.long]: side === BUY,
-                    [Styles.short]: side === SELL
+                    [Styles.short]: side === SELL,
                   })}
                 >
                   {side !== BUY ? SELLING_OUT : BUYING_BACK}
@@ -270,7 +286,7 @@ class Confirm extends Component {
                 <span
                   className={classNames({
                     [Styles.long]: side === BUY,
-                    [Styles.short]: side === SELL
+                    [Styles.short]: side === SELL,
                   })}
                 >
                   {side === BUY ? BUYING : SELLING}
@@ -293,7 +309,7 @@ class Confirm extends Component {
             className={classNames(
               Styles.TradingConfirm__error_message_container,
               {
-                [Styles.error]: messages.type === ERROR
+                [Styles.error]: messages.type === ERROR,
               }
             )}
           >
@@ -301,7 +317,7 @@ class Confirm extends Component {
               className={classNames({
                 [Styles.TradingConfirm__message__warning]:
                   messages.type === WARNING,
-                [Styles.TradingConfirm__message__error]: messages.type === ERROR
+                [Styles.TradingConfirm__message__error]: messages.type === ERROR,
               })}
             >
               {ExclamationCircle}

--- a/packages/augur-ui/src/modules/trading/components/form/form.styles.less
+++ b/packages/augur-ui/src/modules/trading/components/form/form.styles.less
@@ -26,7 +26,8 @@
         }
       }
 
-      &:last-child {
+      &:last-child,
+      &:nth-last-child(1) {
         align-items: center;
         border: none;
         flex-direction: row;
@@ -34,7 +35,7 @@
 
         > label {
           color: @color-secondary-text;
-          padding: 2px 0 0 @size-24;
+          padding: @size-7 0 0 @size-32;
         }
       }
 
@@ -71,7 +72,8 @@
           }
         }
 
-        &:last-child {
+        &:last-child,
+        &:nth-last-child(2) {
           align-items: center;
           border: none;
           display: flex;

--- a/packages/augur-ui/src/modules/trading/components/form/form.tsx
+++ b/packages/augur-ui/src/modules/trading/components/form/form.tsx
@@ -3,8 +3,6 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { BigNumber, createBigNumber } from 'utils/create-big-number';
 import {
-  YES_NO,
-  CATEGORICAL,
   SCALAR,
   MIN_QUANTITY,
   UPPER_FIXED_PRECISION_BOUND,
@@ -16,7 +14,7 @@ import { SquareDropdown } from 'modules/common/selection';
 import { Checkbox } from 'modules/common/form';
 import getPrecision from 'utils/get-number-precision';
 import convertExponentialToDecimal from 'utils/convert-exponential';
-import { MarketData } from 'modules/types';
+import { MarketData, MarketOutcome } from 'modules/types';
 import { MarketInfoOutcome } from '@augurproject/sdk/build/state/getter/Markets';
 
 interface FromProps {
@@ -28,9 +26,11 @@ interface FromProps {
   orderPrice: string;
   orderEthEstimate: string;
   orderEscrowdEth: string;
+  gasCostEst: string;
   selectedNav: string;
   selectedOutcome: MarketInfoOutcome;
   updateState: Function;
+  sortedOutcomes: MarketOutcome[];
   updateOrderProperty: Function;
   doNotCreateOrders: boolean;
   updateSelectedOutcome: Function;
@@ -53,6 +53,7 @@ interface FormState {
   errors: object;
   errorCount: number;
 }
+
 class Form extends Component<FromProps, FormState> {
   INPUT_TYPES: {
     QUANTITY: string;
@@ -179,8 +180,11 @@ class Form extends Component<FromProps, FormState> {
     let errorCount = 0;
     let passedTest = !!isOrderValid;
     const precision = getPrecision(value, 0);
-    if (!BigNumber.isBigNumber(value))
+
+    if (!BigNumber.isBigNumber(value)) {
       return { isOrderValid: false, errors, errorCount };
+    }
+
     if (value && value.lte(0)) {
       errorCount += 1;
       passedTest = false;
@@ -214,8 +218,11 @@ class Form extends Component<FromProps, FormState> {
     const tickSize = createBigNumber(market.tickSize);
     let errorCount = 0;
     let passedTest = !!isOrderValid;
-    if (!BigNumber.isBigNumber(value))
+
+    if (!BigNumber.isBigNumber(value)) {
       return { isOrderValid: false, errors, errorCount };
+    }
+
     if (value && (value.lte(minPrice) || value.gte(maxPrice))) {
       errorCount += 1;
       passedTest = false;
@@ -524,7 +531,9 @@ class Form extends Component<FromProps, FormState> {
       minPrice,
       updateState,
       orderEscrowdEth,
+      gasCostEst,
       updateSelectedOutcome,
+      sortedOutcomes,
     } = this.props;
     const s = this.state;
 
@@ -549,26 +558,18 @@ class Form extends Component<FromProps, FormState> {
 
     return (
       <div className={Styles.TradingForm}>
-        {market.marketType === CATEGORICAL && (
-          <div className={classNames(Styles.Outcome, Styles.HideOnMobile)}>
-            <SquareDropdown
-              defaultValue={defaultOutcome}
-              onChange={value => updateSelectedOutcome(value)}
-              options={market.outcomes.map(outcome => ({
-                label: outcome.description,
-                value: outcome.id,
-              }))}
-              large
-            />
-          </div>
-        )}
-        {market.marketType === YES_NO && (
-          <div className={classNames(Styles.Outcome, Styles.HideOnMobile)}>
-            <div className={Styles.Yes}>
-              <span>Outcome:</span> Yes
-            </div>
-          </div>
-        )}
+        <div className={classNames(Styles.Outcome, Styles.HideOnMobile)}>
+          <SquareDropdown
+            defaultValue={defaultOutcome}
+            onChange={value => updateSelectedOutcome(value)}
+            options={sortedOutcomes
+              .map(outcome => ({
+              label: outcome.description,
+              value: outcome.id,
+            }))}
+            large
+          />
+        </div>
         <ul>
           <li>
             <label htmlFor="tr__input--quantity">Quantity</label>
@@ -696,6 +697,12 @@ class Form extends Component<FromProps, FormState> {
               <label className={Styles.smallLabel}>
                 {ExclamationCircle}
                 {` Max cost of ${orderEscrowdEth} DAI will be escrowed`}
+              </label>
+            )}
+            {gasCostEst && (
+              <label className={Styles.smallLabel}>
+                {ExclamationCircle}
+                {` Max cost of ${gasCostEst} ETH required for gas`}
               </label>
             )}
           </li>

--- a/packages/augur-ui/src/modules/trading/components/wrapper/wrapper.tsx
+++ b/packages/augur-ui/src/modules/trading/components/wrapper/wrapper.tsx
@@ -281,7 +281,7 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
   }
 
   updateTradeNumShares(order) {
-    const { updateTradeShares, selectedOutcome, market } = this.props;
+    const { updateTradeShares, selectedOutcome, market, gasPrice } = this.props;
     this.updateState(
       {
         ...order,
@@ -308,6 +308,8 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
               }
             ).rounded;
 
+            const formattedGasCost = formatGasCostToEther(newOrder.gasLimit, { decimalsRounded: 4 }, String(gasPrice));
+
             this.updateState(
               {
                 ...this.state,
@@ -315,6 +317,7 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
                 orderQuantity: numShares,
                 orderEscrowdEth: newOrder.potentialEthLoss.formatted,
                 trade: newOrder,
+                gasCostEst: formattedGasCost,
               },
               () => {
                 this.updateParentOrderValues();

--- a/packages/augur-ui/src/modules/types.ts
+++ b/packages/augur-ui/src/modules/types.ts
@@ -549,3 +549,15 @@ export interface WalletObject {
   derivationPath: Array<number>;
   serializedPath: string;
 }
+
+export interface Trade {
+  numShares: FormattedNumber;
+  limitPrice: FormattedNumber;
+  potentialEthProfit: FormattedNumber;
+  potentialEthLoss: FormattedNumber;
+  totalCost: FormattedNumber;
+  shareCost: FormattedNumber;
+  side: typeof BUY | typeof SELL;
+  orderShareProfit: FormattedNumber;
+  orderShareTradingFee: FormattedNumber;
+}


### PR DESCRIPTION
#2536

#### Order form changes
- remove RED outcome color

- add an error message for insufficient funds (DAI)
<img src="https://user-images.githubusercontent.com/1683736/60193780-3d77d500-9806-11e9-92f7-e342f08b54ef.png" width="400" />

- add an error message for insufficient ETH to cover gas
<img src="https://user-images.githubusercontent.com/1683736/60197864-51bfd000-980e-11e9-82f7-a697aa5bdf69.png" width="400" />
 
- add an error message for insufficient approved DAI to cover order
<img src="https://user-images.githubusercontent.com/1683736/60193470-bc204280-9805-11e9-8b80-aa9917460dab.png" width="400" />
 
- make every market type have outcome dropdown and move invalid to the bottom (dropdown and outcome list)

![image](https://user-images.githubusercontent.com/1683736/60193063-0228d680-9805-11e9-8843-92289132e335.png)
![image](https://user-images.githubusercontent.com/1683736/60193090-0ce36b80-9805-11e9-874f-8aeb20f4e197.png)
![image](https://user-images.githubusercontent.com/1683736/60193113-17056a00-9805-11e9-94ca-3430ed0040b0.png)
- add gas cost to order form

<img src="https://user-images.githubusercontent.com/1683736/60193174-369c9280-9805-11e9-8f1f-48229011011a.png" width="400" />
