### PR TITLE
Revert "Events for txn status changes"

### DIFF
--- a/packages/augur-sdk/src/constants.ts
+++ b/packages/augur-sdk/src/constants.ts
@@ -44,13 +44,6 @@ export enum SubscriptionEventName {
   UniverseForked = "UniverseForked",
 }
 
-export enum TXEventName {
-  AwaitingSigning = "AwaitingSigning",
-  Pending = "Pending",
-  Success = "Success",
-  Failure = "Failure",
-}
-
 export function isSubscriptionEventName(eventName: string): string | null {
   let retVal: number = -1;
 

--- a/packages/augur-sdk/src/event-handlers.ts
+++ b/packages/augur-sdk/src/event-handlers.ts
@@ -1,7 +1,3 @@
-import { TransactionStatus, TransactionMetadata } from "contract-dependencies-ethers/build";
-import { Transaction } from "ethereumjs-blockstream";
-import { TXEventName } from "./constants";
-
 type Address = string;
 type Bytes32 = string;
 
@@ -281,10 +277,4 @@ export interface UniverseForked extends FormattedEventLog {
   forkingMarket: Address;
 }
 
-export interface TXStatus {
-  transaction: TransactionMetadata;
-  status: TXEventName,
-  hash?: string;
-}
-
-export type SubscriptionType = MarketCreated | InitialReportSubmitted | DisputeCrowdsourcerCreated | DisputeCrowdsourcerContribution | DisputeCrowdsourcerCompleted | InitialReporterRedeemed | DisputeCrowdsourcerRedeemed | ReportingParticipantDisavowed | MarketParticipantsDisavowed | MarketFinalized | MarketMigrated | UniverseForked | UniverseCreated | OrderEvent | CompleteSetsPurchased | CompleteSetsSold | TradingProceedsClaimed | TokensTransferred | TokensMinted | TokensBurned | TokenBalanceChanged | DisputeWindowCreated | InitialReporterTransferred | MarketTransferred | MarketVolumeChanged | MarketOIChanged | ProfitLossChanged | ParticipationTokensRedeemed | TimestampSet | NewBlock | TXStatus;
+export type SubscriptionType = MarketCreated | InitialReportSubmitted | DisputeCrowdsourcerCreated | DisputeCrowdsourcerContribution | DisputeCrowdsourcerCompleted | InitialReporterRedeemed | DisputeCrowdsourcerRedeemed | ReportingParticipantDisavowed | MarketParticipantsDisavowed | MarketFinalized | MarketMigrated | UniverseForked | UniverseCreated | OrderEvent | CompleteSetsPurchased | CompleteSetsSold | TradingProceedsClaimed | TokensTransferred | TokensMinted | TokensBurned | TokenBalanceChanged | DisputeWindowCreated | InitialReporterTransferred | MarketTransferred | MarketVolumeChanged | MarketOIChanged | ProfitLossChanged | ParticipationTokensRedeemed | TimestampSet | NewBlock;

--- a/packages/augur-sdk/src/events.ts
+++ b/packages/augur-sdk/src/events.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "events";
 import { SubscriptionEventName } from "./constants";
-import { SubscriptionType, TXStatus } from "./event-handlers";
+import { SubscriptionType } from "./event-handlers";
 
 export * from "./event-handlers";
 
@@ -18,4 +18,3 @@ export const augurEmitter: EventNameEmitter = new EventNameEmitter();
 // 0 because we need one per websocket client
 augurEmitter.setMaxListeners(0);
 export type Callback = (...args: SubscriptionType[]) => void;
-export type TXStatusCallback = (...args: TXStatus[]) => void;

--- a/packages/augur-sdk/src/state/Controller.ts
+++ b/packages/augur-sdk/src/state/Controller.ts
@@ -11,13 +11,13 @@ const settings = require('./settings.json');
 export class Controller {
   private static latestBlock: Block;
 
-  private readonly events = new Subscriptions(augurEmitter);
+  private events = new Subscriptions(augurEmitter);
 
   public constructor(
     private augur: Augur,
     private db: Promise<DB>,
     private blockAndLogStreamerListener: IBlockAndLogStreamerListener
-  ) { }
+  ) {}
 
   public async run(): Promise<void> {
     try {

--- a/packages/contract-dependencies-ethers/src/ContractDependenciesEthers.ts
+++ b/packages/contract-dependencies-ethers/src/ContractDependenciesEthers.ts
@@ -7,170 +7,170 @@ import { getAddress } from "ethers/utils/address";
 import * as _ from "lodash";
 
 export interface EthersSigner {
-  sendTransaction(transaction: ethers.providers.TransactionRequest): Promise<ethers.providers.TransactionResponse>;
-  getAddress(): Promise<string>;
+    sendTransaction(transaction: ethers.providers.TransactionRequest): Promise<ethers.providers.TransactionResponse>;
+    getAddress(): Promise<string>;
 }
 
 export interface EthersProvider {
-  call(transaction: Transaction<ethers.utils.BigNumber>): Promise<string>;
-  estimateGas(transaction: TransactionRequest): Promise<ethers.utils.BigNumber>;
-  listAccounts(): Promise<string[]>;
-  getBalance(address: string): Promise<ethers.utils.BigNumber>;
-  getGasPrice(): Promise<ethers.utils.BigNumber>;
-  getTransaction(hash: string): Promise<TransactionResponse>;
+    call(transaction: Transaction<ethers.utils.BigNumber>): Promise<string>;
+    estimateGas(transaction: TransactionRequest): Promise<ethers.utils.BigNumber>;
+    listAccounts(): Promise<string[]>;
+    getBalance(address: string): Promise<ethers.utils.BigNumber>;
+    getGasPrice(): Promise<ethers.utils.BigNumber>;
+    getTransaction(hash: string): Promise<TransactionResponse>;
 }
 
 export enum TransactionStatus {
-  AWAITING_SIGNING,
-  PENDING,
-  SUCCESS,
-  FAILURE
+    AWAITING_SIGNING,
+    PENDING,
+    SUCCESS,
+    FAILURE
 }
 
 export type TransactionStatusCallback = (transaction: TransactionMetadata, status: TransactionStatus, hash?: string) => void;
 
 export interface TransactionMetadataParams {
-  [paramName: string]: any;
+    [paramName: string]: any;
 }
 
 export interface TransactionMetadata {
-  name: string;
-  params: TransactionMetadataParams;
+    name: string;
+    params: TransactionMetadataParams;
 }
 
 export class ContractDependenciesEthers implements Dependencies<BigNumber> {
-  public readonly provider: EthersProvider;
-  public readonly signer?: EthersSigner;
-  public readonly address?: string;
+    public readonly provider: EthersProvider;
+    public readonly signer?: EthersSigner;
+    public readonly address?: string;
 
-  private readonly abiCoder: ethers.utils.AbiCoder;
+    private readonly abiCoder: ethers.utils.AbiCoder;
 
-  private transactionDataMetaData: { [data: string]: TransactionMetadata } = {};
-  private transactionStatusCallbacks: { [key: string]: TransactionStatusCallback } = {};
+    private transactionDataMetaData: { [data: string]: TransactionMetadata } = {};
+    private transactionStatusCallbacks: { [key: string]: TransactionStatusCallback } = {};
 
-  public constructor(provider: EthersProvider, signer?: EthersSigner, address?: string) {
-    this.provider = provider;
-    if (this.signer && this.address) throw new Error("Must provide only one of signer or address")
-    this.signer = signer;
-    this.address = address;
-    this.abiCoder = new ethers.utils.AbiCoder();
-  }
-
-  public transactionToEthersTransaction(transaction: Transaction<BigNumber>): Transaction<ethers.utils.BigNumber> {
-    return {
-      to: transaction.to,
-      from: transaction.from,
-      data: transaction.data,
-      value: transaction.value ? new ethers.utils.BigNumber(transaction.value.toString()) : new ethers.utils.BigNumber(0)
-    }
-  }
-
-  public keccak256(utf8String: string): string {
-    return ethers.utils.keccak256(ethers.utils.toUtf8Bytes(utf8String));
-  }
-
-  public encodeParams(abiFunction: AbiFunction, parameters: Array<any>) {
-    const ethersParams = _.map(parameters, (param) => {
-      if (isInstanceOfBigNumber(param)) {
-        return new ethers.utils.BigNumber(param.toFixed());
-      } else if (isInstanceOfArray(param) && param.length > 0 && isInstanceOfBigNumber(param[0])) {
-        return _.map(param, (value) => new ethers.utils.BigNumber(value.toFixed()));
-      }
-      return param;
-    });
-    const txData = this.abiCoder.encode(abiFunction.inputs, ethersParams);
-    this.storeTxMetadata(abiFunction, parameters, txData);
-    return txData.substr(2);
-  }
-
-  public storeTxMetadata(abiFunction: AbiFunction, parameters: Array<any>, txData: string): void {
-    const txParams = _.reduce(abiFunction.inputs, (result, input, index) => {
-      result[input.name] = parameters[index];
-      return result;
-    }, {} as { [paramName: string]: any });
-    this.transactionDataMetaData[txData] = {
-      name: abiFunction.name,
-      params: txParams
-    };
-  }
-
-  public decodeParams(abiParameters: Array<AbiParameter>, encoded: string) {
-    const results = this.abiCoder.decode(abiParameters, encoded);
-    return _.map(results, (result) => {
-      if (isInstanceOfEthersBigNumber(result)) {
-        return new BigNumber(result.toString());
-      } else if (isInstanceOfArray(result) && result.length > 0 && isInstanceOfEthersBigNumber(result[0])) {
-        return _.map(result, (value) => new BigNumber(value.toString()));
-      }
-      return result;
-    });
-  }
-
-  public async call(transaction: Transaction<BigNumber>): Promise<string> {
-    return await this.provider.call(this.transactionToEthersTransaction(transaction));
-  }
-
-  public async getDefaultAddress(): Promise<string | undefined> {
-    if (this.signer) {
-      return getAddress(await this.signer.getAddress());
+    public constructor(provider: EthersProvider, signer?: EthersSigner, address?: string) {
+        this.provider = provider;
+        if (this.signer && this.address) throw new Error("Must provide only one of signer or address")
+        this.signer = signer;
+        this.address = address;
+        this.abiCoder = new ethers.utils.AbiCoder();
     }
 
-    if (this.address) return getAddress(this.address);
-
-    const addresses = await this.provider.listAccounts();
-    if (addresses.length > 0) return getAddress(addresses[0]);
-
-    return undefined;
-  }
-
-  public registerTransactionStatusCallback(key: string, callback: TransactionStatusCallback): void {
-    this.transactionStatusCallbacks[key] = callback;
-  }
-
-  public deRegisterTransactionStatusCallback(key: string): void {
-    delete this.transactionStatusCallbacks[key];
-  }
-
-  public deRegisterAllTransactionStatusCallbacks(): void {
-    Object.keys(this.transactionStatusCallbacks).map((key) => this.deRegisterTransactionStatusCallback(key));
-  }
-
-  public onTransactionStatusChanged(txMetadata: TransactionMetadata, status: TransactionStatus, hash?: string): void {
-    for (let callback of Object.values(this.transactionStatusCallbacks)) {
-      callback(txMetadata, status, hash);
-    }
-  }
-
-  public async submitTransaction(transaction: Transaction<BigNumber>): Promise<TransactionReceipt> {
-    if (!this.signer) throw new Error("Attempting to sign a transaction while not providing a signer");
-    // TODO: figure out a way to propagate a warning up to the user in this scenario, we don't currently have a mechanism for error propagation, so will require infrastructure work
-    // TODO: https://github.com/ethers-io/ethers.js/issues/321
-    const tx = this.transactionToEthersTransaction(transaction);
-    delete tx.from;
-    const txMetadataKey = `0x${transaction.data.substring(10)}`;
-    const txMetadata = this.transactionDataMetaData[txMetadataKey];
-    this.onTransactionStatusChanged(txMetadata, TransactionStatus.AWAITING_SIGNING);
-    let hash = undefined;
-    try {
-      const response = await this.signer.sendTransaction(tx);
-      hash = response.hash;
-      this.onTransactionStatusChanged(txMetadata, TransactionStatus.PENDING, hash);
-      const receipt = await response.wait();
-      const status = receipt.status == 1 ? TransactionStatus.SUCCESS : TransactionStatus.FAILURE;
-      this.onTransactionStatusChanged(txMetadata, status, hash);
-      // ethers has `status` on the receipt as optional, even though it isn't and never will be undefined if using a modern network (which this is designed for)
-      return <TransactionReceipt>receipt;
-    } catch (e) {
-      this.onTransactionStatusChanged(txMetadata, TransactionStatus.FAILURE, hash);
-      throw e;
-    } finally {
-      delete this.transactionDataMetaData[txMetadataKey];
+    public transactionToEthersTransaction(transaction: Transaction<BigNumber>): Transaction<ethers.utils.BigNumber> {
+        return {
+            to: transaction.to,
+            from: transaction.from,
+            data: transaction.data,
+            value: transaction.value ? new ethers.utils.BigNumber(transaction.value.toString()) : new ethers.utils.BigNumber(0)
+        }
     }
 
-  }
+    public keccak256(utf8String: string): string {
+        return ethers.utils.keccak256(ethers.utils.toUtf8Bytes(utf8String));
+    }
 
-  public async estimateGas(transaction: Transaction<BigNumber>): Promise<BigNumber> {
-    const gasEstimate = await this.provider.estimateGas(this.transactionToEthersTransaction(transaction));
-    return new BigNumber(gasEstimate.toString());
-  }
+    public encodeParams(abiFunction: AbiFunction, parameters: Array<any>) {
+        const ethersParams = _.map(parameters, (param) => {
+            if (isInstanceOfBigNumber(param)) {
+                return new ethers.utils.BigNumber(param.toFixed());
+            } else if (isInstanceOfArray(param) && param.length > 0 && isInstanceOfBigNumber(param[0])) {
+                return _.map(param, (value) => new ethers.utils.BigNumber(value.toFixed()));
+            }
+            return param;
+        });
+        const txData = this.abiCoder.encode(abiFunction.inputs, ethersParams);
+        this.storeTxMetadata(abiFunction, parameters, txData);
+        return txData.substr(2);
+    }
+
+    public storeTxMetadata(abiFunction: AbiFunction, parameters: Array<any>, txData: string): void {
+        const txParams = _.reduce(abiFunction.inputs, (result, input, index) => {
+            result[input.name] = parameters[index];
+            return result;
+        }, {} as {[paramName: string]: any});
+        this.transactionDataMetaData[txData] = {
+            name: abiFunction.name,
+            params: txParams
+        };
+    }
+
+    public decodeParams(abiParameters: Array<AbiParameter>, encoded: string) {
+        const results = this.abiCoder.decode(abiParameters, encoded);
+        return _.map(results, (result) => {
+            if (isInstanceOfEthersBigNumber(result)) {
+                return new BigNumber(result.toString());
+            } else if (isInstanceOfArray(result) && result.length > 0 && isInstanceOfEthersBigNumber(result[0])) {
+                return _.map(result, (value) => new BigNumber(value.toString()));
+            }
+            return result;
+        });
+    }
+
+    public async call(transaction: Transaction<BigNumber>): Promise<string> {
+        return await this.provider.call(this.transactionToEthersTransaction(transaction));
+    }
+
+    public async getDefaultAddress(): Promise<string | undefined> {
+        if (this.signer) {
+            return getAddress(await this.signer.getAddress());
+        }
+
+        if (this.address) return getAddress(this.address);
+
+        const addresses = await this.provider.listAccounts();
+        if (addresses.length > 0) return getAddress(addresses[0]);
+
+        return undefined;
+    }
+
+    public registerTransactionStatusCallback(key: string, callback: TransactionStatusCallback): void {
+        this.transactionStatusCallbacks[key] = callback;
+    }
+
+    public deRegisterTransactionStatusCallback(key: string): void {
+        delete this.transactionStatusCallbacks[key];
+    }
+
+    public deRegisterAllTransactionStatusCallbacks(): void {
+        Object.keys(this.transactionStatusCallbacks).map((key) => this.deRegisterTransactionStatusCallback(key));
+    }
+
+    public onTransactionStatusChanged(txMetadata: TransactionMetadata, status: TransactionStatus, hash?: string): void {
+        for (let callback of Object.values(this.transactionStatusCallbacks)) {
+            callback(txMetadata, status, hash);
+        }
+    }
+
+    public async submitTransaction(transaction: Transaction<BigNumber>): Promise<TransactionReceipt> {
+        if (!this.signer) throw new Error("Attempting to sign a transaction while not providing a signer");
+        // TODO: figure out a way to propagate a warning up to the user in this scenario, we don't currently have a mechanism for error propagation, so will require infrastructure work
+        // TODO: https://github.com/ethers-io/ethers.js/issues/321
+        const tx = this.transactionToEthersTransaction(transaction);
+        delete tx.from;
+        const txMetadataKey = `0x${transaction.data.substring(10)}`;
+        const txMetadata = this.transactionDataMetaData[txMetadataKey];
+        this.onTransactionStatusChanged(txMetadata, TransactionStatus.AWAITING_SIGNING);
+        let hash = undefined;
+        try {
+            const response = await this.signer.sendTransaction(tx);
+            hash = response.hash;
+            this.onTransactionStatusChanged(txMetadata, TransactionStatus.PENDING, hash);
+            const receipt = await response.wait();
+            const status = receipt.status == 1 ? TransactionStatus.SUCCESS : TransactionStatus.FAILURE;
+            this.onTransactionStatusChanged(txMetadata, status, hash);
+            // ethers has `status` on the receipt as optional, even though it isn't and never will be undefined if using a modern network (which this is designed for)
+            return <TransactionReceipt>receipt;
+        } catch (e) {
+            this.onTransactionStatusChanged(txMetadata, TransactionStatus.FAILURE, hash);
+            throw e;
+        } finally {
+            delete this.transactionDataMetaData[txMetadataKey];
+        }
+
+    }
+
+    public async estimateGas(transaction: Transaction<BigNumber>): Promise<BigNumber> {
+        const gasEstimate = await this.provider.estimateGas(this.transactionToEthersTransaction(transaction));
+        return new BigNumber(gasEstimate.toString());
+    }
 }


### PR DESCRIPTION
Reverts AugurProject/augur#2716

@brianosaurus -- These changes are broken.

`makeSigner` isn't part of the types for ganache, and ganache.Account isn't exported.

Furthermore, all the imports in TransactionStatus.test.ts are referring to the specific build subdirectory of augur-tools, etc and that's incorrect.

Merging breaks the build, I'm reverting.