### PR TITLE
detect user's wallet is pointing to wrong network

### DIFF
--- a/packages/augur-ui/src/modules/auth/actions/login-with-edge.ts
+++ b/packages/augur-ui/src/modules/auth/actions/login-with-edge.ts
@@ -32,7 +32,7 @@ export const loginWithEdgeEthereumWallet = (
     edgeUiAccount,
   };
 
-  await dispatch(updateSdk(loginAccount, null));
+  await dispatch(updateSdk(loginAccount, undefined, null));
 
   dispatch(updateAuthStatus(IS_LOGGED, true));
   dispatch(loadAccountData(loginAccount));

--- a/packages/augur-ui/src/modules/auth/actions/login-with-fortmatic.ts
+++ b/packages/augur-ui/src/modules/auth/actions/login-with-fortmatic.ts
@@ -55,7 +55,7 @@ export const loginWithFortmatic = (callback: NodeStyleCallback) => async (
         },
       };
 
-      await dispatch(updateSdk(accountObject, provider));
+      await dispatch(updateSdk(accountObject, networkId, provider));
 
       dispatch(updateIsLoggedAndLoadAccountData(
         account,

--- a/packages/augur-ui/src/modules/auth/actions/login-with-injected-web3.ts
+++ b/packages/augur-ui/src/modules/auth/actions/login-with-injected-web3.ts
@@ -18,6 +18,7 @@ export const loginWithInjectedWeb3 = (callback: NodeStyleCallback = logError) =>
     if (!account) return failure();
 
     const provider = new Web3Provider(window.web3.currentProvider);
+    const networkId = window.web3.currentProvider.networkVersion;
     const isWeb3 = true;
 
     const accountObject = {
@@ -32,7 +33,7 @@ export const loginWithInjectedWeb3 = (callback: NodeStyleCallback = logError) =>
       },
     };
 
-    await dispatch(updateSdk(accountObject, provider));
+    await dispatch(updateSdk(accountObject, networkId, provider));
     dispatch(useUnlockedAccount(account));
     callback(null, account);
   };

--- a/packages/augur-ui/src/modules/auth/actions/login-with-ledger.ts
+++ b/packages/augur-ui/src/modules/auth/actions/login-with-ledger.ts
@@ -29,7 +29,7 @@ export default function loginWithLedger(
       },
     };
 
-    await dispatch(updateSdk(loginAccount, null));
+    await dispatch(updateSdk(loginAccount, undefined, null));
     dispatch(updateAuthStatus(IS_LOGGED, true));
     dispatch(loadAccountData(loginAccount));
   };

--- a/packages/augur-ui/src/modules/auth/actions/login-with-portis.ts
+++ b/packages/augur-ui/src/modules/auth/actions/login-with-portis.ts
@@ -51,7 +51,7 @@ export const loginWithPortis = (callback: NodeStyleCallback) => async (
         },
       };
 
-      await dispatch(updateSdk(accountObject, provider));
+      await dispatch(updateSdk(accountObject, networkId, provider));
 
       dispatch(updateIsLoggedAndLoadAccountData(
         account,

--- a/packages/augur-ui/src/modules/auth/actions/login-with-trezor.ts
+++ b/packages/augur-ui/src/modules/auth/actions/login-with-trezor.ts
@@ -28,7 +28,7 @@ export default function loginWithTrezor(
       },
     };
 
-    await dispatch(updateSdk(loginAccount, null));
+    await dispatch(updateSdk(loginAccount, undefined, null));
     dispatch(updateAuthStatus(IS_LOGGED, true));
     dispatch(loadAccountData(loginAccount));
   };

--- a/packages/augur-ui/src/modules/auth/actions/update-sdk.ts
+++ b/packages/augur-ui/src/modules/auth/actions/update-sdk.ts
@@ -3,7 +3,7 @@ import { LoginAccount } from "modules/types";
 import { augurSdk } from "services/augursdk";
 import { JsonRpcProvider } from "ethers/providers";
 
-export function updateSdk(loginAccount: LoginAccount, injectedProvider: JsonRpcProvider | null) {
+export function updateSdk(loginAccount: LoginAccount, networkId: string, injectedProvider: JsonRpcProvider | null) {
   return async () => {
     const { address, meta }  = loginAccount;
     if (!meta || !address) return;
@@ -24,6 +24,7 @@ export function updateSdk(loginAccount: LoginAccount, injectedProvider: JsonRpcP
         address,
         meta.signer,
         env,
+        networkId,
         meta.isWeb3
       );
     } catch (error) {

--- a/packages/augur-ui/src/modules/reports/actions/load-designated-reporter-markets.ts
+++ b/packages/augur-ui/src/modules/reports/actions/load-designated-reporter-markets.ts
@@ -32,7 +32,7 @@ export const loadDesignatedReporterMarkets = (
   const Augur = augurSdk.get();
   const marketIds = await Augur.getMarkets(designatedReportingQuery);
   dispatch(
-    loadMarketsInfoIfNotLoaded(marketIds, (err: any) => {
+    loadMarketsInfoIfNotLoaded(marketIds || [], (err: any) => {
       if (err) return callback(err);
       callback(null, marketIds);
     })

--- a/packages/augur-ui/src/services/augursdk.ts
+++ b/packages/augur-ui/src/services/augursdk.ts
@@ -10,24 +10,29 @@ import { JsonRpcProvider } from 'ethers/providers';
 import { Addresses } from '@augurproject/artifacts';
 import { EnvObject } from 'modules/types';
 import { listenToUpdates } from 'modules/events/actions/listen-to-updates';
+import { getNetworkId } from 'modules/contracts/actions/contractCalls';
 
 export class SDK {
   public sdk: Augur<Provider> | null = null;
   public isWeb3Transport: boolean = false;
   public env: EnvObject = null;
   public isSubscribed: boolean = false;
+  public networkId: string;
+  private signerNetworkId: string;
 
   public async makeApi(
     provider: JsonRpcProvider,
     account: string = '',
     signer: EthersSigner,
     env: EnvObject,
+    signerNetworkId?: string,
     isWeb3: boolean = false
   ) {
     this.isWeb3Transport = isWeb3;
     this.env = env;
+    this.signerNetworkId = signerNetworkId;
     const ethersProvider = new EthersProvider(provider, 10, 0, 40);
-    const networkId = await ethersProvider.getNetworkId();
+    this.networkId = await ethersProvider.getNetworkId();
     const contractDependencies = new ContractDependenciesEthers(
       ethersProvider,
       signer,
@@ -37,7 +42,7 @@ export class SDK {
     this.sdk = await Augur.create<Provider>(
       ethersProvider,
       contractDependencies,
-      Addresses[networkId],
+      Addresses[this.networkId],
       new WebWorkerConnector()
     );
 
@@ -65,11 +70,19 @@ export class SDK {
     if (this.isSubscribed) return;
     try {
       this.isSubscribed = true;
-      console.log("Subscribing to Augur events");
+      console.log('Subscribing to Augur events');
       dispatch(listenToUpdates(this.get()));
     } catch (e) {
       this.isSubscribed = false;
     }
+  }
+
+  public sameNetwork(): boolean {
+    const localNetwork = this.networkId;
+    const signerNetworkId = this.signerNetworkId;
+
+    if (!localNetwork || !signerNetworkId) return undefined;
+    return localNetwork.toString() === signerNetworkId.toString();
   }
 }
 

--- a/packages/augur-ui/src/services/initialize.ts
+++ b/packages/augur-ui/src/services/initialize.ts
@@ -8,16 +8,16 @@ import getInjectedWeb3Accounts from "utils/get-injected-web3-accounts";
 export const connect = async (env: EnvObject, callback: NodeStyleCallback = logError) => {
   const injectedAccount = await getInjectedWeb3Accounts();
   const loggedInAccount = windowRef.localStorage.getItem("loggedInAccount");
-
+  let signer = undefined;
+  let signerNetworkId = undefined;
+  let account = undefined;
   // Use injected provider if returning User has a unlocked injected account that matches the current logged in account
   if (injectedAccount && (loggedInAccount === injectedAccount[0])) {
     const provider = new Web3Provider(windowRef.web3.currentProvider);
-    const account = windowRef.web3.currentProvider.selectedAddress;
-
-    await augurSdk.makeApi(provider, account, provider.getSigner(), env, true);
-  } else {
-    await augurSdk.makeApi(new JsonRpcProvider(env["ethereum-node"].http), undefined, undefined, env, false);
+    account = windowRef.web3.currentProvider.selectedAddress;
+    signerNetworkId = windowRef.web3.currentProvider.networkVersion;
+    signer = provider.getSigner()
   }
-
+  await augurSdk.makeApi(new JsonRpcProvider(env["ethereum-node"].http), account, signer, env, signerNetworkId, false);
   callback(null);
 };


### PR DESCRIPTION
fixes https://github.com/AugurProject/augur/issues/2644

User's provider/wallet has to provide networkId they are connected to. Check against ethersProvider provided to sdk. 

![Screen Shot 2019-07-15 at 7 13 35 PM](https://user-images.githubusercontent.com/3970376/61256989-a92dcd80-a734-11e9-85ee-ef8cb864a212.png)
