### PR TITLE
fix order form issue where user changes price after clicking on order…

### DIFF
--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -83,7 +83,7 @@ export default class MarketView extends Component<MarketViewProps, MarketViewSta
       extendOrderBook: false,
       extendTradeHistory: false,
       selectedOrderProperties: this.DEFAULT_ORDER_PROPERTIES,
-      selectedOutcomeId: props.market.defaultSelectedOutcomeId,
+      selectedOutcomeId: props.market ? props.market.defaultSelectedOutcomeId : 0,
       fixedPrecision: 4,
       selectedOutcomeProperties: {
         1: {

--- a/packages/augur-ui/src/modules/orders/selectors/user-open-orders.ts
+++ b/packages/augur-ui/src/modules/orders/selectors/user-open-orders.ts
@@ -164,7 +164,7 @@ function getUserOpenOrders(
 
   return Object.keys(typeOrders)
     .map(orderId => typeOrders[orderId])
-    .filter(order => isOrderOfUser(order, userId) && order.orderState === OPEN)
+    .filter(order => isOrderOfUser(order, userId))
     .sort((order1, order2) =>
       createBigNumber(order2.price, 10).comparedTo(
         createBigNumber(order1.price, 10)

--- a/packages/augur-ui/src/modules/trading/components/form/form.tsx
+++ b/packages/augur-ui/src/modules/trading/components/form/form.tsx
@@ -452,7 +452,7 @@ class Form extends Component<FromProps, FormState> {
                 order[this.INPUT_TYPES.QUANTITY] &&
                 order[this.INPUT_TYPES.PRICE] &&
                 order[this.INPUT_TYPES.QUANTITY] !== '0' &&
-                ((this.state.lastInputModified === this.INPUT_TYPES.QUANTITY &&
+                (((!this.state.lastInputModified || this.state.lastInputModified === this.INPUT_TYPES.QUANTITY) &&
                   property === this.INPUT_TYPES.PRICE) ||
                   property === this.INPUT_TYPES.QUANTITY)
               ) {


### PR DESCRIPTION
… book order

fixes https://github.com/AugurProject/augur/issues/1911


Issue was order form didn't allow for `lastInputModified` variable to be empty when trying to calc order form values.

also noticed that market-view can throw if market hasn't been loaded, need to default selected outcome id. 

also saw that user open orders is filtering on order status, FILLED. since we get user open orders specifically we don't need to filter. Also, FILLED means partially filled.