### PR TITLE
wait until connected to load filtered markets

### DIFF
--- a/packages/augur-ui/src/modules/markets-list/components/markets-view.tsx
+++ b/packages/augur-ui/src/modules/markets-list/components/markets-view.tsx
@@ -11,6 +11,7 @@ interface MarketsViewProps {
   markets: Array<MarketData>;
   location: object;
   history: object;
+  isConnected: boolean,
   toggleFavorite: (...args: any[]) => any;
   loadMarketsInfoIfNotLoaded: (...args: any[]) => any;
   isMobile: boolean;
@@ -64,16 +65,16 @@ export default class MarketsView extends Component<
   }
 
   componentDidMount() {
-    const { universe } = this.props;
-    if (universe) {
+    const { isConnected } = this.props;
+    if (isConnected) {
       this.updateFilteredMarkets();
     }
   }
 
   componentDidUpdate(prevProps) {
-    const { search, category, universe } = this.props;
+    const { search, category, isConnected } = this.props;
     if (
-      universe !== prevProps.universe ||
+      isConnected !== prevProps.isConnected ||
       (search !== prevProps.search || category !== prevProps.category)
     ) {
       this.updateFilteredMarkets();

--- a/packages/augur-ui/src/modules/markets-list/containers/markets-view-container.ts
+++ b/packages/augur-ui/src/modules/markets-list/containers/markets-view-container.ts
@@ -25,6 +25,7 @@ const mapStateToProps = (state: AppState, { location }) => {
   const searchPhrase = buildSearchString(keywords, selectedTagNames);
 
   return {
+    isConnected: state.connection.isConnected && state.universe.id != null,
     isLogged: state.authStatus.isLogged,
     universe: (state.universe || {}).id,
     search: searchPhrase,


### PR DESCRIPTION
fix initial load of markets list page. sometimes UI tries to get markets when the sdk hasn't processed logs yet.