### PR TITLE
Closes #2808 - all tracked users for db create

### DIFF
--- a/packages/augur-sdk/src/state/db/DB.ts
+++ b/packages/augur-sdk/src/state/db/DB.ts
@@ -135,20 +135,25 @@ export class DB {
     this.blockAndLogStreamerListener = blockAndLogStreamerListener;
 
     // Create SyncableDBs for generic event types & UserSyncableDBs for user-specific event types
-    for (let eventName of this.genericEventNames) {
+    for (const eventName of this.genericEventNames) {
       new SyncableDB(this.augur, this, networkId, eventName, this.getDatabaseName(eventName), []);
     }
 
-    for (let derivedDBConfiguration of this.basicDerivedDBs) {
+    for (const derivedDBConfiguration of this.basicDerivedDBs) {
       new DerivedDB(this, networkId, derivedDBConfiguration.name, derivedDBConfiguration.eventNames, derivedDBConfiguration.idFields);
     }
 
     // Custom Derived DBs here
     this.marketDatabase = new MarketDB(this, networkId);
 
-    for (let trackedUser of await this.trackedUsers.getUsers()) {
+    // add passed in tracked users to the tracked uses db
+    for (const trackedUser of trackedUsers) {
       await this.trackedUsers.setUserTracked(trackedUser);
-      for (let userSpecificEvent of this.userSpecificDBs) {
+    }
+
+    // iterate over all known tracked users
+    for (const trackedUser of await this.trackedUsers.getUsers()) {
+      for (const userSpecificEvent of this.userSpecificDBs) {
         new UserSyncableDB(this.augur, this, networkId, userSpecificEvent.name, trackedUser, userSpecificEvent.numAdditionalTopics, userSpecificEvent.userTopicIndicies, userSpecificEvent.idFields);
       }
     }

--- a/packages/augur-sdk/src/state/db/DB.ts
+++ b/packages/augur-sdk/src/state/db/DB.ts
@@ -146,7 +146,7 @@ export class DB {
     // Custom Derived DBs here
     this.marketDatabase = new MarketDB(this, networkId);
 
-    for (let trackedUser of trackedUsers) {
+    for (let trackedUser of await this.trackedUsers.getUsers()) {
       await this.trackedUsers.setUserTracked(trackedUser);
       for (let userSpecificEvent of this.userSpecificDBs) {
         new UserSyncableDB(this.augur, this, networkId, userSpecificEvent.name, trackedUser, userSpecificEvent.numAdditionalTopics, userSpecificEvent.userTopicIndicies, userSpecificEvent.idFields);


### PR DESCRIPTION
Only one account is passed into create-api methods. That account was turning into trackedUsers but there are more than one in the TrackedUsers db. So...create would create one db but rollback/sync would get all of the users and try to rollback/sync. This caused an exception and events wouldn't fire.