### PR TITLE
draft and validations polish

### DIFF
--- a/packages/augur-ui/src/modules/create-market/components/form-details.tsx
+++ b/packages/augur-ui/src/modules/create-market/components/form-details.tsx
@@ -215,7 +215,10 @@ export default class FormDetails extends React.Component<
                 <TextInput
                   type="number"
                   placeholder="0"
-                  onChange={(value: string) => onChange("minPrice", value)}
+                  onChange={(value: string) => {
+                    onChange("minPrice", value)
+                    onError("maxPrice", "");
+                  }}
                   value={minPrice}
                   errorMessage={validations[currentStep].minPrice}
                 />
@@ -223,7 +226,10 @@ export default class FormDetails extends React.Component<
                 <TextInput
                   type="number"
                   placeholder="100"
-                  onChange={(value: string) => onChange("maxPrice", value)}
+                  onChange={(value: string) => {
+                    onChange("maxPrice", value)
+                    onError("minPrice", "");
+                  }}
                   trailingLabel={scalarDenomination !=="" ? scalarDenomination : "Denomination"}
                   value={maxPrice}
                   errorMessage={validations[currentStep].maxPrice}

--- a/packages/augur-ui/src/modules/create-market/components/form-details.tsx
+++ b/packages/augur-ui/src/modules/create-market/components/form-details.tsx
@@ -184,7 +184,7 @@ export default class FormDetails extends React.Component<
             })}
             rows="3"
             value={description}
-            errorMessage={validations[currentStep].description}
+            errorMessage={validations[currentStep].description && (validations[currentStep].description.charAt(0).toUpperCase() + validations[currentStep].description.slice(1).toLowerCase())}
           />
 
           {marketType === CATEGORICAL && 

--- a/packages/augur-ui/src/modules/create-market/components/form.tsx
+++ b/packages/augur-ui/src/modules/create-market/components/form.tsx
@@ -447,7 +447,7 @@ export default class Form extends React.Component<
     const disabledSave = savedDraft && JSON.stringify(newMarket) === JSON.stringify(savedDraft);
 
     const noErrors = Object.values(((validations && validations[currentStep]) || {})).every(field => (Array.isArray(field) ? field.every(val => val === "" || !val) : !field || field === ''));
-    const saveDraftError = validations[currentStep].description === draftError;
+    const saveDraftError = validations && validations[currentStep] && validations[currentStep].description === draftError;
 
     return (
       <div 

--- a/packages/augur-ui/src/modules/create-market/landing.tsx
+++ b/packages/augur-ui/src/modules/create-market/landing.tsx
@@ -29,7 +29,8 @@ export default class Landing extends React.Component<
 
   render() {
     const {
-      updatePage
+      updatePage,
+      clearNewMarket
     } = this.props;
     const s = this.state;
 
@@ -74,8 +75,8 @@ export default class Landing extends React.Component<
             <SecondaryButton 
               text="Create a custom market" 
               action={() => {
+                clearNewMarket();
                 updatePage(SCRATCH);
-                this.props.clearNewMarket();
               }}
             />
           </ContentBlock>

--- a/packages/augur-ui/src/modules/markets/reducers/new-market.ts
+++ b/packages/augur-ui/src/modules/markets/reducers/new-market.ts
@@ -66,8 +66,6 @@ export const DEFAULT_STATE: NewMarket = {
   maxPriceBigNumber: createBigNumber(1),
   initialLiquidityEth: createBigNumber(0),
   initialLiquidityGas: createBigNumber(0),
-  creationError:
-    "Unable to create market.  Ensure your market is unique and all values are valid."
 };
 
 export default function(newMarket: NewMarket = DEFAULT_STATE, { type, data }: BaseAction): NewMarket {
@@ -147,7 +145,25 @@ export default function(newMarket: NewMarket = DEFAULT_STATE, { type, data }: Ba
     }
     case RESET_STATE:
     case CLEAR_NEW_MARKET:
-      return DEFAULT_STATE;
+      return {
+        ...DEFAULT_STATE,
+        validations: [{
+          description: null,
+          categories: ["", "", ""],
+          designatedReporterAddress: null,
+          expirySourceType: null,
+          endTime: null,
+          hour: null,
+          minute: null,
+          meridiem: null,
+          outcomes: null,
+          scalarDenomination: null,
+          outcomes: ["", ""]
+        },
+        {
+          settlementFee: ""
+        }],
+      };
     default:
       return newMarket;
   }


### PR DESCRIPTION
- don't show draft saving modal when only validations are in newMarket
- don't compare validation differences to tell whether draft is saved
- show error when they save draft without a market description
- make sure validations get cleared when newMarket gets cleared
- clear min and max errors when min or max gets changed