### PR TITLE
reduce-padding-transaction-history-modal

### DIFF
--- a/packages/augur-ui/src/modules/modal/modal.styles.less
+++ b/packages/augur-ui/src/modules/modal/modal.styles.less
@@ -638,10 +638,11 @@ div.ButtonsRow:last-of-type {
     grid-template-rows: 1fr 2fr;
 
     @media @breakpoint-mobile {
-      grid-gap: 0 @size-12;
+      grid-gap: @size-8 @size-12;
       grid-template-columns: 1fr 1fr;
       grid-template-rows: auto;
-      height: 280px;
+      height: auto;
+      margin-bottom: @size-8;
 
       > span:first-of-type {
         order: 2;

--- a/packages/augur-ui/src/modules/modal/transactions.tsx
+++ b/packages/augur-ui/src/modules/modal/transactions.tsx
@@ -14,12 +14,10 @@ import {
 } from "modules/common/constants";
 import { Pagination } from "modules/common/pagination";
 import { ValueLabel, TextLabel } from "modules/common/labels";
-import { SquareDropdown } from "modules/common/selection";
-import { DatePicker } from "modules/common/form";
+import { DatePicker, FormDropdown } from "modules/common/form";
 import { Title } from "modules/modal/common";
 import { formatEther, formatShares } from "utils/format-number";
 import Styles from "modules/modal/modal.styles.less";
-import { FormDropdown } from "modules/common/form";
 
 interface TransactionsProps {
   closeAction: Function;


### PR DESCRIPTION
consolidated imports in transactions.tsx, updated the modal styling for mobile to fix padding, discovered issues with common components and created a new issue to address it

https://github.com/AugurProject/augur/issues/1708