### PR TITLE
fix-tag-spacing-mobile

### DIFF
--- a/packages/augur-ui/src/modules/market/components/market-header/market-header.styles.less
+++ b/packages/augur-ui/src/modules/market/components/market-header/market-header.styles.less
@@ -286,9 +286,14 @@
 
       > div:first-of-type {
         padding-top: 0;
+        margin-top: -@size-8;
 
         > span {
-          margin: 0 @size-8 0 0;
+          margin: @size-8 @size-8 0 0;
+        }
+
+        > button {
+          margin-top: @size-8;
         }
       }
     }


### PR DESCRIPTION
added margins to separate the tag bubbles on mobile on the trading page

https://github.com/AugurProject/augur/issues/1722