### PR TITLE
increase-text-touch-area-mobile

### DIFF
--- a/packages/augur-ui/src/modules/common/buttons.styles.less
+++ b/packages/augur-ui/src/modules/common/buttons.styles.less
@@ -242,6 +242,10 @@
   line-height: @size-10;
   text-transform: uppercase;
 
+  @media @breakpoint-mobile {
+    line-height: @size-24;
+  }
+
   &:hover {
     font-weight: bold;
   }


### PR DESCRIPTION
upped line height of SubmitTextbutton on mobile from 10 to 24px in order to increase surface area of touch events

https://github.com/augurproject/augur/issues/1989