### PR TITLE
load marketIds of user's pending orders

### DIFF
--- a/packages/augur-ui/src/modules/markets/actions/load-markets-info.ts
+++ b/packages/augur-ui/src/modules/markets/actions/load-markets-info.ts
@@ -43,7 +43,7 @@ export const loadMarketsInfo = (
 };
 
 export const loadMarketsInfoIfNotLoaded = (
-  marketIds: Array<string>,
+  marketIds: string[],
   callback: NodeStyleCallback = logError
 ): ThunkAction<any, any, any, any> => (
   dispatch: ThunkDispatch<void, any, Action>,

--- a/packages/augur-ui/src/modules/reports/actions/load-reporting-history.ts
+++ b/packages/augur-ui/src/modules/reports/actions/load-reporting-history.ts
@@ -33,6 +33,8 @@ const loadReportingHistoryInternal = (
 ) => (dispatch: ThunkDispatch<void, any, Action>, getState: () => AppState) => {
   const { universe, loginAccount } = getState();
   if (!loginAccount.address) return callback(null, {});
+  return callback(null, {}); // TODO: needed to resolve promises in load-account-history;
+
   // TODO: get reporting history of user as part of the reporting redsign
   /*
   .reporting.getReportingHistory(


### PR DESCRIPTION
in load user history (called when user logs in) add marketIds that user has pending orders. So portfolio will show those pending orders. 

![image](https://user-images.githubusercontent.com/3970376/62335043-cf22d400-b48f-11e9-8ad1-c02d416ca461.png)


fixes https://github.com/augurproject/augur/issues/2746

Edge case. If user creates orders in a market that they don't have any history, then closes the browser when they come back and won't see the pending order in portfolio b/c the market hasn't been loaded. 