### PR TITLE
only update user balances when they are logged in.

### DIFF
--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -115,7 +115,7 @@ export const handleNewBlockLog = (log: Events.NewBlock) => (
     dispatch(updateConnectionStatus(true));
   }
   // update assets each block
-  dispatch(updateAssets());
+  if (getState().authStatus.isLogged) dispatch(updateAssets());
 };
 
 export const handleMarketCreatedLog = (log: any) => (


### PR DESCRIPTION
fixes https://github.com/AugurProject/augur/issues/2986

new block event was causing user's balance to go to 0. This can still happen if connection to ethereum node is lost when user's browser tab goes inactive.