### PR TITLE
update pending orders with transaction data when user logs in

### DIFF
--- a/packages/augur-sdk/src/Augur.ts
+++ b/packages/augur-sdk/src/Augur.ts
@@ -19,6 +19,7 @@ import { Users } from "./state/getter/Users";
 import { getAddress } from "ethers/utils/address";
 import { isSubscriptionEventName, SubscriptionEventName, TXEventName } from "./constants";
 import { Liquidity } from "./api/Liquidity";
+import { TransactionResponse } from "ethers/providers";
 
 export class Augur<TProvider extends Provider = Provider> {
   readonly provider: TProvider;
@@ -99,11 +100,21 @@ export class Augur<TProvider extends Provider = Provider> {
     return augur;
   }
 
-  async getTransaction(hash: string): Promise<string> {
-    const tx = await this.dependencies.provider.getTransaction(hash);
-    if (!tx) return "";
-    return tx.from;
+  async isTransactionConfirmed(hash: string): Promise<boolean> {
+    const tx = await this.getTransaction(hash);
+    if (!tx) {
+      console.log("Transaction could not be found", hash);
+      return false;
+    }
+    // confirmations is number of blocks beyond block that includes tx
+    return tx.confirmations > 0;
   }
+
+  async getTransaction(hash: string): Promise<TransactionResponse> {
+    const tx = await this.dependencies.provider.getTransaction(hash);
+    return tx;
+  }
+
   async listAccounts() {
     return this.dependencies.provider.listAccounts();
   }

--- a/packages/augur-sdk/src/Augur.ts
+++ b/packages/augur-sdk/src/Augur.ts
@@ -100,16 +100,6 @@ export class Augur<TProvider extends Provider = Provider> {
     return augur;
   }
 
-  async isTransactionConfirmed(hash: string): Promise<boolean> {
-    const tx = await this.getTransaction(hash);
-    if (!tx) {
-      console.log("Transaction could not be found", hash);
-      return false;
-    }
-    // confirmations is number of blocks beyond block that includes tx
-    return tx.confirmations > 0;
-  }
-
   async getTransaction(hash: string): Promise<TransactionResponse> {
     const tx = await this.dependencies.provider.getTransaction(hash);
     return tx;

--- a/packages/augur-ui/src/modules/auth/actions/load-account-data-from-local-storage.ts
+++ b/packages/augur-ui/src/modules/auth/actions/load-account-data-from-local-storage.ts
@@ -3,7 +3,7 @@ import { loadDrafts } from "modules/create-market/actions/update-drafts";
 import { addAlert } from "modules/alerts/actions/alerts";
 import { loadPendingLiquidityOrders } from "modules/orders/actions/liquidity-management";
 import { updateReadNotifications } from "modules/notifications/actions/update-notifications";
-import { loadPendingOrders } from "modules/orders/actions/pending-orders-management";
+import { loadPendingOrdersTransactions } from "modules/orders/actions/pending-orders-management";
 import { updateGasPriceInfo } from "modules/app/actions/update-gas-price-info";
 import { registerUserDefinedGasPriceFunction } from "modules/app/actions/register-user-defined-gasPrice-function";
 import { updateUniverse } from "modules/universe/actions/update-universe";
@@ -74,9 +74,9 @@ export const loadAccountDataFromLocalStorage = (address: string): ThunkAction<an
         );
       }
       if (
-        pendingOrders
+        pendingOrders && Object.keys(pendingOrders).length > 0
       ) {
-        dispatch(loadPendingOrders(pendingOrders));
+        dispatch(loadPendingOrdersTransactions(pendingOrders));
       }
       if (
         pendingQueue

--- a/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
+++ b/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
@@ -41,6 +41,16 @@ export function isWeb3Transport(): boolean {
   return augurSdk.isWeb3Transport;
 }
 
+export async function isTransactionConfirmed(hash: string): Promise<boolean> {
+  const tx = await getTransaction(hash);
+  if (!tx) {
+    console.log("Transaction could not be found", hash);
+    return false;
+  }
+  // confirmations is number of blocks beyond block that includes tx
+  return tx.confirmations > 0;
+}
+
 export async function getTransaction(hash: string): Promise<any> {
   const Augur = augurSdk.get();
   const tx = await Augur.getTransaction(hash);

--- a/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
+++ b/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
@@ -24,7 +24,7 @@ export const addUpdateTransaction = (txStatus: Events.TXStatus) => (
           const market = marketInfos[marketId];
           return addOrder(txStatus, market, dispatch);
         }
-        dispatch(updatePendingOrderStatus(tradeGroupId, marketId, eventName));
+        dispatch(updatePendingOrderStatus(tradeGroupId, marketId, eventName, hash));
         if (eventName === TXEventName.Success) {
           dispatch(removePendingOrder(tradeGroupId, marketId));
         }
@@ -44,9 +44,9 @@ export const addUpdateTransaction = (txStatus: Events.TXStatus) => (
   }
 };
 
-function addOrder(tx: Events.TXStatus, market: Getters.MarketInfo, dispatch) {
+function addOrder(tx: Events.TXStatus, market: Getters.Markets.MarketInfo, dispatch) {
   if (!market) return console.log(`Could not find ${market.id} to process transaction`)
-  const order: UIOrder = convertTransactionOrderToUIOrder(tx.transaction.params, tx.eventName, market);
+  const order: UIOrder = convertTransactionOrderToUIOrder(tx.hash, tx.transaction.params, tx.eventName, market);
   if (!order) return console.log(`Could not process order to add pending order for market ${market.id}`);
   dispatch(addPendingOrder(order, market.id));
 }

--- a/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
+++ b/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
@@ -26,7 +26,7 @@ export const addUpdateTransaction = (txStatus: Events.TXStatus) => (
         }
         dispatch(updatePendingOrderStatus(tradeGroupId, marketId, eventName, hash));
         if (eventName === TXEventName.Success) {
-          dispatch(removePendingOrder(tradeGroupId, marketId));
+          //dispatch(removePendingOrder(tradeGroupId, marketId));
         }
         break;
       }

--- a/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
+++ b/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
@@ -26,7 +26,7 @@ export const addUpdateTransaction = (txStatus: Events.TXStatus) => (
         }
         dispatch(updatePendingOrderStatus(tradeGroupId, marketId, eventName, hash));
         if (eventName === TXEventName.Success) {
-          //dispatch(removePendingOrder(tradeGroupId, marketId));
+          dispatch(removePendingOrder(tradeGroupId, marketId));
         }
         break;
       }

--- a/packages/augur-ui/src/modules/events/actions/transaction-conversions.ts
+++ b/packages/augur-ui/src/modules/events/actions/transaction-conversions.ts
@@ -3,7 +3,7 @@ import { Getters, convertOnChainPriceToDisplayPrice, convertOnChainAmountToDispl
 import { SELL, BUY, TX_TRADE_GROUP_ID, TX_MARKET_ID, TX_OUTCOME_ID, TX_PRICE, TX_AMOUNT, TX_DIRECTION } from 'modules/common/constants';
 import { createBigNumber } from 'utils/create-big-number';
 
-export function convertTransactionOrderToUIOrder(onChainOrder, status: string, market: Getters.Markets.MarketInfo): UIOrder {
+export function convertTransactionOrderToUIOrder(hash: string, onChainOrder, status: string, market: Getters.Markets.MarketInfo): UIOrder {
   console.log(JSON.stringify(onChainOrder));
   const outcomeId = onChainOrder[TX_OUTCOME_ID].toNumber();
   const outcome = market.outcomes.find(o => o.id === outcomeId);
@@ -23,7 +23,8 @@ export function convertTransactionOrderToUIOrder(onChainOrder, status: string, m
     fullPrecisionAmount: amount,
     type: onChainOrder[TX_DIRECTION].eq(0) ? BUY : SELL,
     outcomeName: outcome.description,
-    status
+    status,
+    hash
   }
 }
 

--- a/packages/augur-ui/src/modules/orders/reducers/pending-orders.ts
+++ b/packages/augur-ui/src/modules/orders/reducers/pending-orders.ts
@@ -24,12 +24,13 @@ export default function(
       };
     }
     case UPDATE_PENDING_ORDER: {
-      const { id, marketId, status } = data;
+      const { id, marketId, status, hash } = data;
       const orders = pendingOrders[marketId];
       if (!orders) return pendingOrders;
       const order = orders.find(o => o.id === id)
       if (!order) return pendingOrders;
       order.status = status;
+      order.hash = hash;
       return pendingOrders;
     }
     case REMOVE_PENDING_ORDER: {

--- a/packages/augur-ui/src/modules/orders/reducers/pending-orders.ts
+++ b/packages/augur-ui/src/modules/orders/reducers/pending-orders.ts
@@ -1,20 +1,21 @@
 import {
   ADD_PENDING_ORDER,
   REMOVE_PENDING_ORDER,
-  LOAD_PENDING_ORDERS,
   UPDATE_PENDING_ORDER,
-} from "modules/orders/actions/pending-orders-management";
-import { PendingOrders, BaseAction, UIOrder } from "modules/types";
+} from 'modules/orders/actions/pending-orders-management';
+import { PendingOrders, BaseAction, UIOrder } from 'modules/types';
+import { RESET_STATE } from 'modules/app/actions/reset-state';
 
 const DEFAULT_STATE: PendingOrders = {};
 
 export default function(
   pendingOrders: PendingOrders = DEFAULT_STATE,
-  { type, data }: BaseAction,
+  { type, data }: BaseAction
 ): PendingOrders {
   switch (type) {
     case ADD_PENDING_ORDER: {
       const { pendingOrder, marketId } = data;
+      console.log('add pending orders', pendingOrder);
       const orders = pendingOrders[marketId] || [];
       if (pendingOrder) orders.push(pendingOrder);
 
@@ -27,29 +28,25 @@ export default function(
       const { id, marketId, status, hash } = data;
       const orders = pendingOrders[marketId];
       if (!orders) return pendingOrders;
-      const order = orders.find(o => o.id === id)
+      const order = orders.find(o => o.id === id);
       if (!order) return pendingOrders;
       order.status = status;
       order.hash = hash;
       return pendingOrders;
     }
     case REMOVE_PENDING_ORDER: {
-      const { id, marketId } = data;
-      let orders = pendingOrders[marketId] || [];
-      orders = orders.filter((obj: UIOrder) => obj.id !== id);
+      let orders = pendingOrders[data.marketId] || [];
+      orders = orders.filter(obj => obj.id !== data.id);
       if (orders.length > 0) {
         return {
           ...pendingOrders,
-          [marketId]: orders,
+          [data.marketId]: orders,
         };
       }
-      delete pendingOrders[marketId];
+      delete pendingOrders[data.marketId];
       return {
         ...pendingOrders,
       };
-    }
-    case LOAD_PENDING_ORDERS: {
-      return data.pendingOrders;
     }
     default:
       return pendingOrders;

--- a/packages/augur-ui/src/modules/pending-queue/actions/pending-queue-management.ts
+++ b/packages/augur-ui/src/modules/pending-queue/actions/pending-queue-management.ts
@@ -3,7 +3,6 @@ import { BaseAction, UIOrder } from "modules/types";
 export const ADD_PENDING_DATA = "ADD_PENDING_DATA";
 export const REMOVE_PENDING_DATA = "REMOVE_PENDING_DATA";
 export const LOAD_PENDING_QUEUE = "LOAD_PENDING_QUEUE";
-import { PUBLICTRADE, CANCELORDER } from 'modules/common/constants';
 
 export const loadPendingQueue = (pendingQueue: any): BaseAction => ({
   type: LOAD_PENDING_QUEUE,

--- a/packages/augur-ui/src/modules/types.ts
+++ b/packages/augur-ui/src/modules/types.ts
@@ -244,6 +244,7 @@ export interface UIOrder {
   cumulativeShares?: number;
   ignoreShares?: boolean;
   status?: string;
+  hash?: string;
 }
 
 export interface LiquidityOrders {


### PR DESCRIPTION
fixes https://github.com/augurproject/augur/issues/3086


When user logs in and pending orders are loaded, check order transaction confirmations if confirmed don't add to state.