### PR TITLE
multiple transactions to trade

### DIFF
--- a/packages/augur-ui/src/modules/trades/helpers/generate-trade.ts
+++ b/packages/augur-ui/src/modules/trades/helpers/generate-trade.ts
@@ -83,7 +83,8 @@ export const generateTrade = memoize(
       limitPrice,
       sharesFilled: formatShares(sharesFilled),
       selfTrade: !!outcomeTradeInProgress.selfTrade,
-      numSimFills: outcomeTradeInProgress.numFills ? outcomeTradeInProgress.numFills.toNumber() : 0,
+      numFills: outcomeTradeInProgress.numFills ? outcomeTradeInProgress.numFills.toNumber() : 0,
+      loopLimit: outcomeTradeInProgress.loopLimit ? outcomeTradeInProgress.loopLimit.toNumber() : 0,
       totalOrderValue: totalOrderValue
         ? formatDaiValue(totalOrderValue)
         : null,

--- a/packages/augur-ui/src/modules/trading/components/confirm/confirm.tsx
+++ b/packages/augur-ui/src/modules/trading/components/confirm/confirm.tsx
@@ -99,7 +99,7 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
 
     if (!isNaN(numTrades) && numTrades > 1) {
       messages = {
-        header: 'MULTIPLE TRADES',
+        header: 'MULTIPLE TRANSACTIONS',
         type: WARNING,
         message: `This trade will take ${numTrades} Transactions`,
       };

--- a/packages/augur-ui/src/modules/trading/components/confirm/confirm.tsx
+++ b/packages/augur-ui/src/modules/trading/components/confirm/confirm.tsx
@@ -41,6 +41,8 @@ interface ConfirmProps {
   minPrice: BigNumber;
   scalarDenomination: string | null;
   numOutcomes: number;
+  numFills: number;
+  loopLimit: number;
 }
 
 interface ConfirmState {
@@ -85,8 +87,8 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
       availableDai,
     } = props || this.props;
 
-    const { totalCost, selfTrade, potentialEthLoss } = trade;
-
+    const { totalCost, selfTrade, potentialEthLoss, numFills, loopLimit } = trade;
+    const numTrades = Math.ceil(numFills / loopLimit);
     let messages: Message | null = null;
     const tradeTotalCost = createBigNumber(totalCost.fullPrecision, 10);
     const gasCost = formatGasCostToEther(
@@ -94,6 +96,14 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
       { decimalsRounded: 4 },
       gasPrice
     );
+
+    if (!isNaN(numTrades) && numTrades > 1) {
+      messages = {
+        header: 'MULTIPLE TRADES',
+        type: WARNING,
+        message: `This trade will take ${numTrades} Transactions`,
+      };
+    }
 
     if (selfTrade) {
       messages = {
@@ -161,7 +171,6 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
     const {
       limitPrice,
       numShares,
-      numSimFills,
       potentialEthProfit,
       potentialEthLoss,
       totalCost,

--- a/packages/augur-ui/src/modules/trading/components/form/form.tsx
+++ b/packages/augur-ui/src/modules/trading/components/form/form.tsx
@@ -26,7 +26,6 @@ interface FromProps {
   orderPrice: string;
   orderDaiEstimate: string;
   orderEscrowdEth: string;
-  gasCostEst: string;
   selectedNav: string;
   selectedOutcome: Getters.Markets.MarketInfoOutcome;
   updateState: Function;
@@ -532,7 +531,6 @@ class Form extends Component<FromProps, FormState> {
       minPrice,
       updateState,
       orderEscrowdEth,
-      gasCostEst,
       updateSelectedOutcome,
       sortedOutcomes,
       initialLiquidity
@@ -699,12 +697,6 @@ class Form extends Component<FromProps, FormState> {
               <label className={Styles.smallLabel}>
                 {ExclamationCircle}
                 {` Max cost of ${orderEscrowdEth} DAI will be escrowed`}
-              </label>
-            )}
-            {gasCostEst && (
-              <label className={Styles.smallLabel}>
-                {ExclamationCircle}
-                {` Max cost of ${gasCostEst} ETH required for gas`}
               </label>
             )}
           </li>


### PR DESCRIPTION
removed label telling user amount of gas needed, direction from produce https://github.com/AugurProject/augur/issues/3054

dev task, PR is mostly for adding the infrastructure 
https://github.com/AugurProject/augur/issues/2663


bug fix in sdk to trade needing multiple transactions, added warning to user there will be multiple tx

![image](https://user-images.githubusercontent.com/3970376/62745998-2a664080-ba13-11e9-9cab-8929d3093e63.png)


placeholder to tell user multiple transactions are needed. Might change if design comes up with standard way of telling user multiple transactions are needed to complete a task.


To test, 
created a lot of 1 DAI orders on the book

Using a different user
take the multiple orders, notice the warning in the order confirmation.