### PR TITLE
fixes to market creation order form for scalar markets

### DIFF
--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -431,7 +431,7 @@ export const PERIODS = [
 ];
 
 // # Precision Constants
-export const UPPER_FIXED_PRECISION_BOUND = 8;
+export const UPPER_FIXED_PRECISION_BOUND = 2;
 export const LOWER_FIXED_PRECISION_BOUND = 0;
 
 // # Modal Constants

--- a/packages/augur-ui/src/modules/create-market/components/form.tsx
+++ b/packages/augur-ui/src/modules/create-market/components/form.tsx
@@ -514,6 +514,16 @@ export default class Form extends React.Component<FormProps, FormState> {
       );
 
       updateNewMarket({ endTimeFormatted, setEndTime, hour, minute, meridiem, offset, offsetName, timezone });
+    } else if (
+      name === "minPrice"
+    ) {
+      const minPriceBigNumber = createBigNumber(value);
+      updateNewMarket({ minPriceBigNumber });
+    } else if (
+      name === "maxPrice"
+    ) {
+      const maxPriceBigNumber = createBigNumber(value);
+      updateNewMarket({ maxPriceBigNumber });
     }
     this.onError(name, '');
     if (callback) callback(name);

--- a/packages/augur-ui/src/modules/create-market/components/review.tsx
+++ b/packages/augur-ui/src/modules/create-market/components/review.tsx
@@ -258,7 +258,7 @@ export default class Review extends React.Component<
           {marketType === SCALAR &&
             <>
               <SmallSubheaders header="Unit of Measurement" subheader={scalarDenomination} />
-              <SmallSubheaders header="Numeric range" subheader={minPrice + "-" + maxPrice} />
+              <SmallSubheaders header="Numeric range" subheader={minPrice + " to " + maxPrice} />
               <SmallSubheaders header="precision" subheader={tickSize.toString()} />
             </>
           }

--- a/packages/augur-ui/src/modules/market/components/core-properties/core-properties.tsx
+++ b/packages/augur-ui/src/modules/market/components/core-properties/core-properties.tsx
@@ -44,8 +44,8 @@ const CoreProperties = ({ market }) => (
     )}
     {getValue(market, "marketType") === SCALAR && (
       <PropertyLabel
-        label="Min - Max"
-        value={`${market.minPrice} — ${market.maxPrice}`}
+        label="Numeric Range"
+        value={`${market.minPrice} to ${market.maxPrice}`}
       />
     )}
   </div>

--- a/packages/augur-ui/src/modules/market/components/market-header/market-header.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-header/market-header.tsx
@@ -138,7 +138,7 @@ export default class MarketHeader extends Component<MarketHeaderProps, MarketHea
       const denomination = scalarDenomination ? ` ${scalarDenomination}` : "";
       const warningText =
         (details.length > 0 ? `\n\n` : ``) +
-        `If the real-world outcome for this market is above this market's maximum value, the maximum value (${maxPrice.toNumber()}${denomination}) should be reported. If the real-world outcome for this market is below this market's minimum value, the minimum value (${minPrice.toNumber()}${denomination}) should be reported.`;
+        `If the real-world outcome for this market is above this market's maximum value, the maximum value (${maxPrice.toString()}${denomination}) should be reported. If the real-world outcome for this market is below this market's minimum value, the minimum value (${minPrice.toString()}${denomination}) should be reported.`;
       details += warningText;
     }
 

--- a/packages/augur-ui/src/modules/markets/reducers/new-market.ts
+++ b/packages/augur-ui/src/modules/markets/reducers/new-market.ts
@@ -94,7 +94,7 @@ export default function(newMarket: NewMarket = DEFAULT_STATE, { type, data }: Ba
           orderInfo.quantity = createBigNumber(order.quantity).plus(createBigNumber(quantity)).toString();
           orderInfo.shares = createBigNumber(order.quantity).plus(createBigNumber(quantity)).toString();
           orderInfo.orderEstimate = createBigNumber(order.orderEstimate).plus(
-            createBigNumber(orderEstimate.replace(" DAI", ""))
+            createBigNumber(orderEstimate)
           ),
           orderAdded = true;
           return orderInfo;
@@ -111,11 +111,11 @@ export default function(newMarket: NewMarket = DEFAULT_STATE, { type, data }: Ba
           shares: quantity,
           mySize: quantity,
           cumulativeShares: quantity,
-          orderEstimate: createBigNumber(orderEstimate.replace(" DAI", "")),
+          orderEstimate: createBigNumber(orderEstimate),
           avgPrice: formatDai(price),
           unmatchedShares: formatShares(quantity),
           sharesEscrowed: formatShares(quantity),
-          tokensEscrowed: formatDai(createBigNumber(orderEstimate.replace(" DAI", ""))),
+          tokensEscrowed: formatDai(createBigNumber(orderEstimate)),
           id: updatedOrders.length,
         } as any);
       }

--- a/packages/augur-ui/src/modules/trades/helpers/calc-order-profit-loss-percents.ts
+++ b/packages/augur-ui/src/modules/trades/helpers/calc-order-profit-loss-percents.ts
@@ -11,8 +11,8 @@ import { SCALAR, BUY } from "modules/common/constants";
  * @param type the market type
  * @param settlementFee
  * @returns object with the following properties
- *    potentialEthProfit:     number, maximum number of ether that can be made according to the current numShares and limit price
- *    potentialEthLoss:       number, maximum number of ether that can be lost according to the current numShares and limit price
+ *    potentialDaiProfit:     number, maximum number of ether that can be made according to the current numShares and limit price
+ *    potentialDaiLoss:       number, maximum number of ether that can be lost according to the current numShares and limit price
  *    potentialProfitPercent: number, the maximum percentage profit that can be earned with current numShares and limit price,
  *                                    excluding first 100% (so a 2x is a 100% return and not a 200% return). For BUYs, loss is always 100% (exc. fees)
  *    potentialLossPercent:   number, the max percentage loss that can be lost with current numShares and limit price; for SELLs loss is always 100%
@@ -77,10 +77,10 @@ export const calcOrderProfitLossPercents = (
     .dividedBy(totalETHValueWinnable)
     .times(100);
 
-  const potentialEthProfit =
+  const potentialDaiProfit =
     side === BUY ? shortETHpotentialProfit : longETHpotentialProfit;
 
-  const potentialEthLoss =
+  const potentialDaiLoss =
     side === BUY ? longETHpotentialProfit : shortETHpotentialProfit;
 
   const potentialProfitPercent =
@@ -92,8 +92,8 @@ export const calcOrderProfitLossPercents = (
   const tradingFees = winningSettlementCost;
 
   return {
-    potentialEthProfit,
-    potentialEthLoss,
+    potentialDaiProfit,
+    potentialDaiLoss,
     potentialProfitPercent,
     potentialLossPercent,
     tradingFees,
@@ -160,25 +160,25 @@ export const calcOrderShareProfitLoss = (
       .minus(winningSettlementCost);
   }
 
-  let potentialEthProfit =
+  let potentialDaiProfit =
     side === BUY ? shortETHpotentialProfit : longETHpotentialProfit;
 
   if (reversal) {
     const quantity = createBigNumber(Math.min(shareCost, reversal.quantity));
     if (side === BUY) {
       const normalizedPrice = max.minus(reversal.price);
-      potentialEthProfit = shortETH
+      potentialDaiProfit = shortETH
         .minus(createBigNumber(normalizedPrice).times(quantity))
         .minus(winningSettlementCost);
     } else {
-      potentialEthProfit = longETH
+      potentialDaiProfit = longETH
         .minus(createBigNumber(reversal.price).times(quantity))
         .minus(winningSettlementCost);
     }
   }
 
   return {
-    potentialEthProfit,
+    potentialDaiProfit,
     tradingFees: winningSettlementCost,
   };
 };

--- a/packages/augur-ui/src/modules/trades/helpers/calc-order-profits-loss-percents.test.ts
+++ b/packages/augur-ui/src/modules/trades/helpers/calc-order-profits-loss-percents.test.ts
@@ -54,8 +54,8 @@ describe("modules/trades/helpers/calc-order-profit-loss-percents.js", () => {
     const actual = calcProfits("10", "0.4", BUY, "0", "1", YES_NO, "0.02");
 
     const expected = {
-      potentialEthProfit: createBigNumber("6"),
-      potentialEthLoss: createBigNumber("4"),
+      potentialDaiProfit: createBigNumber("6"),
+      potentialDaiLoss: createBigNumber("4"),
       potentialProfitPercent: createBigNumber("150"),
       potentialLossPercent: createBigNumber("100"),
       tradingFees: createBigNumber("0.2"),
@@ -68,8 +68,8 @@ describe("modules/trades/helpers/calc-order-profit-loss-percents.js", () => {
     const actual = calcProfits("10", "0.4", SELL, "0", "1", YES_NO, "0.04");
 
     const expected = {
-      potentialEthProfit: createBigNumber("4"),
-      potentialEthLoss: createBigNumber("6"),
+      potentialDaiProfit: createBigNumber("4"),
+      potentialDaiLoss: createBigNumber("6"),
       potentialProfitPercent: createBigNumber("66.666666666666666667"),
       potentialLossPercent: createBigNumber("100"),
       tradingFees: createBigNumber("0.4"),
@@ -82,8 +82,8 @@ describe("modules/trades/helpers/calc-order-profit-loss-percents.js", () => {
     const actual = calcProfits("10", "1", BUY, "-5", "10", SCALAR, "0.25");
 
     const expected = {
-      potentialEthProfit: createBigNumber("90"),
-      potentialEthLoss: createBigNumber("60"),
+      potentialDaiProfit: createBigNumber("90"),
+      potentialDaiLoss: createBigNumber("60"),
       potentialProfitPercent: createBigNumber("150"),
       potentialLossPercent: createBigNumber("100"),
       tradingFees: createBigNumber("37.5"),
@@ -96,8 +96,8 @@ describe("modules/trades/helpers/calc-order-profit-loss-percents.js", () => {
     const actual = calcProfits("10", "1", SELL, "-5", "10", SCALAR, "0.2");
 
     const expected = {
-      potentialEthProfit: createBigNumber("60"),
-      potentialEthLoss: createBigNumber("90"),
+      potentialDaiProfit: createBigNumber("60"),
+      potentialDaiLoss: createBigNumber("90"),
       potentialProfitPercent: createBigNumber("66.666666666666666667"),
       potentialLossPercent: createBigNumber("100"),
       tradingFees: createBigNumber("30"),
@@ -119,7 +119,7 @@ describe("modules/trades/helpers/calc-order-profit-loss-percents.js", () => {
     );
 
     const expected = {
-      potentialEthProfit: createBigNumber("3"),
+      potentialDaiProfit: createBigNumber("3"),
       tradingFees: createBigNumber("2"),
     };
 

--- a/packages/augur-ui/src/modules/trades/helpers/generate-trade.ts
+++ b/packages/augur-ui/src/modules/trades/helpers/generate-trade.ts
@@ -89,16 +89,16 @@ export const generateTrade = memoize(
         ? formatDaiValue(totalOrderValue)
         : null,
       orderShareProfit: orderShareProfitLoss
-        ? formatDaiValue(orderShareProfitLoss.potentialEthProfit)
+        ? formatDaiValue(orderShareProfitLoss.potentialDaiProfit)
         : null,
       orderShareTradingFee: orderShareProfitLoss
         ? formatDaiValue(orderShareProfitLoss.tradingFees)
         : null,
-      potentialEthProfit: preOrderProfitLoss
-        ? formatDaiValue(preOrderProfitLoss.potentialEthProfit)
+      potentialDaiProfit: preOrderProfitLoss
+        ? formatDaiValue(preOrderProfitLoss.potentialDaiProfit)
         : null,
-      potentialEthLoss: preOrderProfitLoss
-        ? formatDaiValue(preOrderProfitLoss.potentialEthLoss)
+      potentialDaiLoss: preOrderProfitLoss
+        ? formatDaiValue(preOrderProfitLoss.potentialDaiLoss)
         : null,
       potentialLossPercent: preOrderProfitLoss
         ? formatDaiValue(preOrderProfitLoss.potentialLossPercent)

--- a/packages/augur-ui/src/modules/trading/components/confirm/confirm.tsx
+++ b/packages/augur-ui/src/modules/trading/components/confirm/confirm.tsx
@@ -87,7 +87,7 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
       availableDai,
     } = props || this.props;
 
-    const { totalCost, selfTrade, potentialEthLoss, numFills, loopLimit } = trade;
+    const { totalCost, selfTrade, potentialDaiLoss, numFills, loopLimit } = trade;
     const numTrades = Math.ceil(numFills / loopLimit);
     let messages: Message | null = null;
     const tradeTotalCost = createBigNumber(totalCost.fullPrecision, 10);
@@ -126,7 +126,7 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
 
     if (
       totalCost &&
-      createBigNumber(potentialEthLoss.fullPrecision, 10).gt(
+      createBigNumber(potentialDaiLoss.fullPrecision, 10).gt(
         createBigNumber(availableDai, 10)
       )
     ) {
@@ -140,7 +140,7 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
     if (
       totalCost &&
       allowanceAmount &&
-      createBigNumber(potentialEthLoss.fullPrecision, 10).gt(
+      createBigNumber(potentialDaiLoss.fullPrecision, 10).gt(
         createBigNumber(allowanceAmount.fullPrecision, 10)
       )
     ) {
@@ -171,8 +171,8 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
     const {
       limitPrice,
       numShares,
-      potentialEthProfit,
-      potentialEthLoss,
+      potentialDaiProfit,
+      potentialDaiLoss,
       totalCost,
       shareCost,
       side,
@@ -216,8 +216,8 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
     const notProfitable =
       (orderShareProfit && createBigNumber(orderShareProfit.value).lte(0)) ||
       (totalCost.value > 0 &&
-        potentialEthProfit &&
-        potentialEthProfit.value <= 0);
+        potentialDaiProfit &&
+        potentialDaiProfit.value <= 0);
 
     return (
       <section className={Styles.TradingConfirm}>
@@ -298,11 +298,11 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
               </div>
               <LinearPropertyLabel
                 label="Max Profit"
-                value={`${potentialEthProfit.rounded} DAI`}
+                value={`${potentialDaiProfit.formatted} DAI`}
               />
               <LinearPropertyLabel
                 label="Max Loss"
-                value={`${potentialEthLoss.rounded} DAI`}
+                value={`${potentialDaiLoss.formatted} DAI`}
               />
             </div>
           )}

--- a/packages/augur-ui/src/modules/trading/components/wrapper/wrapper.tsx
+++ b/packages/augur-ui/src/modules/trading/components/wrapper/wrapper.tsx
@@ -230,7 +230,7 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
             {
               ...this.state,
               ...order,
-              orderDaiEstimate: totalCost ? formattedValue.formatted : '',
+              orderDaiEstimate: totalCost ? formattedValue.roundedValue : '',
               orderEscrowdEth: '',
               gasCostEst: '',
               trade: trade,
@@ -266,7 +266,7 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
                 {
                   decimalsRounded: UPPER_FIXED_PRECISION_BOUND,
                 }
-              ).rounded;
+              ).roundedValue;
 
               const formattedGasCost = formatGasCostToEther(
                 newOrder.gasLimit,
@@ -278,7 +278,7 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
                   ...this.state,
                   ...order,
                   orderDaiEstimate: neworderDaiEstimate,
-                  orderEscrowdEth: newOrder.potentialEthLoss.formatted,
+                  orderEscrowdEth: newOrder.potentialDaiLoss.formatted,
                   trade: newOrder,
                   gasCostEst: formattedGasCost,
                 },
@@ -351,7 +351,7 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
                 ...this.state,
                 ...order,
                 orderQuantity: numShares,
-                orderEscrowdEth: newOrder.potentialEthLoss.formatted,
+                orderEscrowdEth: newOrder.potentialDaiLoss.formatted,
                 trade: newOrder,
                 gasCostEst: formattedGasCost,
               },

--- a/packages/augur-ui/src/modules/types.ts
+++ b/packages/augur-ui/src/modules/types.ts
@@ -602,8 +602,8 @@ export interface WalletObject {
 export interface Trade {
   numShares: FormattedNumber;
   limitPrice: FormattedNumber;
-  potentialEthProfit: FormattedNumber;
-  potentialEthLoss: FormattedNumber;
+  potentialDaiProfit: FormattedNumber;
+  potentialDaiLoss: FormattedNumber;
   totalCost: FormattedNumber;
   sharesFilled: FormattedNumber;
   shareCost: FormattedNumber;


### PR DESCRIPTION
fixed order form for creating scalar markets, updated variables names to be accurate, simplified order estimate for create market liquidity
fixes https://github.com/AugurProject/augur/issues/3208
fixes https://github.com/augurproject/augur/issues/3108

fixed order ticket in create market for scalar markets
![image](https://user-images.githubusercontent.com/3970376/62948427-ed4ed500-bda9-11e9-98eb-6d7dca4ca6c3.png)


fixed estimate price of order ticket  for estimate cost to be 2 decimals.
![image](https://user-images.githubusercontent.com/3970376/62948359-d1e3ca00-bda9-11e9-8a39-06f097aab3cd.png)
