### PR TITLE
fix calc for num ticks when creation scalar markets

### DIFF
--- a/packages/augur-sdk/src/utils.ts
+++ b/packages/augur-sdk/src/utils.ts
@@ -23,6 +23,14 @@ export function numTicksToTickSizeWithDisplayPrices(
   return maxPrice.minus(minPrice).div(numTicks);
 }
 
+export function tickSizeToNumTickWithDisplayPrices(
+  tickSize: BigNumber,
+  minPrice: BigNumber,
+  maxPrice: BigNumber
+): BigNumber {
+  return maxPrice.minus(minPrice).dividedBy(tickSize);
+}
+
 export function convertOnChainAmountToDisplayAmount(
   onChainAmount: BigNumber,
   tickSize: BigNumber

--- a/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
+++ b/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
@@ -19,6 +19,7 @@ import {
   CreateScalarMarketParams,
   stringTo32ByteHex,
   QUINTILLION,
+  tickSizeToNumTickWithDisplayPrices,
 } from '@augurproject/sdk';
 
 import { generateTradeGroupId } from 'utils/generate-trade-group-id';
@@ -264,9 +265,7 @@ export function createMarket(newMarket: CreateNewMarketParams) {
         new BigNumber(newMarket.minPrice).multipliedBy(QUINTILLION),
         new BigNumber(newMarket.maxPrice).multipliedBy(QUINTILLION),
       ];
-      const numTicks = prices[1]
-        .minus(prices[0])
-        .dividedBy(new BigNumber(newMarket.tickSize)).abs();
+      const numTicks = tickSizeToNumTickWithDisplayPrices(new BigNumber(newMarket.tickSize), new BigNumber(newMarket.minPrice), new BigNumber(newMarket.maxPrice));
       const params: CreateScalarMarketParams = Object.assign(baseParams, {
         prices,
         numTicks,


### PR DESCRIPTION
issue with trading manually created scalar markets. canned markets are fine.

The error was in calc numTicks, all past scalar markets won't be able to be traded. 