### PR TITLE
added tslint rule quotemark

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -6,5 +6,7 @@
   "extends": [
     "gts/tslint.json"
   ],
-  "rules": {}
+  "rules": {
+    "quotemark": [true, "single", "jsx-single", "avoid-template", "avoid-escape"]
+  }
 }


### PR DESCRIPTION
Must use single-quotes unless that would require escaping. Can use backticks if you need them.