### PR TITLE
add pagination to market list page.

### DIFF
--- a/packages/augur-ui/src/modules/common/pagination.tsx
+++ b/packages/augur-ui/src/modules/common/pagination.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import classNames from "classnames";
 import { DirectionButton } from "modules/common/buttons";
 
-import Styles from "modules/common/pagination.styles";
+import Styles from "modules/common/pagination.styles.less";
 
 interface PaginationProps {
   page: number;

--- a/packages/augur-ui/src/modules/filter-sort/components/filter-dropdowns.tsx
+++ b/packages/augur-ui/src/modules/filter-sort/components/filter-dropdowns.tsx
@@ -69,12 +69,11 @@ export default class FilterSearch extends Component<FilterSearchProps> {
       filter,
       updateSortOption,
       updateFilter,
-      hasOrders,
     } = this.props;
 
     this.goToPageOne();
     updateSortOption(value);
-    updateFilter({ filter, sort: value, hasOrders });
+    updateFilter({ filter, sort: value, limit: 0, offset: 1 });
   }
 
   changeFilterDropdown(value) {
@@ -82,12 +81,11 @@ export default class FilterSearch extends Component<FilterSearchProps> {
       sort,
       updateFilterOption,
       updateFilter,
-      hasOrders,
     } = this.props;
 
     this.goToPageOne();
     updateFilterOption(value);
-    updateFilter({ filter: value, sort, hasOrders });
+    updateFilter({ filter: value, sort, limit: 0, offset: 1 });
   }
 
   changeHasOrders(event) {
@@ -95,15 +93,12 @@ export default class FilterSearch extends Component<FilterSearchProps> {
       filter,
       sort,
       updateFilter,
-      hasOrders,
-      updateHasOpenOrders,
     } = this.props;
-    const hasOpenOrders = !hasOrders;
-    updateHasOpenOrders(hasOpenOrders);
     updateFilter({
       filter,
       sort,
-      hasOrders: hasOpenOrders,
+      limit: 0,
+      offset: 1,
     });
   }
 

--- a/packages/augur-ui/src/modules/markets-list/components/markets-list.sytles.less
+++ b/packages/augur-ui/src/modules/markets-list/components/markets-list.sytles.less
@@ -1,0 +1,8 @@
+@import (reference) '~assets/styles/shared';
+
+.Pagination {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  margin: 2rem 2rem;
+}

--- a/packages/augur-ui/src/modules/markets-list/components/markets-list.tsx
+++ b/packages/augur-ui/src/modules/markets-list/components/markets-list.tsx
@@ -1,13 +1,12 @@
 import React, { Component } from "react";
 
 import { PAGINATION_PARAM_NAME } from "modules/routes/constants/param-names";
-import Paginator from "modules/common/paginator_v1";
+import { Pagination } from "modules/common/pagination";
 import NullStateMessage from "modules/common/null-state-message";
 import { TYPE_TRADE } from "modules/common/constants";
 import MarketCard from "modules/market-cards/containers/market-card";
 import { MarketData } from "modules/types";
-
-const PAGINATION_COUNT = 10;
+import Styles from "modules/markets-list/components/markets-list.sytles.less";
 
 interface MarketsListProps {
   testid?: string;
@@ -24,17 +23,20 @@ interface MarketsListProps {
   pendingLiquidityOrders?: object;
   nullMessage?: string;
   addNullPadding?: boolean;
-  style?: object;
   showDisputingCard?: boolean;
   outcomes?: object;
   showOutstandingReturns?: boolean;
+  marketCount: number;
+  showPagination: boolean;
+  limit: number;
+  offset: number;
+  setOffset: Function;
 }
 
 interface MarketsListState {
   lowerBound: number;
   boundedLength: number;
   marketIdsMissingInfo: Array<any>;
-  showPagination: boolean;
 }
 
 export default class MarketsList extends Component<
@@ -48,7 +50,6 @@ export default class MarketsList extends Component<
     nullMessage: "No Markets Available",
     pendingLiquidityOrders: {},
     addNullPadding: false,
-    style: null,
     showDisputingCard: false,
     outcomes: null,
     showOutstandingReturns: false
@@ -61,11 +62,8 @@ export default class MarketsList extends Component<
       lowerBound: 1,
       boundedLength: 10,
       marketIdsMissingInfo: [], // This is ONLY the currently displayed markets that are missing info
-      showPagination:
-        props.filteredMarkets && props.filteredMarkets.length > PAGINATION_COUNT
     };
 
-    this.setSegment = this.setSegment.bind(this);
     this.setMarketIDsMissingInfo = this.setMarketIDsMissingInfo.bind(this);
     this.loadMarketsInfoIfNotLoaded = this.loadMarketsInfoIfNotLoaded.bind(this);
   }
@@ -103,10 +101,6 @@ export default class MarketsList extends Component<
     }
   }
 
-  setSegment(lowerBound, upperBound, boundedLength) {
-    this.setState({ lowerBound, boundedLength });
-  }
-
   setMarketIDsMissingInfo(filteredMarkets, lowerBound, boundedLength) {
     if (filteredMarkets.length && boundedLength) {
       const marketIdLength = boundedLength + (lowerBound - 1);
@@ -114,8 +108,7 @@ export default class MarketsList extends Component<
         lowerBound - 1,
         marketIdLength
       );
-      const showPagination = filteredMarkets.length > PAGINATION_COUNT;
-      this.setState({ marketIdsMissingInfo, showPagination });
+      this.setState({ marketIdsMissingInfo });
     }
   }
 
@@ -130,30 +123,23 @@ export default class MarketsList extends Component<
     const {
       filteredMarkets,
       history,
-      isLogged,
-      isMobile,
       location,
       markets,
-      paginationPageParam,
-      toggleFavorite,
       testid,
-      pendingLiquidityOrders,
       nullMessage,
       addNullPadding,
-      style,
-      showDisputingCard,
-      outcomes,
-      linkType,
-      showOutstandingReturns
+      marketCount,
+      showPagination,
+      limit,
+      offset,
+      setOffset
     } = this.props;
     const s = this.state;
 
-    const marketsLength = (filteredMarkets || []).length;
-
     return (
-      <article className="markets-list" data-testid={testid} style={style}>
-        {marketsLength && s.boundedLength ? (
-          [...Array(s.boundedLength)].map((unused, i) => {
+      <article data-testid={testid}>
+        {marketCount && s.boundedLength ? (
+          filteredMarkets.map((unused, i) => {
             const id = filteredMarkets[s.lowerBound - 1 + i];
             const market = markets.find(
               (market: MarketData) => market.id === id
@@ -179,15 +165,15 @@ export default class MarketsList extends Component<
             message={nullMessage}
           />
         )}
-        {!!marketsLength && s.showPagination && (
-          <Paginator
-            itemsLength={marketsLength}
-            itemsPerPage={PAGINATION_COUNT}
-            location={location}
-            history={history}
-            setSegment={this.setSegment}
-            pageParam={paginationPageParam}
-          />
+        {showPagination && (
+          <div className={Styles.Pagination}>
+            <Pagination
+              page={offset}
+              itemCount={marketCount}
+              itemsPerPage={limit}
+              action={setOffset}
+            />
+          </div>
         )}
       </article>
     );

--- a/packages/augur-ui/src/modules/markets/actions/load-markets.ts
+++ b/packages/augur-ui/src/modules/markets/actions/load-markets.ts
@@ -108,8 +108,8 @@ export const loadMarketsByFilter = (
     // search: filterOptions.search,
     maxFee: filterOptions.maxFee,
     includeInvalidMarkets: filterOptions.includeInvalidMarkets,
-    // limit: filterOptions.limit,
-    // offset: filterOptions.offset,
+    limit: filterOptions.limit,
+    offset: filterOptions.offset,
     reportingStates,
     ...sort,
   };


### PR DESCRIPTION
fixes https://github.com/AugurProject/augur/issues/3168
fixes https://github.com/AugurProject/augur/issues/2862


wire up pagination with `getMarkets` getter

![image](https://user-images.githubusercontent.com/3970376/63141076-f9a18080-bfa9-11e9-89ed-467c66b8e792.png)


created new ticket for adding dropdown for user to choose how many items per page.
<https://github.com/AugurProject/augur/issues/3260> 