### PR TITLE
Create meta object after offset/limit

### DIFF
--- a/packages/augur-sdk/src/state/getter/Markets.ts
+++ b/packages/augur-sdk/src/state/getter/Markets.ts
@@ -559,14 +559,14 @@ export class Markets {
       }
     }
 
-    const meta = getMarketsMeta(marketsResults, filteredOutCount);
-
     // Sort & limit markets
     _.sortBy(marketsResults, [(market: any) => market[params.sortBy]]);
     if (params.isSortDescending) {
       marketsResults = marketsResults.reverse();
     }
     marketsResults = marketsResults.slice(params.offset, params.offset + params.limit);
+
+    const meta = getMarketsMeta(marketsResults, filteredOutCount);
 
     // Get markets info to return
     const marketsInfo = await Markets.getMarketsInfo(


### PR DESCRIPTION
Closes #3282. The actual bug was occurring because there was only one market result, and the offset was set to 1. The empty `markets` array was correct, but the `meta` object was not. When I implemented offset/limit a while back, I forgot to move the line that creates the `meta` object after that block of code.