### PR TITLE
get meta data before slicing markets array

### DIFF
--- a/packages/augur-sdk/src/state/getter/Markets.ts
+++ b/packages/augur-sdk/src/state/getter/Markets.ts
@@ -596,14 +596,14 @@ export class Markets {
       }
     }
 
+    const meta = getMarketsMeta(marketsResults, filteredOutCount);
+
     // Sort & limit markets
     marketsResults = _.sortBy(marketsResults, [params.sortBy]);
     if (params.isSortDescending) {
       marketsResults = marketsResults.reverse();
     }
     marketsResults = marketsResults.slice(params.offset, params.offset + params.limit);
-
-    const meta = getMarketsMeta(marketsResults, filteredOutCount);
 
     // Get markets info to return
     const marketsInfo = await Markets.getMarketsInfo(


### PR DESCRIPTION
Moved getMarketsMeta up before **Sort & limit markets** in order to get back all the metadata for the results, instead of just the limit slice.