### PR TITLE
Fix 24 hour

### DIFF
--- a/packages/augur-ui/src/modules/account/components/open-markets.tsx
+++ b/packages/augur-ui/src/modules/account/components/open-markets.tsx
@@ -56,7 +56,7 @@ export default class OpenMarkets extends Component<OpenMarketsProps> {
                   showBrackets
                   showIcon
                   showPlusMinus
-                  value={position.valueChange.formatted}
+                  value={position.unrealizedPercent.formatted}
                   size={SizeTypes.SMALL}
                 />
               </div>

--- a/packages/augur-ui/src/modules/account/containers/funds.ts
+++ b/packages/augur-ui/src/modules/account/containers/funds.ts
@@ -16,7 +16,7 @@ const mapStateToProps = (state: AppState) => {
     totalAccountValue,
   } = selectAccountFunds(state);
   const { reportingWindowStats } = state;
-  const { rep, realizedPLPercent } = loginAccount;
+  const { rep, tradingPositionsTotal } = loginAccount;
 
   return {
     repStaked:
@@ -29,7 +29,7 @@ const mapStateToProps = (state: AppState) => {
     totalAvailableTradingBalance: formatEther(totalAvailableTradingBalance)
       .formatted,
     totalAccountValue: formatEther(totalAccountValue).formatted,
-    realizedPLPercent: formatPercent(realizedPLPercent)
+    realizedPLPercent: formatPercent(tradingPositionsTotal.unrealizedRevenue24hChangePercent)
       .formattedValue,
   };
 };

--- a/packages/augur-ui/src/modules/markets/selectors/select-market-position-summary.ts
+++ b/packages/augur-ui/src/modules/markets/selectors/select-market-position-summary.ts
@@ -30,7 +30,7 @@ export const selectMarketPositionsSummary = createSelector(
     );
     const valueChange = formatPercent(
       createBigNumber(
-        marketPositions.unrealizedRevenue24hChangePercent || ZERO
+        marketPositions.unrealizedPercent || ZERO
       ).times(100),
       { decimalsRounded: 2 }
     );


### PR DESCRIPTION
account summary isn't showing correct percentages for user positions.

![image](https://user-images.githubusercontent.com/3970376/63968742-fe643b00-ca65-11e9-8d9f-4093cf429780.png)
