### PR TITLE
add reporting to login account state

### DIFF
--- a/packages/augur-ui/src/modules/account/actions/login-account.ts
+++ b/packages/augur-ui/src/modules/account/actions/login-account.ts
@@ -9,15 +9,6 @@ export interface UpdateLoginAccountAction {
   data: Partial<LoginAccount>;
 }
 
-export function updateLoginAccountBalances(
-  data: AccountBalances
-) {
-  return {
-    type: UPDATE_LOGIN_ACCOUNT_BALANCES,
-    data,
-  };
-}
-
 export function updateLoginAccount(
   data: Partial<LoginAccount>
 ): UpdateLoginAccountAction {

--- a/packages/augur-ui/src/modules/auth/actions/load-account-history.ts
+++ b/packages/augur-ui/src/modules/auth/actions/load-account-history.ts
@@ -9,6 +9,7 @@ import { ThunkDispatch, ThunkAction } from 'redux-thunk';
 import { Action } from 'redux';
 import { NodeStyleCallback } from 'modules/types';
 import { AppState } from 'store';
+import { loadAccountReportingHistory } from 'modules/auth/actions/load-account-reporting';
 
 export const loadAccountHistory = (): ThunkAction<any, any, any, any> => (
   dispatch: ThunkDispatch<void, any, Action>,
@@ -50,13 +51,13 @@ function loadTransactions(
       dispatch(loadCreateMarketHistory(options, resolve))
     )
   );
-/*
+
   promises.push(
     new Promise(resolve =>
-      dispatch(loadReportingHistory(options, null, resolve))
+      dispatch(loadAccountReportingHistory(resolve))
     )
   );
-*/
+
   Promise.all(promises).then((marketIds: string[][]) => {
     marketIds = [...marketIds, Object.keys(appState.pendingOrders)];
 

--- a/packages/augur-ui/src/modules/auth/actions/load-account-reporting.ts
+++ b/packages/augur-ui/src/modules/auth/actions/load-account-reporting.ts
@@ -1,0 +1,27 @@
+import { ThunkDispatch } from 'redux-thunk';
+import { Action } from 'redux';
+import { augurSdk } from 'services/augursdk';
+import { AppState } from 'store';
+import { updateLoginAccount } from 'modules/account/actions/login-account';
+
+export const loadAccountReportingHistory = (marketIdAggregator: Function) => async (
+  dispatch: ThunkDispatch<void, any, Action>,
+  getState: () => AppState
+) => {
+  const { universe, loginAccount } = getState();
+  const Augur = augurSdk.get();
+  const reporting = await Augur.getAccountReportingHistory({
+    universe: universe.id,
+    account: loginAccount.address,
+  });
+  // pull all markets from reporting, disputing.
+  const marketIds = [];
+  if (reporting.reporting && reporting.reporting.contracts.length > 0)
+    reporting.reporting.contracts.map(c => [...marketIds, c.marketId]);
+  if (reporting.disputing && reporting.disputing.contracts.length > 0)
+    reporting.disputing.contracts.map(c => [...marketIds, c.marketId]);
+  // TODO: when we get real data pass to market id aggregator
+  if (marketIdAggregator) marketIdAggregator([]);
+
+  dispatch(updateLoginAccount({ reporting }));
+};

--- a/packages/augur-ui/src/modules/auth/actions/update-assets.ts
+++ b/packages/augur-ui/src/modules/auth/actions/update-assets.ts
@@ -1,5 +1,9 @@
-import { LoginAccount, NodeStyleCallback, AccountBalances } from 'modules/types';
-import { updateLoginAccount, updateLoginAccountBalances } from 'modules/account/actions/login-account';
+import {
+  NodeStyleCallback,
+} from 'modules/types';
+import {
+  updateLoginAccount,
+} from 'modules/account/actions/login-account';
 import logError from 'utils/log-error';
 import {
   getEthBalance,
@@ -34,7 +38,7 @@ function updateBalances(
     const rep = amounts[0];
     const dai = amounts[1];
     const eth = amounts[2];
-    dispatch(updateLoginAccountBalances({ rep, dai, eth }));
+    dispatch(updateLoginAccount({ balances: { rep, dai, eth } }));
     return callback(null, { rep, dai, eth });
   });
 }

--- a/packages/augur-ui/src/modules/auth/reducers/login-account.ts
+++ b/packages/augur-ui/src/modules/auth/reducers/login-account.ts
@@ -2,7 +2,6 @@ import { RESET_STATE } from 'modules/app/actions/reset-state';
 import {
   UPDATE_LOGIN_ACCOUNT,
   CLEAR_LOGIN_ACCOUNT,
-  UPDATE_LOGIN_ACCOUNT_BALANCES,
 } from 'modules/account/actions/login-account';
 import { LoginAccount, BaseAction } from 'modules/types';
 
@@ -12,6 +11,7 @@ const DEFAULT_STATE: LoginAccount = {
     rep: 0,
     dai: 0,
   },
+  reporting: null
 };
 
 export default function(
@@ -23,11 +23,6 @@ export default function(
       return {
         ...loginAccount,
         ...(data || {}),
-      };
-    case UPDATE_LOGIN_ACCOUNT_BALANCES:
-      return {
-        ...loginAccount,
-        balances: data,
       };
     case RESET_STATE:
     case CLEAR_LOGIN_ACCOUNT:

--- a/packages/augur-ui/src/modules/types.ts
+++ b/packages/augur-ui/src/modules/types.ts
@@ -571,6 +571,7 @@ export interface LoginAccount {
   allowanceFormatted?: FormattedNumber;
   allowance?: BigNumber;
   balances: AccountBalances;
+  reporting: Getters.Accounts.AccountReportingHistory;
 }
 
 export interface Web3 {


### PR DESCRIPTION
simplify how objects are added to login account through actions. added reporting from calling new account reporting history getter.

![Screen Shot 2019-08-29 at 3 10 55 PM](https://user-images.githubusercontent.com/3970376/63972957-5fdcd780-ca6f-11e9-9595-5682e400eb33.png)
