### PR TITLE
add recently depleted as a spread filter

### DIFF
--- a/packages/augur-ui/src/modules/app/components/inner-nav/markets-list-filters.tsx
+++ b/packages/augur-ui/src/modules/app/components/inner-nav/markets-list-filters.tsx
@@ -7,8 +7,6 @@ import {
   MAXFEE_PARAM_NAME,
   SPREAD_PARAM_NAME,
   SHOW_INVALID_MARKETS_PARAM_NAME,
-  INVALID_HIDE,
-  INVALID_SHOW,
 } from 'modules/common/constants';
 import Styles from 'modules/app/components/inner-nav/markets-list-filters.styles.less';
 import { helpIcon } from 'modules/common/icons';

--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -195,16 +195,18 @@ export const feeFilters = [
 
 
 // # Valid Market Liquidity Spreads
-export const MAX_SPREAD_ALL_SPREADS = 'all';
+export const MAX_SPREAD_ALL_SPREADS = '100';
 export const MAX_SPREAD_20_PERCENT = '20';
 export const MAX_SPREAD_15_PERCENT = '15';
 export const MAX_SPREAD_10_PERCENT = '10';
+export const MAX_SPREAD_RECENTLY_DEPLETED = '0';
 
 export const spreadFilters = [
   { header: 'All', value: MAX_SPREAD_ALL_SPREADS },
   { header: 'Less than 10%', value: MAX_SPREAD_10_PERCENT },
   { header: 'Less than 15%', value: MAX_SPREAD_15_PERCENT },
   { header: 'Less than 20%', value: MAX_SPREAD_20_PERCENT },
+  { header: 'Recently Depleted Liquidity', value: MAX_SPREAD_RECENTLY_DEPLETED },
 ];
 
 // # Market Invalid Show/Hide

--- a/packages/augur-ui/src/modules/filter-sort/actions/update-filter-sort-options.ts
+++ b/packages/augur-ui/src/modules/filter-sort/actions/update-filter-sort-options.ts
@@ -5,7 +5,6 @@ export const MARKET_MAX_FEES = 'maxFee';
 export const MARKET_MAX_SPREAD = 'maxLiquiditySpread';
 export const MARKET_SHOW_INVALID = 'includeInvalidMarkets';
 export const TRANSACTION_PERIOD = 'transactionPeriod';
-export const HAS_OPEN_ORDERS = 'hasOrders';
 
 export function updateFilterSortOptions(
   optionKey: string,

--- a/packages/augur-ui/src/modules/filter-sort/reducers/filter-sort-options.ts
+++ b/packages/augur-ui/src/modules/filter-sort/reducers/filter-sort-options.ts
@@ -5,7 +5,6 @@ import {
   MARKET_SORT,
   MARKET_MAX_FEES,
   TRANSACTION_PERIOD,
-  HAS_OPEN_ORDERS,
   MARKET_MAX_SPREAD,
   MARKET_SHOW_INVALID,
 } from 'modules/filter-sort/actions/update-filter-sort-options';
@@ -25,7 +24,6 @@ const DEFAULT_STATE: FilterSortOptions = {
   [MARKET_MAX_SPREAD]: MAX_SPREAD_10_PERCENT,
   [MARKET_SHOW_INVALID]: INVALID_OPTIONS.Hide,
   [TRANSACTION_PERIOD]: DAY,
-  [HAS_OPEN_ORDERS]: false,
 };
 
 const KEYS = Object.keys(DEFAULT_STATE);

--- a/packages/augur-ui/src/modules/markets/actions/load-markets.ts
+++ b/packages/augur-ui/src/modules/markets/actions/load-markets.ts
@@ -132,18 +132,9 @@ export const loadMarketsByFilter = (
     limit: filterOptions.limit,
     offset: paginationOffset * filterOptions.limit,
     reportingStates,
+    maxLiquiditySpread: filterOptions.maxLiquiditySpread,
     ...sort,
   };
-
-  if (
-    filterOptions.maxLiquiditySpread &&
-    filterOptions.maxLiquiditySpread !== MAX_SPREAD_ALL_SPREADS
-  ) {
-    params = Object.assign(params, {
-      ...params,
-      maxLiquiditySpread: filterOptions.maxLiquiditySpread,
-    });
-  }
 
   const markets = await augur.getMarkets({ ...params });
   const marketInfos = markets.markets.reduce(


### PR DESCRIPTION
closes #3500 
<img width="221" alt="Screen Shot 2019-09-07 at 4 16 26 PM" src="https://user-images.githubusercontent.com/1683736/64479956-d921ac00-d18c-11e9-9023-24334ce45c67.png">
<img width="515" alt="Screen Shot 2019-09-07 at 4 29 33 PM" src="https://user-images.githubusercontent.com/1683736/64479957-d921ac00-d18c-11e9-90fa-f75d0ca512e4.png">

Currently, the SDK doesn't like 0 as a maxLiquiditySpread value. It also doesn't return the expected results for 100. Assuming some getter work is still to be completed before we merge this.
<img width="571" alt="Screen Shot 2019-09-07 at 4 16 19 PM" src="https://user-images.githubusercontent.com/1683736/64479955-d921ac00-d18c-11e9-8698-c37a2e6b06c4.png">
