### PR TITLE
fix reporting on scalar markets including invalid outcome

### DIFF
--- a/packages/augur-sdk/src/utils.ts
+++ b/packages/augur-sdk/src/utils.ts
@@ -149,7 +149,7 @@ export function calculatePayoutNumeratorsArray(
   numOutcomes: number,
   marketType: string,
   outcome: number,
-  isInvalid: boolean
+  isInvalid: boolean = false,
 ): BigNumber[] {
   const payoutNumerators = Array(numOutcomes).fill(new BigNumber(0));
   const isScalar = marketType === MarketTypeName.Scalar;

--- a/packages/augur-sdk/src/utils.ts
+++ b/packages/augur-sdk/src/utils.ts
@@ -74,8 +74,8 @@ export function convertPayoutNumeratorsToStrings(
 }
 
 export function convertDisplayValuetoAttoValue(
-  displayValue: BigNumber,
-) {
+  displayValue: BigNumber
+): BigNumber {
   return displayValue.multipliedBy(QUINTILLION);
 }
 
@@ -143,15 +143,22 @@ export function calculatePayoutNumeratorsValue(
 }
 
 export function calculatePayoutNumeratorsArray(
-  displayMaxPrice,
-  displayMinPrice,
-  numTicks,
-  numOutcomes,
-  marketType,
-  outcome
-): BigNumber [] {
+  displayMaxPrice: string,
+  displayMinPrice: string,
+  numTicks: string,
+  numOutcomes: number,
+  marketType: string,
+  outcome: number,
+  isInvalid: boolean
+): BigNumber[] {
   const payoutNumerators = Array(numOutcomes).fill(new BigNumber(0));
   const isScalar = marketType === MarketTypeName.Scalar;
+  const numTicksBN = new BigNumber(numTicks);
+
+  if (isInvalid) {
+    payoutNumerators[0] = numTicksBN;
+    return payoutNumerators;
+  }
 
   if (isScalar) {
     const priceRange = new BigNumber(displayMaxPrice).minus(
@@ -161,13 +168,13 @@ export function calculatePayoutNumeratorsArray(
       new BigNumber(displayMinPrice)
     );
     const longPayout = reportNormalizedToZero
-      .times(numTicks)
+      .times(numTicksBN)
       .dividedBy(priceRange);
-    const shortPayout = new BigNumber(numTicks).minus(longPayout);
-    payoutNumerators[0] = shortPayout;
-    payoutNumerators[1] = longPayout;
+    const shortPayout = numTicksBN.minus(longPayout);
+    payoutNumerators[1] = shortPayout;
+    payoutNumerators[2] = longPayout;
   } else {
-    payoutNumerators[outcome] = new BigNumber(numTicks);
+    payoutNumerators[outcome] = numTicksBN;
   }
   return payoutNumerators;
 }

--- a/packages/augur-tools/src/flash/scripts.ts
+++ b/packages/augur-tools/src/flash/scripts.ts
@@ -421,6 +421,13 @@ export function addScripts(flash: FlashSession) {
           'description to be added to contracts for initial report (optional)',
         required: false,
       },
+      {
+        name: 'isInvalid',
+        abbr: 'i',
+        description:
+          'isInvalid flag is used only for scalar markets (optional)',
+        required: false,
+      },
     ],
     async call(this: FlashSession, args: FlashArguments) {
       if (this.noProvider()) return;
@@ -429,6 +436,7 @@ export function addScripts(flash: FlashSession) {
       const outcome = Number(args.outcome);
       const extraStake = args.extraStake as string;
       const desc = args.description as string;
+      const isInvalid = args.isInvalid as boolean;
       let preEmptiveStake = '0';
       if (extraStake) {
         preEmptiveStake = new BigNumber(extraStake)
@@ -454,7 +462,8 @@ export function addScripts(flash: FlashSession) {
         marketInfo.numTicks,
         marketInfo.numOutcomes,
         marketInfo.marketType,
-        outcome
+        outcome,
+        isInvalid
       );
 
       await user.doInitialReport(
@@ -495,6 +504,13 @@ export function addScripts(flash: FlashSession) {
           'description to be added to contracts for dispute (optional)',
         required: false,
       },
+      {
+        name: 'isInvalid',
+        abbr: 'i',
+        description:
+          'isInvalid flag is used only for scalar markets (optional)',
+        required: false,
+      },
     ],
     async call(this: FlashSession, args: FlashArguments) {
       if (this.noProvider()) return;
@@ -503,6 +519,7 @@ export function addScripts(flash: FlashSession) {
       const outcome = Number(args.outcome);
       const amount = args.amount as string;
       const desc = args.description as string;
+      const isInvalid = args.isInvalid as boolean;
       if (amount === '0') return this.log('amount of REP is required');
       const stake = new BigNumber(amount).multipliedBy(QUINTILLION);
 
@@ -529,7 +546,8 @@ export function addScripts(flash: FlashSession) {
         marketInfo.numTicks,
         marketInfo.numOutcomes,
         marketInfo.marketType,
-        outcome
+        outcome,
+        isInvalid,
       );
 
       await user.contribute(market, payoutNumerators, stake, desc);
@@ -566,6 +584,13 @@ export function addScripts(flash: FlashSession) {
           'description to be added to contracts for contribution (optional)',
         required: false,
       },
+      {
+        name: 'isInvalid',
+        abbr: 'i',
+        description:
+          'isInvalid flag is used only for scalar markets (optional)',
+        required: false,
+      },
     ],
     async call(this: FlashSession, args: FlashArguments) {
       if (this.noProvider()) return;
@@ -574,6 +599,7 @@ export function addScripts(flash: FlashSession) {
       const outcome = Number(args.outcome);
       const amount = args.amount as string;
       const desc = args.description as string;
+      const isInvalid = args.isInvalid as boolean;
       if (amount === '0') return this.log('amount of REP is required');
       const stake = new BigNumber(amount).multipliedBy(QUINTILLION);
 
@@ -600,7 +626,8 @@ export function addScripts(flash: FlashSession) {
         marketInfo.numTicks,
         marketInfo.numOutcomes,
         marketInfo.marketType,
-        outcome
+        outcome,
+        isInvalid,
       );
 
       await user.contributeToTentative(market, payoutNumerators, stake, desc);

--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -346,6 +346,7 @@ export const MARKET_FULLY_LOADING = 'MARKET_FULLY_LOADING';
 export const MARKET_FULLY_LOADED = 'MARKET_FULLY_LOADED';
 
 // # Market Outcome Constants
+export const INVALID_OUTCOME_ID = 0;
 export const YES_NO_NO_ID = 1;
 export const YES_NO_NO_OUTCOME_NAME = 'No';
 export const YES_NO_YES_ID = 2;

--- a/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
+++ b/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
@@ -21,7 +21,6 @@ import {
   Getters,
   numTicksToTickSizeWithDisplayPrices,
   calculatePayoutNumeratorsArray,
-  stringTo32ByteHex,
   convertDisplayValuetoAttoValue,
 } from '@augurproject/sdk';
 
@@ -230,17 +229,17 @@ export interface doReportDisputeAddStake {
   outcomeId: number;
   description: string;
   amount: string;
+  isInvalid: boolean;
 }
 
 export async function doInitialReport(report: doReportDisputeAddStake) {
   const market = getMarket(report.marketId);
   if (!market) return false;
   const payoutNumerators = getPayoutNumerators(report);
-  const description = stringTo32ByteHex(report.description);
   const amount = convertDisplayValuetoAttoValue(
     new BigNumber(report.amount || '0')
   );
-  return await market.doInitialReport(payoutNumerators, description, amount);
+  return await market.doInitialReport(payoutNumerators, report.description, amount);
 }
 
 export async function addRepToTentativeWinningOutcome(
@@ -249,12 +248,11 @@ export async function addRepToTentativeWinningOutcome(
   const market = getMarket(addStake.marketId);
   if (!market) return false;
   const payoutNumerators = getPayoutNumerators(addStake);
-  const description = stringTo32ByteHex(addStake.description);
   const amount = convertDisplayValuetoAttoValue(new BigNumber(addStake.amount));
   return await market.contributeToTentative(
     payoutNumerators,
     amount,
-    description
+    addStake.description
   );
 }
 
@@ -262,9 +260,8 @@ export async function contribute(dispute: doReportDisputeAddStake) {
   const market = getMarket(dispute.marketId);
   if (!market) return false;
   const payoutNumerators = getPayoutNumerators(dispute);
-  const description = stringTo32ByteHex(dispute.description);
   const amount = convertDisplayValuetoAttoValue(new BigNumber(dispute.amount));
-  return await market.contribute(payoutNumerators, amount, description);
+  return await market.contribute(payoutNumerators, amount, dispute.description);
 }
 
 function getMarket(marketId) {
@@ -284,7 +281,8 @@ function getPayoutNumerators(inputs: doReportDisputeAddStake) {
     inputs.numTicks,
     inputs.numOutcomes,
     inputs.marketType,
-    inputs.outcomeId
+    inputs.outcomeId,
+    inputs.isInvalid,
   );
 }
 

--- a/packages/augur-ui/src/modules/modal/reporting.tsx
+++ b/packages/augur-ui/src/modules/modal/reporting.tsx
@@ -6,7 +6,7 @@ import { MarketTypeLabel, RepBalance } from 'modules/common/labels';
 import { Subheaders } from 'modules/reporting/common';
 import { RadioBarGroup } from 'modules/common/form';
 import { formatAttoRep } from 'utils/format-number';
-import { SCALAR } from 'modules/common/constants';
+import { SCALAR, INVALID_OUTCOME_ID } from 'modules/common/constants';
 import {
   doInitialReport,
   contribute,
@@ -77,7 +77,7 @@ export default class ModalReporting extends Component<
         description: '',
         amount: this.state.preFilledStake,
         outcomeId,
-        isInvalid: this.state.checked === "0",
+        isInvalid: this.state.checked === INVALID_OUTCOME_ID.toString(),
       });
       // wait a moment before closing the form.
       // need to either give user wait indicator in form

--- a/packages/augur-ui/src/modules/modal/reporting.tsx
+++ b/packages/augur-ui/src/modules/modal/reporting.tsx
@@ -64,7 +64,8 @@ export default class ModalReporting extends Component<
       } = this.props.market;
       let outcomeId = parseInt(this.state.checked, 10);
       if (marketType === SCALAR) {
-        outcomeId = parseFloat(this.state.scalarOutcome);
+        // checked might be invalid outcome
+        outcomeId = parseFloat(this.state.scalarOutcome || this.state.checked);
       }
       doInitialReport({
         marketId,
@@ -76,6 +77,7 @@ export default class ModalReporting extends Component<
         description: '',
         amount: this.state.preFilledStake,
         outcomeId,
+        isInvalid: this.state.checked === "0",
       });
       // wait a moment before closing the form.
       // need to either give user wait indicator in form
@@ -141,8 +143,6 @@ export default class ModalReporting extends Component<
           },
         };
       });
-
-    console.log(s.scalarOutcome);
 
     return (
       <div className={Styles.ModalReporting}>


### PR DESCRIPTION
fixes https://github.com/augurproject/augur/issues/3549

old util helper was using v1 logic instead of v2 logic to convert from outcome to payout numerators