### PR TITLE
amount now shows dai icon and percentage shows percentage sign

### DIFF
--- a/packages/augur-ui/src/modules/portfolio/components/common/positions-header.tsx
+++ b/packages/augur-ui/src/modules/portfolio/components/common/positions-header.tsx
@@ -57,7 +57,7 @@ const PositionsHeader = (props: PositionsHeaderProps) => (
           Returns
         </span>
         <DaiPercentButton
-          showEth={props.showPercent}
+          showEth={!props.showPercent}
           title="dai/percent"
           action={props.updateShowPercent}
         />


### PR DESCRIPTION
Icons displaying properly on the portfolio page (right side, on total returns).

![Screenshot](https://user-images.githubusercontent.com/10351013/65200867-e1b49500-da5e-11e9-8d62-a3c762e9984f.png)
