### PR TITLE
refactored buy participation modal to have one page instead of two, w…

### DIFF
--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -660,6 +660,7 @@ export const NEW_ORDER_GAS_ESTIMATE = createBigNumber(700000);
 export const NEW_MARKET_GAS_ESTIMATE = createBigNumber(2000000);
 export const CLAIM_MARKETS_PROCEEDS_GAS_ESTIMATE = createBigNumber(1121349); // Gas cost for claiming proceeds from a categorical market with 8 outcomes (worst-case gas cost)
 export const CLAIM_MARKETS_PROCEEDS_GAS_LIMIT = createBigNumber(3000000);
+export const BUY_PARTICIPATION_TOKENS_GAS_LIMIT = createBigNumber(3000000);
 export const MAX_BULK_CLAIM_MARKETS_PROCEEDS_COUNT = Math.floor(
   createBigNumber(CLAIM_MARKETS_PROCEEDS_GAS_LIMIT)
     .div(CLAIM_MARKETS_PROCEEDS_GAS_ESTIMATE)

--- a/packages/augur-ui/src/modules/modal/common.tsx
+++ b/packages/augur-ui/src/modules/modal/common.tsx
@@ -48,7 +48,7 @@ export interface AlertMessageProps {
 }
 
 export interface DescriptionMessageProps {
-  messages: Array<AlertMessageProps>;
+  messages: AlertMessageProps[];
 }
 
 interface SubheaderContent {

--- a/packages/augur-ui/src/modules/modal/common.tsx
+++ b/packages/augur-ui/src/modules/modal/common.tsx
@@ -66,7 +66,7 @@ export interface CallToActionProps {
 }
 
 export interface BreakdownProps {
-  rows: Array<LinearPropertyLabelProps>;
+  rows: LinearPropertyLabelProps[];
   title?: string;
   short?: boolean;
   reverse?: boolean;

--- a/packages/augur-ui/src/modules/modal/components/common/common.styles.less
+++ b/packages/augur-ui/src/modules/modal/components/common/common.styles.less
@@ -32,42 +32,19 @@
   max-width: 35rem;
   padding: @size-24 0;
   position: relative;
-  text-align: center;
+  text-align: left;
   width: 100%;
 
   > * {
     width: 100%;
   }
 
-  form.ModalTightForm > h1,
-  h1 {
-    color: @color-primary-text;
-    font-size: @size-22;
-    font-weight: 500;
-    line-height: 1.75rem;
-    margin: @size-8 0 @size-24;
-    text-align: center;
-  }
+  .ModalParticipation {
+    > div:last-of-type {
+      padding-top: @size-16;
+    }
 
-  form.ModalTightForm > label {
-    color: @color-primary-text;
-    font-size: @size-14;
-    font-weight: 600;
-    line-height: @size-18;
-    margin: 0 @size-32 @size-8;
-    text-align: left;
-    width: auto;
-  }
-
-  form.ModalTightForm > div {
-    font-size: @size-14;
-    line-height: @size-16;
-    margin: 0 7rem @size-24;
-    width: auto;
-  }
-
-  form.ModalTightForm > div:last-of-type {
-    margin: @size-8 @size-32 0;
+    padding: @size-24
   }
 }
 

--- a/packages/augur-ui/src/modules/modal/components/common/common.styles.less
+++ b/packages/augur-ui/src/modules/modal/components/common/common.styles.less
@@ -54,7 +54,7 @@
     font-size: @size-14;
     font-weight: 600;
     line-height: @size-18;
-    margin: 0 7rem @size-8;
+    margin: 0 @size-32 @size-8;
     text-align: left;
     width: auto;
   }
@@ -108,7 +108,7 @@
   }
 
   form.ModalTightForm > div:last-of-type {
-    margin: @size-8 0 0;
+    margin: @size-8 @size-32 0;
   }
 }
 

--- a/packages/augur-ui/src/modules/modal/components/common/common.styles.less
+++ b/packages/augur-ui/src/modules/modal/components/common/common.styles.less
@@ -82,7 +82,7 @@
   }
 
   form.ModalTightForm > p.Error {
-    margin: 0 7rem @size-24;
+    margin: @size-4 @size-32 @size-24;
     padding: 0;
   }
 

--- a/packages/augur-ui/src/modules/modal/components/common/common.styles.less
+++ b/packages/augur-ui/src/modules/modal/components/common/common.styles.less
@@ -59,52 +59,11 @@
     width: auto;
   }
 
-  form.ModalTightForm > p,
-  > p {
-    color: @color-primary-text;
-    font-size: @size-12;
-    line-height: @size-18;
-    margin: 0;
-    padding: 0 4rem;
-
-    &:last-of-type {
-      margin-bottom: @size-24;
-    }
-
-    > button {
-      text-decoration: underline;
-    }
-  }
-
-  form.ModalTightForm > p.Error,
-  > p.Error {
-    color: @color-error;
-  }
-
-  form.ModalTightForm > p.Error {
-    margin: @size-4 @size-32 @size-24;
-    padding: 0;
-  }
-
   form.ModalTightForm > div {
     font-size: @size-14;
     line-height: @size-16;
     margin: 0 7rem @size-24;
     width: auto;
-
-    > input {
-      font-size: @size-14;
-      line-height: @size-16;
-      padding: @size-12 @size-16;
-    }
-
-    > input::placeholder {
-      color: @color-primary-text;
-    }
-  }
-
-  form.ModalTightForm > div.ErrorField {
-    margin-bottom: @size-8;
   }
 
   form.ModalTightForm > div:last-of-type {

--- a/packages/augur-ui/src/modules/modal/components/modal-participate.tsx
+++ b/packages/augur-ui/src/modules/modal/components/modal-participate.tsx
@@ -4,17 +4,21 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { createBigNumber, BigNumber } from 'utils/create-big-number';
 import { InputErrorIcon } from 'modules/common/icons';
-import { Input } from 'modules/common/form';
+import { Input, TextInput } from 'modules/common/form';
 import ModalReview from 'modules/modal/components/modal-review';
 import Styles from 'modules/modal/components/common/common.styles.less';
 import { formatRep, formatGasCostToEther } from 'utils/format-number';
 import { BUY_PARTICIPATION_TOKENS_GAS_LIMIT } from 'modules/common/constants';
+import ModalActions from './common/modal-actions';
+import { Title, DescriptionMessage, AlertMessageProps } from '../common';
 
 interface ModalParticipateProps {
   rep: string;
   gasPrice: string;
   closeModal: (...args: any[]) => any;
   purchaseParticipationTokens: Function;
+  messages: AlertMessageProps[];
+  title: string;
 }
 
 interface ModalParticipateState {
@@ -51,7 +55,7 @@ export default class ModalParticipate extends Component<
         this.state.quantity,
         true,
         (err, gasEstimate) => {
-          if (!err && !!gasEstimate) this.setState({ gasEstimate});
+          if (!err && !!gasEstimate) this.setState({ gasEstimate });
         }
       );
     }
@@ -113,7 +117,7 @@ export default class ModalParticipate extends Component<
   }
 
   render() {
-    const { closeModal, gasPrice } = this.props;
+    const { closeModal, gasPrice, messages, title } = this.props;
     const { errors, isValid, quantity, gasEstimate } = this.state;
     const invalidWithErrors = !isValid && errors.length > 0;
     const formattedQuantity = formatRep(quantity || 0);
@@ -147,51 +151,30 @@ export default class ModalParticipate extends Component<
 
     return (
       <section className={Styles.ModalContainer}>
-        <form className={Styles.ModalTightForm}>
-          <h1>Buy Participation Tokens</h1>
-          <label htmlFor="modal__participate-quantity">
-            Quantity (1 token @ 1 REP)
-          </label>
-          {/*
-              // @ts-ignore */}
-          <Input
-            id="modal__participate-quantity"
-            type="number"
-            className={classNames({
-              [`${Styles.ErrorField}`]: invalidWithErrors,
-            })}
-            value={quantity}
-            placeholder="0.0"
-            onChange={value => this.updateQuantity(value)}
-            onKeyDown={e => this.handleKeyDown(e)}
-            autoComplete="off"
-            maxButton
-            onMaxButtonClick={() => this.handleMaxClick()}
-          />
-          {!!errors.length &&
-            errors.map((error, index) => (
-              <p key={error} className={Styles.Error}>
-                {InputErrorIcon()} {error}
-              </p>
-            ))}
-          <ModalReview
-            title=""
-            items={items}
-            buttons={[
-              {
-                label: 'cancel',
-                action: closeModal,
-                type: 'gray',
-              },
-              {
-                label: 'buy',
-                action: this.submitForm,
-                type: 'purple',
-                isDisabled: !isValid,
-              },
-            ]}
-          />
-        </form>
+        <Title title={title} closeAction={() => closeModal()} />
+        <DescriptionMessage messages={messages} />
+        <TextInput
+          placeholder={'0.0000'}
+          value={quantity}
+          onChange={value => this.updateQuantity(value)}
+          errorMessage={errors[0]}
+          innerLabel="REP"
+        />
+        <ModalActions
+          buttons={[
+            {
+              label: 'cancel',
+              action: closeModal,
+              type: 'gray',
+            },
+            {
+              label: 'buy',
+              action: this.submitForm,
+              type: 'purple',
+              isDisabled: !isValid,
+            },
+          ]}
+        />
       </section>
     );
   }

--- a/packages/augur-ui/src/modules/modal/components/modal-participate.tsx
+++ b/packages/augur-ui/src/modules/modal/components/modal-participate.tsx
@@ -7,10 +7,15 @@ import { InputErrorIcon } from 'modules/common/icons';
 import { Input, TextInput } from 'modules/common/form';
 import ModalReview from 'modules/modal/components/modal-review';
 import Styles from 'modules/modal/components/common/common.styles.less';
-import { formatRep, formatGasCostToEther } from 'utils/format-number';
+import { formatRep, formatGasCostToEther, formatEtherEstimate } from 'utils/format-number';
 import { BUY_PARTICIPATION_TOKENS_GAS_LIMIT } from 'modules/common/constants';
 import ModalActions from './common/modal-actions';
-import { Title, DescriptionMessage, AlertMessageProps } from '../common';
+import {
+  Title,
+  DescriptionMessage,
+  AlertMessageProps,
+  Breakdown,
+} from '../common';
 
 interface ModalParticipateProps {
   rep: string;
@@ -119,47 +124,48 @@ export default class ModalParticipate extends Component<
   render() {
     const { closeModal, gasPrice, messages, title } = this.props;
     const { errors, isValid, quantity, gasEstimate } = this.state;
-    const invalidWithErrors = !isValid && errors.length > 0;
     const formattedQuantity = formatRep(quantity || 0);
-    const formattedGas = formatGasCostToEther(
-      gasEstimate,
-      { decimalsRounded: 4 },
-      gasPrice
+    const formattedGas = formatEtherEstimate(
+      formatGasCostToEther(
+        gasEstimate,
+        { decimalsRounded: 4 },
+        gasPrice
+      )
     );
     const items = [
       {
-        label: 'Purchase',
-        value: 'Participation Tokens',
-        denomination: '',
-      },
-      {
         label: 'quantity',
-        value: formattedQuantity.fullPrecision,
+        value: formattedQuantity,
         denomination: '',
       },
       {
         label: 'price',
-        value: formattedQuantity.fullPrecision,
+        value: formattedQuantity,
         denomination: 'REP',
+        showDenomination: true,
       },
       {
         label: 'gas',
         value: formattedGas,
         denomination: 'ETH',
+        showDenomination: true,
       },
     ];
 
     return (
       <section className={Styles.ModalContainer}>
         <Title title={title} closeAction={() => closeModal()} />
-        <DescriptionMessage messages={messages} />
-        <TextInput
-          placeholder={'0.0000'}
-          value={quantity}
-          onChange={value => this.updateQuantity(value)}
-          errorMessage={errors[0]}
-          innerLabel="REP"
-        />
+        <div className={Styles.ModalParticipation}>
+          <DescriptionMessage messages={messages} />
+          <TextInput
+            placeholder={'0.0000'}
+            value={quantity}
+            onChange={value => this.updateQuantity(value)}
+            errorMessage={errors[0]}
+            innerLabel="REP"
+          />
+          <Breakdown rows={items} />
+        </div>
         <ModalActions
           buttons={[
             {

--- a/packages/augur-ui/src/modules/modal/components/modal-participate.tsx
+++ b/packages/augur-ui/src/modules/modal/components/modal-participate.tsx
@@ -1,11 +1,8 @@
 /* eslint jsx-a11y/label-has-for: 0 */
 
 import React, { Component } from 'react';
-import classNames from 'classnames';
 import { createBigNumber, BigNumber } from 'utils/create-big-number';
-import { InputErrorIcon } from 'modules/common/icons';
-import { Input, TextInput } from 'modules/common/form';
-import ModalReview from 'modules/modal/components/modal-review';
+import { TextInput } from 'modules/common/form';
 import Styles from 'modules/modal/components/common/common.styles.less';
 import { formatRep, formatGasCostToEther, formatEtherEstimate } from 'utils/format-number';
 import { BUY_PARTICIPATION_TOKENS_GAS_LIMIT } from 'modules/common/constants';

--- a/packages/augur-ui/src/modules/modal/containers/modal-participate.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-participate.ts
@@ -11,7 +11,11 @@ import { getGasPrice } from 'modules/auth/selectors/get-gas-price';
 const mapStateToProps = (state: AppState) => ({
   modal: state.modal,
   rep: state.loginAccount.balances.rep,
-  gasPrice: getGasPrice(state)
+  gasPrice: getGasPrice(state),
+  messages: [{
+    preText: 'Quantity (1 token @ 1 REP)'
+  }],
+  title: 'Buy Participation Tokens',
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({

--- a/packages/augur-ui/src/modules/modal/containers/modal-participate.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-participate.ts
@@ -6,10 +6,12 @@ import { closeModal } from "modules/modal/actions/close-modal";
 import { AppState } from "store";
 import { ThunkDispatch } from "redux-thunk";
 import { Action } from "redux";
+import { getGasPrice } from 'modules/auth/selectors/get-gas-price';
 
 const mapStateToProps = (state: AppState) => ({
   modal: state.modal,
   rep: state.loginAccount.balances.rep,
+  gasPrice: getGasPrice(state)
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({


### PR DESCRIPTION
…ired up estimation, added a default gas value if estimation fails

Waiting for contracts addresses to get worked out. gas estimation fails and buying participation tokens fails until contracts addresses are worked out.

![image](https://user-images.githubusercontent.com/3970376/65551827-63397680-dee8-11e9-924a-3dfc042fd48e.png)

