### PR TITLE
add a unique id that we compare when updating and deleting

### DIFF
--- a/packages/augur-ui/src/modules/account/actions/get-rep.ts
+++ b/packages/augur-ui/src/modules/account/actions/get-rep.ts
@@ -1,4 +1,3 @@
-import { updateAlert } from "modules/alerts/actions/alerts";
 import { selectCurrentTimestampInSeconds as getTime } from "store/select-state";
 import logError from "utils/log-error";
 import { AppState } from "store";
@@ -9,14 +8,6 @@ import { getRep } from "modules/contracts/actions/contractCalls";
 
 export default function(callback: NodeStyleCallback = logError) {
   return (dispatch: ThunkDispatch<void, any, Action>, getState: () => AppState) => {
-    const update = (id: string, status: string) =>
-      dispatch(
-        updateAlert(id, {
-          id,
-          status,
-          timestamp: getTime(getState()),
-        }),
-      );
-      getRep();
+    const update = (id: string, status: string) => getRep();
   };
 }

--- a/packages/augur-ui/src/modules/alerts/actions/alerts.ts
+++ b/packages/augur-ui/src/modules/alerts/actions/alerts.ts
@@ -83,15 +83,25 @@ export function updateExistingAlert(id, alert) {
   };
 }
 
-export function updateAlert(id: string, alert: any) {
+function createUniqueOrderId(alert) {
+  const price = alert.params._price ? alert.params._price.toString() : new BigNumber(alert.params.price).toString();
+  const outcome = alert.params._outcome ? alert.params._outcome.toString() : new BigNumber(alert.params.outcome).toString();
+  const direction = alert.params._direction ? alert.params._direction.toString() : alert.params.orderType;
+
+  return `${alert.id}_${price}_${outcome}_${direction}`;
+}
+
+export function updateAlert(txHash: string, alert: any) {
   return (dispatch: ThunkDispatch<void, any, Action>): void => {
-    alert.id = id;
     if (alert) {
       const { alerts, loginAccount } = store.getState() as AppState;
       const alertName = alert.name.toUpperCase();
+      alert.txHash = txHash;
+      alert.uniqueId = alertName === PUBLICTRADE ? createUniqueOrderId(alert) : txHash;
+
       if (alertName === DOINITIALREPORT) {
         dispatch(
-          updateAlert(id, {
+          updateAlert(txHash, {
             ...alert,
             params: {
               ...alert.params,
@@ -176,12 +186,12 @@ export function updateAlert(id: string, alert: any) {
       }
       const foundAlert = alerts.find(findAlert => {
         return (
-          findAlert.id === id &&
+          findAlert.uniqueId === alert.uniqueId &&
           findAlert.name.toUpperCase() === alert.name.toUpperCase()
         );
       });
       if (foundAlert) {
-        dispatch(removeAlert(id, alert.name));
+        dispatch(removeAlert(alert.uniqueId, alert.name));
         dispatch(
           addAlert({
             ...foundAlert,

--- a/packages/augur-ui/src/modules/alerts/components/alerts-view.tsx
+++ b/packages/augur-ui/src/modules/alerts/components/alerts-view.tsx
@@ -26,7 +26,7 @@ export default class AlertsView extends Component<AlertsViewProps> {
     if (this.props.alertsVisible && !nextProps.alertsVisible) {
       const { updateExistingAlert, alerts } = this.props;
       alerts.forEach(alert => {
-        updateExistingAlert(alert.id, { ...alert, seen: true });
+        updateExistingAlert(alert.uniqueId, { ...alert, seen: true });
       });
     }
   }
@@ -76,7 +76,7 @@ export default class AlertsView extends Component<AlertsViewProps> {
               {alerts.map((alert, i) => (
                 <Alert
                   key={`${i}-${alert.id}-${alert.title}`}
-                  removeAlert={() => removeAlert(alert.id, alert.name)}
+                  removeAlert={() => removeAlert(alert.uniqueId, alert.name)}
                   toggleAlerts={toggleAlerts}
                   timestampInMilliseconds={alert.timestamp}
                   {...alert}

--- a/packages/augur-ui/src/modules/alerts/components/toasts-view.tsx
+++ b/packages/augur-ui/src/modules/alerts/components/toasts-view.tsx
@@ -20,7 +20,7 @@ export default class ToastsView extends Component<ToastsViewProps, {}> {
           name: this.props.toasts[0].name, 
           toast: false,
         };
-        this.props.updateExistingAlert(this.props.toasts[0].id, newToast);
+        this.props.updateExistingAlert(this.props.toasts[0].uniqueId, newToast);
       }
     }, 3000);
   }
@@ -40,7 +40,7 @@ export default class ToastsView extends Component<ToastsViewProps, {}> {
           {toasts.map((toast, i) => (
               <Alert
                   key={`${toast.id}-${toast.title}`}
-                  removeAlert={() => removeAlert(toast.id, toast.name)}
+                  removeAlert={() => removeAlert(toast.uniqueId, toast.name)}
                   toggleAlerts={toggleAlerts}
                   noShow={i !== 0}
                   showToast={true}

--- a/packages/augur-ui/src/modules/alerts/reducers/alerts.ts
+++ b/packages/augur-ui/src/modules/alerts/reducers/alerts.ts
@@ -48,7 +48,7 @@ export default function alert(alerts = DEFAULT_STATE, { data, type }: BaseAction
 
     case UPDATE_EXISTING_ALERT:
       let updatedAlerts = alerts.map((alert, i) => {
-        if (alert.id !== data.id || data.alert.name.toUpperCase() !== alert.name.toUpperCase()) {
+        if (alert.uniqueId !== data.id || data.alert.name.toUpperCase() !== alert.name.toUpperCase()) {
           return alert;
         }
 
@@ -59,7 +59,7 @@ export default function alert(alerts = DEFAULT_STATE, { data, type }: BaseAction
 
     case REMOVE_ALERT:
       let newAlerts = alerts;
-      newAlerts = newAlerts.filter((alert, i) => alert.id !== data.id || data.name.toUpperCase() !== alert.name.toUpperCase())
+      newAlerts = newAlerts.filter((alert, i) => alert.uniqueId !== data.id || data.name.toUpperCase() !== alert.name.toUpperCase())
       return newAlerts;
 
     case CLEAR_ALERTS:

--- a/packages/augur-ui/src/modules/auth/actions/load-account-data-from-local-storage.ts
+++ b/packages/augur-ui/src/modules/auth/actions/load-account-data-from-local-storage.ts
@@ -64,7 +64,7 @@ export const loadAccountDataFromLocalStorage = (address: string): ThunkAction<an
         );
       }
       if (alerts) {
-        alerts.map(n => dispatch(updateAlert(n.id, n)));
+        alerts.map(n => dispatch(updateAlert(n.txHash, n)));
       }
       if (
         pendingLiquidityOrders

--- a/packages/augur-ui/src/modules/auth/actions/transfer-funds.ts
+++ b/packages/augur-ui/src/modules/auth/actions/transfer-funds.ts
@@ -1,5 +1,4 @@
 import * as speedomatic from "speedomatic";
-import { updateAlert, addAlert } from "modules/alerts/actions/alerts";
 import { selectCurrentTimestampInSeconds as getTime } from "store/select-state";
 import { ETH, REP, CONFIRMED, FAILED } from "modules/common/constants";
 import { AppState } from "store";
@@ -16,15 +15,7 @@ export function transferFunds(
     const { universe, loginAccount } = getState();
     const fromAddress = loginAccount.address;
     const to = speedomatic.formatEthereumAddress(toAddress);
-    const update = (id: string, status: string) => {
-      dispatch(
-        updateAlert(id, {
-          id,
-          status,
-          timestamp: getTime(getState())
-        })
-      );
-    };
+    
     // TODO: need to add ability to transfer DAI
     switch (currency) {
       case ETH:

--- a/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
+++ b/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
@@ -64,7 +64,8 @@ export const addUpdateTransaction = (txStatus: Events.TXStatus) => (
     if (hash && eventName === TXEventName.Failure) {
       dispatch(
         addAlert({
-          id: hash ? hash : generateTxParameterId(transaction.params),
+          txHash: hash ? hash : generateTxParameterId(transaction.params),
+          uniqueId: hash ? hash : generateTxParameterId(transaction.params),
           params: transaction.params,
           status: eventName,
           timestamp: blockchain.currentAugurTimestamp * 1000,

--- a/packages/augur-ui/src/modules/orders/actions/cancel-order.ts
+++ b/packages/augur-ui/src/modules/orders/actions/cancel-order.ts
@@ -36,7 +36,8 @@ export const cancelOrder = (
     // TODO: we'll update state using pending tx events.
     dispatch(
       addAlert({
-        id: orderId,
+        txHash: orderId,
+        uniqueId: orderId,
         name: CANCELORDER,
         status: '',
         params: {


### PR DESCRIPTION
closes https://github.com/AugurProject/augur/issues/3847

now alerts have an id/txHash and a uniqueId 
- in most cases uniqueId is the same as the id/txHash, except for orders and whatever else we need down the line, because multiple orders can have the same txHash
- uniqueId is used to compare for updating and deleting and to tell if the alerts are the same
- id/txhash isn't always the txHash, for market alerts it is the marketId and cancel order alerts it is the orderId


also removed some calls to update and add alert that we don't need anymore