### PR TITLE
was adding total for market instead of amount of reporting or disputing

### DIFF
--- a/packages/augur-ui/src/modules/auth/actions/load-account-reporting.ts
+++ b/packages/augur-ui/src/modules/auth/actions/load-account-reporting.ts
@@ -20,8 +20,8 @@ export const loadAccountReportingHistory = (marketIdAggregator?: Function) => as
     reporting.reporting.contracts.map(c => [...marketIds, c.marketId]);
   if (reporting.disputing && reporting.disputing.contracts.length > 0)
     reporting.disputing.contracts.map(c => [...marketIds, c.marketId]);
-  // TODO: when we get real data pass to market id aggregator
-  if (marketIdAggregator) marketIdAggregator([]);
+
+  if (marketIdAggregator) marketIdAggregator(marketIds);
 
   dispatch(updateLoginAccount({ reporting }));
 };

--- a/packages/augur-ui/src/modules/modal/containers/modal-claim-fees.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-claim-fees.ts
@@ -14,6 +14,7 @@ import { ActionRowsProps } from 'modules/modal/common';
 import {
   CLAIM_FEES_GAS_COST,
   redeemStake,
+  redeemStakeBatches,
 } from 'modules/reporting/actions/claim-reporting-fees';
 import {
   CLAIM_FEE_WINDOWS,
@@ -44,6 +45,16 @@ const mergeProps = (sP: any, dP: any, oP: any) => {
   const { gasCost, pendingQueue } = sP;
   const claimReportingFees = sP.claimReportingFees as MarketReportClaimableContracts;
   const modalRows: ActionRowsProps[] = [];
+
+  const reportingParticipants = claimReportingFees.claimableMarkets.marketContracts.reduce(
+    (p, c) => [...p, ...c.contracts],
+    []
+  );
+  const AllRedeemStakeOptions = {
+    disputeWindows: claimReportingFees.participationContracts.contracts,
+    reportingParticipants,
+  };
+  const submitAllTxCount = redeemStakeBatches(AllRedeemStakeOptions);
   const claimableMarkets = claimReportingFees.claimableMarkets;
   claimableMarkets.marketContracts.map(marketObj => {
     const market = marketObj.marketObject;
@@ -120,6 +131,7 @@ const mergeProps = (sP: any, dP: any, oP: any) => {
   }
   return {
     title: 'Claim Stake & Fees',
+    submitAllTxCount,
     descriptionMessage: [
       {
         preText: 'You have',
@@ -144,15 +156,7 @@ const mergeProps = (sP: any, dP: any, oP: any) => {
         text: 'Claim All',
         disabled: modalRows.find(market => market.status === 'pending'),
         action: () => {
-          const reportingParticipants = claimReportingFees.claimableMarkets.marketContracts.reduce(
-            (p, c) => [...p, ...c.contracts],
-            []
-          );
-          const RedeemStakeOptions = {
-            disputeWindows: claimReportingFees.participationContracts.contracts,
-            reportingParticipants,
-          };
-          dP.redeemStake(RedeemStakeOptions, () => {
+          dP.redeemStake(AllRedeemStakeOptions, () => {
             if (sP.modal.cb) {
               sP.modal.cb();
             }

--- a/packages/augur-ui/src/modules/positions/selectors/select-reporting-winnings-by-market.ts
+++ b/packages/augur-ui/src/modules/positions/selectors/select-reporting-winnings-by-market.ts
@@ -66,7 +66,7 @@ export const selectReportingWinningsByMarket = createSelector(
     ) {
       claimableMarkets = userReporting.reporting.contracts.reduce(
         (p, contract) =>
-          isClaimable(contract.marketId) ? sumClaims(contract, p) : p,
+          isClaimable(contract.marketId, contract.amount) ? sumClaims(contract, p) : p,
         claimableMarkets
       );
     }
@@ -77,7 +77,7 @@ export const selectReportingWinningsByMarket = createSelector(
     ) {
       claimableMarkets = userReporting.disputing.contracts.reduce(
         (p, contract) =>
-          isClaimable(contract.marketId) ? sumClaims(contract, p) : p,
+          isClaimable(contract.marketId, contract.amount) ? sumClaims(contract, p) : p,
         claimableMarkets
       );
     }
@@ -129,8 +129,10 @@ function sumClaims(
   return marketsCollection;
 }
 
-function isClaimable(marketId: string) {
+function isClaimable(marketId: string, amount: BigNumber) {
+  if (createBigNumber(amount).lte(ZERO)) return false;
   const market = selectMarket(marketId);
+  if (!market) return false;
   return (
     market.reportingState === REPORTING_STATE.AWAITING_FINALIZATION ||
     market.reportingState === REPORTING_STATE.FINALIZED

--- a/packages/augur-ui/src/modules/positions/selectors/select-reporting-winnings-by-market.ts
+++ b/packages/augur-ui/src/modules/positions/selectors/select-reporting-winnings-by-market.ts
@@ -63,6 +63,7 @@ export const selectReportingWinningsByMarket = createSelector(
         unclaimedRep: calcUnclaimed.rep,
       };
     }
+    console.log("strating claimableMarkets unclaimed rep", formatAttoRep(claimableMarkets.unclaimedRep).formatted);
     if (
       userReporting &&
       userReporting.reporting &&
@@ -74,6 +75,7 @@ export const selectReportingWinningsByMarket = createSelector(
         claimableMarkets
       );
     }
+    console.log("claimableMarkets unclaimed rep", formatAttoRep(claimableMarkets.unclaimedRep).formatted);
     if (
       userReporting &&
       userReporting.disputing &&
@@ -89,6 +91,7 @@ export const selectReportingWinningsByMarket = createSelector(
     const totalUnclaimedRep = participationContracts.unclaimedRep.plus(
       claimableMarkets.unclaimedRep
     );
+    console.log("totalUnclaimedRep claimableMarkets unclaimed rep", formatAttoRep(totalUnclaimedRep).formatted);
     return {
       participationContracts,
       claimableMarkets,
@@ -109,12 +112,13 @@ function sumClaims(
   const found = marketsCollection.marketContracts.find(
     c => c.marketId === marketId
   );
+  console.log(found !== undefined, "did find", marketId);
   if (found) {
     found.totalAmount = createBigNumber(found.totalAmount).plus(
       createBigNumber(contractInfo.amount)
     );
     found.contracts = [...found.contracts, contractInfo.address];
-    addedValue = createBigNumber(found.totalAmount);
+    addedValue = createBigNumber(contractInfo.amount);
   } else {
     addedValue = createBigNumber(contractInfo.amount);
     marketsCollection.marketContracts = [
@@ -127,15 +131,17 @@ function sumClaims(
       },
     ];
   }
+  console.log("adding value", formatAttoRep(addedValue).formatted);
   marketsCollection.unclaimedRep = marketsCollection.unclaimedRep.plus(
     addedValue
   );
+  console.log("summing unclaimedRep", formatAttoRep(marketsCollection.unclaimedRep).formatted);
   return marketsCollection;
 }
 
 function isClaimable(marketId: string) {
   const market = selectMarket(marketId);
-  if (!market) return false;
+  if (!market) {console.log("market is null", marketId); return false;}
   return (
     market.reportingState === REPORTING_STATE.AWAITING_FINALIZATION ||
     market.reportingState === REPORTING_STATE.FINALIZED

--- a/packages/augur-ui/src/modules/positions/selectors/select-reporting-winnings-by-market.ts
+++ b/packages/augur-ui/src/modules/positions/selectors/select-reporting-winnings-by-market.ts
@@ -1,6 +1,4 @@
 import { createSelector } from 'reselect';
-
-import store from 'store';
 import {
   selectMarketInfosState,
   selectLoginAccountReportingState,
@@ -15,8 +13,6 @@ import {
   marketsReportingCollection,
 } from 'modules/types';
 import {
-  formatDai,
-  formatRep,
   formatAttoDai,
   formatAttoRep,
 } from 'utils/format-number';
@@ -63,7 +59,6 @@ export const selectReportingWinningsByMarket = createSelector(
         unclaimedRep: calcUnclaimed.rep,
       };
     }
-    console.log("strating claimableMarkets unclaimed rep", formatAttoRep(claimableMarkets.unclaimedRep).formatted);
     if (
       userReporting &&
       userReporting.reporting &&
@@ -75,7 +70,6 @@ export const selectReportingWinningsByMarket = createSelector(
         claimableMarkets
       );
     }
-    console.log("claimableMarkets unclaimed rep", formatAttoRep(claimableMarkets.unclaimedRep).formatted);
     if (
       userReporting &&
       userReporting.disputing &&
@@ -91,7 +85,6 @@ export const selectReportingWinningsByMarket = createSelector(
     const totalUnclaimedRep = participationContracts.unclaimedRep.plus(
       claimableMarkets.unclaimedRep
     );
-    console.log("totalUnclaimedRep claimableMarkets unclaimed rep", formatAttoRep(totalUnclaimedRep).formatted);
     return {
       participationContracts,
       claimableMarkets,
@@ -112,7 +105,6 @@ function sumClaims(
   const found = marketsCollection.marketContracts.find(
     c => c.marketId === marketId
   );
-  console.log(found !== undefined, "did find", marketId);
   if (found) {
     found.totalAmount = createBigNumber(found.totalAmount).plus(
       createBigNumber(contractInfo.amount)
@@ -131,17 +123,14 @@ function sumClaims(
       },
     ];
   }
-  console.log("adding value", formatAttoRep(addedValue).formatted);
   marketsCollection.unclaimedRep = marketsCollection.unclaimedRep.plus(
     addedValue
   );
-  console.log("summing unclaimedRep", formatAttoRep(marketsCollection.unclaimedRep).formatted);
   return marketsCollection;
 }
 
 function isClaimable(marketId: string) {
   const market = selectMarket(marketId);
-  if (!market) {console.log("market is null", marketId); return false;}
   return (
     market.reportingState === REPORTING_STATE.AWAITING_FINALIZATION ||
     market.reportingState === REPORTING_STATE.FINALIZED

--- a/packages/augur-ui/src/modules/positions/selectors/select-reporting-winnings-by-market.ts
+++ b/packages/augur-ui/src/modules/positions/selectors/select-reporting-winnings-by-market.ts
@@ -131,6 +131,7 @@ function sumClaims(
 
 function isClaimable(marketId: string) {
   const market = selectMarket(marketId);
+  if (!market) return false;
   return (
     market.reportingState === REPORTING_STATE.AWAITING_FINALIZATION ||
     market.reportingState === REPORTING_STATE.FINALIZED

--- a/packages/augur-ui/src/modules/positions/selectors/select-reporting-winnings-by-market.ts
+++ b/packages/augur-ui/src/modules/positions/selectors/select-reporting-winnings-by-market.ts
@@ -5,7 +5,7 @@ import {
   selectDisputeWindowStats,
 } from 'store/select-state';
 import { selectMarket } from 'modules/markets/selectors/market';
-import { createBigNumber } from 'utils/create-big-number';
+import { createBigNumber, BigNumber } from 'utils/create-big-number';
 import { ZERO, REPORTING_STATE } from 'modules/common/constants';
 import { Getters } from '@augurproject/sdk';
 import {

--- a/packages/augur-ui/src/modules/reporting/actions/claim-reporting-fees.ts
+++ b/packages/augur-ui/src/modules/reporting/actions/claim-reporting-fees.ts
@@ -1,9 +1,12 @@
-import logError from "utils/log-error";
-import { AppState } from "store";
-import { NodeStyleCallback, ClaimReportingOptions } from "modules/types";
-import { ThunkDispatch, ThunkAction } from "redux-thunk";
-import { Action } from "redux";
-import { redeemUserStakes, redeemUserStakesEstimateGas } from "modules/contracts/actions/contractCalls";
+import logError from 'utils/log-error';
+import { AppState } from 'store';
+import { NodeStyleCallback, ClaimReportingOptions } from 'modules/types';
+import { ThunkDispatch, ThunkAction } from 'redux-thunk';
+import { Action } from 'redux';
+import {
+  redeemUserStakes,
+  redeemUserStakesEstimateGas,
+} from 'modules/contracts/actions/contractCalls';
 
 export const CLAIM_FEES_GAS_COST = 3000000;
 export const CLAIM_WINDOW_GAS_COST = 210000;
@@ -13,73 +16,84 @@ export const DISPUTE_WINDOW_BATCH_SIZE = 10;
 export function redeemStake(
   options: ClaimReportingOptions,
   callback: NodeStyleCallback = logError
-): ThunkAction<any, any, any, any> {
-  return (
-    dispatch: ThunkDispatch<void, any, Action>,
-    getState: () => AppState
-  ) => {
-    const {
-      reportingParticipants,
-      disputeWindows,
+) {
+  const { reportingParticipants, disputeWindows, estimateGas } = options;
+
+  batchContractIds(disputeWindows, reportingParticipants).map(batch =>
+    runPayload(
+      batch.disputeWindows,
+      batch.reportingParticipants,
+      callback,
       estimateGas
-    } = options;
+    )
+  );
+}
 
-    batchContractIds(disputeWindows, reportingParticipants).map(batch =>
-      runPayload(batch.disputeWindows, batch.reportingParticipants, callback, estimateGas)
-    );
-  };
+export function redeemStakeBatches(
+  options: ClaimReportingOptions
+) {
+  const { reportingParticipants, disputeWindows } = options;
+  const batches = batchContractIds(disputeWindows, reportingParticipants);
+  return batches.length;
+}
 
-  interface Batch {
-    disputeWindows: string[],
-    reportingParticipants: string[]
+interface Batch {
+  disputeWindows: string[];
+  reportingParticipants: string[];
+}
+
+function batchContractIds(
+  disputeWindows: string[],
+  reportingParticipants: string[]
+) {
+  const batches = [] as Batch[];
+  const disputeWindowBatchSize = Math.ceil(
+    disputeWindows.length / DISPUTE_WINDOW_BATCH_SIZE
+  );
+  const crowdsourcerBatchSize = Math.ceil(
+    reportingParticipants.length / CROWDSOURCER_BATCH_SIZE
+  );
+
+  // max case, assuming DISPUTE_WINDOW_BATCH_SIZE number of fee windows and CROWDSOURCER_BATCH_SIZE number of crowdsourcers can run in one tx.
+  if (disputeWindowBatchSize < 2 && crowdsourcerBatchSize < 2)
+    return [{ disputeWindows, reportingParticipants }];
+
+  // dispute windows
+  for (let i = 0; i < disputeWindowBatchSize; i++) {
+    batches.push({
+      disputeWindows: disputeWindows.slice(
+        i * DISPUTE_WINDOW_BATCH_SIZE,
+        i * DISPUTE_WINDOW_BATCH_SIZE + DISPUTE_WINDOW_BATCH_SIZE
+      ),
+      reportingParticipants: [],
+    });
   }
 
-  function batchContractIds(
-    disputeWindows: string[],
-    reportingParticipants: string[]
-  ) {
-    const batches = [] as Batch[];
-    const disputeWindowBatchSize = Math.ceil(
-      disputeWindows.length / DISPUTE_WINDOW_BATCH_SIZE
-    );
-    const crowdsourcerBatchSize = Math.ceil(
-      reportingParticipants.length / CROWDSOURCER_BATCH_SIZE
-    );
-
-    // max case, assuming DISPUTE_WINDOW_BATCH_SIZE number of fee windows and CROWDSOURCER_BATCH_SIZE number of crowdsourcers can run in one tx.
-    if (disputeWindowBatchSize < 2 && crowdsourcerBatchSize < 2)
-      return [{ disputeWindows, reportingParticipants }];
-
-    // dispute windows
-    for (let i = 0; i < disputeWindowBatchSize; i++) {
-      batches.push({
-        disputeWindows: disputeWindows.slice(
-          i * DISPUTE_WINDOW_BATCH_SIZE,
-          i * DISPUTE_WINDOW_BATCH_SIZE + DISPUTE_WINDOW_BATCH_SIZE
-        ),
-        reportingParticipants: []
-      });
-    }
-
-    for (let i = 0; i < crowdsourcerBatchSize; i++) {
-      batches.push({
-        disputeWindows: [],
-        reportingParticipants: reportingParticipants.slice(
-          i * CROWDSOURCER_BATCH_SIZE,
-          i * CROWDSOURCER_BATCH_SIZE + CROWDSOURCER_BATCH_SIZE
-        )
-      });
-    }
-
-    return batches;
+  for (let i = 0; i < crowdsourcerBatchSize; i++) {
+    batches.push({
+      disputeWindows: [],
+      reportingParticipants: reportingParticipants.slice(
+        i * CROWDSOURCER_BATCH_SIZE,
+        i * CROWDSOURCER_BATCH_SIZE + CROWDSOURCER_BATCH_SIZE
+      ),
+    });
   }
 
-  async function runPayload(disputeWindows: string[], reportingParticipants: string[], callback: Function, estimateGas: boolean) {
+  return batches;
+}
 
-    if(estimateGas) {
-      const gas = await redeemUserStakesEstimateGas(reportingParticipants, disputeWindows);
-      if (callback) callback(null, gas);
-    }
-    redeemUserStakes(reportingParticipants, disputeWindows);
+async function runPayload(
+  disputeWindows: string[],
+  reportingParticipants: string[],
+  callback: Function,
+  estimateGas: boolean
+) {
+  if (estimateGas) {
+    const gas = await redeemUserStakesEstimateGas(
+      reportingParticipants,
+      disputeWindows
+    );
+    if (callback) callback(null, gas);
   }
+  redeemUserStakes(reportingParticipants, disputeWindows);
 }

--- a/packages/augur-ui/src/modules/types.ts
+++ b/packages/augur-ui/src/modules/types.ts
@@ -643,7 +643,7 @@ export interface MarketClaimablePositions {
 export interface ClaimReportingOptions {
   reportingParticipants: string[],
   disputeWindows: string[],
-  estimateGas: boolean;
+  estimateGas?: boolean;
 }
 
 export interface MarketReportContracts {


### PR DESCRIPTION
fix bug when summing up reporting / disputing staked REP

filter out contracts that have already been claimed. verified that redeem works. there is an issue with dispute windows showing up when user buys participation tokens.

![Screen Shot 2019-09-26 at 6 11 32 PM](https://user-images.githubusercontent.com/3970376/65731702-62414a00-e08c-11e9-9f76-0054dc5125a0.png)
