### PR TITLE
fix rep faucet and outcome order in market card

### DIFF
--- a/packages/augur-ui/src/modules/account/actions/get-rep.ts
+++ b/packages/augur-ui/src/modules/account/actions/get-rep.ts
@@ -1,13 +1,19 @@
-import { selectCurrentTimestampInSeconds as getTime } from "store/select-state";
 import logError from "utils/log-error";
 import { AppState } from "store";
 import { Action } from "redux";
 import { ThunkDispatch } from "redux-thunk";
 import { NodeStyleCallback } from "modules/types";
 import { getRep } from "modules/contracts/actions/contractCalls";
+import { updateAssets } from "modules/auth/actions/update-assets";
 
 export default function(callback: NodeStyleCallback = logError) {
-  return (dispatch: ThunkDispatch<void, any, Action>, getState: () => AppState) => {
-    const update = (id: string, status: string) => getRep();
+  return async (dispatch: ThunkDispatch<void, any, Action>, getState: () => AppState) => {
+    await getRep().catch((err: Error) => {
+      console.log("error could not get dai", err);
+      logError(new Error("get-Dai"));
+    });
+    // TODO: this will change when pending tx exists
+    dispatch(updateAssets());
+    callback(null);
   };
 }

--- a/packages/augur-ui/src/modules/market-cards/common.styles.less
+++ b/packages/augur-ui/src/modules/market-cards/common.styles.less
@@ -188,7 +188,7 @@
 		color: @color-secondary-text;
 		display: flex;
     	justify-content: space-between;
-		
+
 		> span {
 			.mono-9;
 		}
@@ -198,7 +198,7 @@
 .OutcomeGroup {
 	display: grid;
     grid-gap: @size-6;
-	
+
 	&.Categorical {
 		grid-template-columns: repeat(3, 1fr);
 
@@ -211,7 +211,7 @@
 		grid-template-columns: repeat(3, 1fr);
 
 		> div:first-of-type {
-			grid-column: 1 / span 2;
+			grid-column: 1;
 		}
 
 		@media @breakpoint-mobile-mid {
@@ -267,7 +267,7 @@
 
 	@media @breakpoint-mobile-mid{
 		flex-direction: column;
-		
+
 		> span:first-of-type {
 			> span {
 				display: none;
@@ -277,7 +277,7 @@
 
 	&.Condensed {
 		flex-direction: column;
-		
+
 		> span:first-of-type {
 			> span {
 				display: none;

--- a/packages/augur-ui/src/modules/market-cards/common.tsx
+++ b/packages/augur-ui/src/modules/market-cards/common.tsx
@@ -213,13 +213,21 @@ export interface OutcomeGroupProps {
   dispute?: Function;
 }
 
+const MARKET_CARD_FOLD_OUTCOME_COUNT = 4;
 export const OutcomeGroup = (props: OutcomeGroupProps) => {
   const inDispute =
     props.reportingState === REPORTING_STATE.CROWDSOURCING_DISPUTE ||
     props.reportingState === REPORTING_STATE.AWAITING_NEXT_WINDOW;
   let outcomesCopy = props.outcomes.slice(0);
   const removedInvalid = outcomesCopy.splice(0, 1)[0];
-  outcomesCopy.splice(2, 0, removedInvalid);
+  if (
+    !props.expanded &&
+    props.outcomes.length > MARKET_CARD_FOLD_OUTCOME_COUNT
+  ) {
+    outcomesCopy.splice(MARKET_CARD_FOLD_OUTCOME_COUNT - 1, 0, removedInvalid);
+  } else {
+    outcomesCopy.splice(outcomesCopy.length, 0, removedInvalid);
+  }
   const sortedStakeOutcomes = selectSortedDisputingOutcomes(
     props.marketType,
     props.outcomes,
@@ -261,7 +269,7 @@ export const OutcomeGroup = (props: OutcomeGroupProps) => {
       {(props.marketType !== SCALAR || inDispute) &&
         outcomesShow.map(
           (outcome: OutcomeFormatted, index: number) =>
-            ((!props.expanded && index < 4) ||
+            ((!props.expanded && index < MARKET_CARD_FOLD_OUTCOME_COUNT) ||
               (props.expanded || props.marketType === YES_NO)) &&
             (inDispute ? (
               <DisputeOutcome


### PR DESCRIPTION
associated with
https://github.com/AugurProject/augur/issues/3875
keep `invalid` as the last outcome. if market card is collapsed or expanded

fixed rep faucet

![image](https://user-images.githubusercontent.com/3970376/65779897-3e264d00-e10e-11e9-9d89-a41f3f14596c.png)


expanded

![image](https://user-images.githubusercontent.com/3970376/65779913-467e8800-e10e-11e9-9036-57f29104115f.png)


fixed Yes No market card
https://github.com/augurproject/augur/issues/3765
![image](https://user-images.githubusercontent.com/3970376/65781509-5481d800-e111-11e9-9059-c9eb5fb10034.png)

![image](https://user-images.githubusercontent.com/3970376/65781520-59468c00-e111-11e9-904c-afb0727de098.png)

