### PR TITLE
wip: keep topBar in view

### DIFF
--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -141,6 +141,8 @@ export default class MarketView extends Component<
 
   componentDidMount() {
     this.node.scrollIntoView();
+    window.scrollTo(0, 1);
+
     const { isMarketLoading, showMarketLoadingModal } = this.props;
     if (isMarketLoading) {
       showMarketLoadingModal();


### PR DESCRIPTION
Prevents TopBar from disappearing when navigating to the trading page on mobile.