### PR TITLE
Should only increase overall height when there are three lines of text

### DIFF
--- a/packages/augur-ui/src/modules/market-cards/market-card.styles.less
+++ b/packages/augur-ui/src/modules/market-cards/market-card.styles.less
@@ -21,10 +21,12 @@
 	> span,
 	> button:last-of-type {
 		border-left: 1px solid @color-dark-grey;
-		padding-left: @size-16;
+    padding-left: @size-16;
 	}
 
 	> div:nth-of-type(3) {
+    grid-row: 2 / span 4;
+
 		> div {
 			flex-direction: column;
 			text-transform: uppercase;

--- a/packages/augur-ui/src/modules/market-cards/market-card.styles.less
+++ b/packages/augur-ui/src/modules/market-cards/market-card.styles.less
@@ -8,7 +8,7 @@
 	margin: @size-4 0;
 	display: grid;
 	grid-template-columns: 111px auto;
-	grid-template-rows: auto 67px auto;
+	grid-template-rows: auto auto auto;
 	padding: 0 @size-16;
 
 	> div:first-of-type,


### PR DESCRIPTION
With auto in the middle row, the market title only goes as far as 77px when the title has 3 rows of text.
When collapsed, 1 row of text should only occupy the height of 1 row, and so forth.
https://github.com/AugurProject/augur/issues/3902