### PR TITLE
Update README to fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Running on the "kovan" testnet
 All parts of Augur are entirely open source. You can view, edit, and contribute to Augur via the repositories hosted on GitHub!
 
 - [Augur Core](packages/augur-core) - The core implementation of the Augur Project as Smart Contracts written in Solidity for the Ethereum Network.
-- [Augur.js](packages/augur.js) - Javascript library for Node.js and the browser to help you communicate with the Augur smart contracts, and Augur Node.
-- [Augur Node](packages/augur-node) - Helper application to aggregate the activity of the Augur community on the Ethereum Network. Allows you to quickly build responsive and performant user interfaces.
+- [Augur.js](https://github.com/AugurProject/augur.js) - Javascript library for Node.js and the browser to help you communicate with the Augur smart contracts, and Augur Node.
+- [Augur Node](https://github.com/AugurProject/augur-node) - Helper application to aggregate the activity of the Augur community on the Ethereum Network. Allows you to quickly build responsive and performant user interfaces.
 - [Augur UI](packages/augur-ui/) - A reference client UI which uses Augur Node and a connection to the Ethereum Network to interact with the Augur community.
 
 ## Documentation and Whitepaper

--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ Running on the "kovan" testnet
 All parts of Augur are entirely open source. You can view, edit, and contribute to Augur via the repositories hosted on GitHub!
 
 - [Augur Core](packages/augur-core) - The core implementation of the Augur Project as Smart Contracts written in Solidity for the Ethereum Network.
-- [Augur.js](https://github.com/AugurProject/augur.js) - Javascript library for Node.js and the browser to help you communicate with the Augur smart contracts, and Augur Node.
-- [Augur Node](https://github.com/AugurProject/augur-node) - Helper application to aggregate the activity of the Augur community on the Ethereum Network. Allows you to quickly build responsive and performant user interfaces.
+- [Augur Sdk](packages/augur-sdk) - Typescript library for Node.js and the browser to help communicate with the Augur smart contracts.
 - [Augur UI](packages/augur-ui/) - A reference client UI which uses Augur Node and a connection to the Ethereum Network to interact with the Augur community.
 
 ## Documentation and Whitepaper


### PR DESCRIPTION
Links to the Augur Node and augur.js repos go to a 404. Switched to current repos.