### PR TITLE
Fix participation token dispute markets

### DIFF
--- a/packages/augur-ui/src/modules/positions/selectors/select-reporting-winnings-by-market.ts
+++ b/packages/augur-ui/src/modules/positions/selectors/select-reporting-winnings-by-market.ts
@@ -2,11 +2,10 @@ import { createSelector } from 'reselect';
 import {
   selectMarketInfosState,
   selectLoginAccountReportingState,
-  selectDisputeWindowStats,
 } from 'store/select-state';
 import { selectMarket } from 'modules/markets/selectors/market';
-import { createBigNumber, BigNumber } from 'utils/create-big-number';
-import { ZERO, REPORTING_STATE } from 'modules/common/constants';
+import { createBigNumber } from 'utils/create-big-number';
+import { ZERO } from 'modules/common/constants';
 import { Getters } from '@augurproject/sdk';
 import {
   MarketReportClaimableContracts,
@@ -19,7 +18,7 @@ export const selectReportingWinningsByMarket = createSelector(
   selectMarketInfosState,
   (
     userReporting,
-    marketInfos, // this is needed to trigger the selector if marketInfos changes
+    marketInfos // this is needed to trigger the selector if marketInfos changes
   ): MarketReportClaimableContracts => {
     let claimableMarkets = {
       unclaimedRep: ZERO,

--- a/packages/augur-ui/src/modules/positions/selectors/select-reporting-winnings-by-market.ts
+++ b/packages/augur-ui/src/modules/positions/selectors/select-reporting-winnings-by-market.ts
@@ -19,7 +19,7 @@ export const selectReportingWinningsByMarket = createSelector(
   selectMarketInfosState,
   (
     userReporting,
-    marketInfos // this is needed to trigger the selector if marketInfos changes
+    marketInfos, // this is needed to trigger the selector if marketInfos changes
   ): MarketReportClaimableContracts => {
     let claimableMarkets = {
       unclaimedRep: ZERO,
@@ -58,28 +58,20 @@ export const selectReportingWinningsByMarket = createSelector(
       userReporting.reporting &&
       userReporting.reporting.contracts.length > 0
     ) {
-      const claimable = userReporting.reporting.contracts.filter(
-        contract => contract.isClaimable
+      claimableMarkets = userReporting.reporting.contracts.reduce(
+        (p, contract) => (contract.isClaimable ? sumClaims(contract, p) : p),
+        claimableMarkets
       );
-      claimableMarkets = {
-        unclaimedRep: createBigNumber(userReporting.reporting.totalClaimable),
-        marketContracts: claimable,
-      };
     }
     if (
       userReporting &&
       userReporting.disputing &&
       userReporting.disputing.contracts.length > 0
     ) {
-      const claimable = userReporting.disputing.contracts.filter(
-        contract => contract.isClaimable
+      claimableMarkets = userReporting.disputing.contracts.reduce(
+        (p, contract) => (contract.isClaimable ? sumClaims(contract, p) : p),
+        claimableMarkets
       );
-      claimableMarkets = {
-        unclaimedRep: claimableMarkets.unclaimedRep.plus(
-          createBigNumber(userReporting.disputing.totalClaimable)
-        ),
-        marketContracts: [...claimableMarkets.marketContracts, ...claimable],
-      };
     }
     const totalUnclaimedDai = participationContracts.unclaimedDai;
     const totalUnclaimedRep = participationContracts.unclaimedRep.plus(
@@ -95,3 +87,36 @@ export const selectReportingWinningsByMarket = createSelector(
     };
   }
 );
+
+function sumClaims(
+  contractInfo: Getters.Accounts.ContractInfo,
+  marketsCollection: marketsReportingCollection
+): marketsReportingCollection {
+  const marketId = contractInfo.marketId;
+  let addedValue = ZERO;
+  const found = marketsCollection.marketContracts.find(
+    c => c.marketId === marketId
+  );
+  if (found) {
+    found.totalAmount = createBigNumber(found.totalAmount).plus(
+      createBigNumber(contractInfo.amount)
+    );
+    found.contracts = [...found.contracts, contractInfo.address];
+    addedValue = createBigNumber(contractInfo.amount);
+  } else {
+    addedValue = createBigNumber(contractInfo.amount);
+    marketsCollection.marketContracts = [
+      ...marketsCollection.marketContracts,
+      {
+        ...contractInfo,
+        contracts: [contractInfo.address],
+        totalAmount: createBigNumber(contractInfo.amount),
+        marketObject: selectMarket(contractInfo.marketId),
+      },
+    ];
+  }
+  marketsCollection.unclaimedRep = marketsCollection.unclaimedRep.plus(
+    addedValue
+  );
+  return marketsCollection;
+}

--- a/packages/augur-ui/src/modules/reporting/common.tsx
+++ b/packages/augur-ui/src/modules/reporting/common.tsx
@@ -624,7 +624,6 @@ export class ReportingBondsView extends Component<
       userAttoRep,
       id,
       migrateRep,
-      migrateMarket,
       initialReport,
       owesRep,
     } = this.props;
@@ -634,7 +633,7 @@ export class ReportingBondsView extends Component<
     const repAmount = migrateRep ? formatAttoRep(inputtedReportingStake.inputToAttoRep).formatted : formatAttoRep(market.noShowBondAmount).formatted;
     let repLabel = migrateRep ? 'REP to migrate' : 'open reporter winning Stake'
     if (owesRep) {
-      repLabel = 'REP owned'
+      repLabel = 'REP needed'
     }
     const totalRep = owesRep
       ? formatAttoRep(
@@ -648,7 +647,6 @@ export class ReportingBondsView extends Component<
           [Styles.Scalar]: isScalar,
           [Styles.InitialReport]: initialReport,
           [Styles.MigrateRep]: migrateRep,
-          [Styles.MigrateMarket]: migrateMarket,
         })}
       >
         {isScalar && id === 'null' && (
@@ -951,9 +949,10 @@ export interface ParticipationTokensViewProps {
   openModal: Function;
   disputeWindowFees: FormattedNumber;
   purchasedParticipationTokens: FormattedNumber;
-  participationTokens: object;
   tokensOwned: FormattedNumber;
   percentageOfTotalFees: FormattedNumber;
+  participationTokensClaimable: FormattedNumber,
+  participationTokensClaimableFees: FormattedNumber,
 }
 
 export const ParticipationTokensView = (
@@ -965,6 +964,8 @@ export const ParticipationTokensView = (
     purchasedParticipationTokens,
     tokensOwned,
     percentageOfTotalFees,
+    participationTokensClaimable,
+    participationTokensClaimableFees,
   } = props;
 
   return (
@@ -1010,12 +1011,12 @@ export const ParticipationTokensView = (
       <Subheaders
         info
         header="Participation Tokens Purchased"
-        subheader="0.0000"
+        subheader={participationTokensClaimable.formatted}
       />
       <Subheaders
         info
         header="My Portion of Reporting Fees"
-        subheader="0.0000"
+        subheader={participationTokensClaimableFees.formatted}
         secondSubheader="DAI"
       />
 

--- a/packages/augur-ui/src/modules/reporting/components/markets-in-dispute.tsx
+++ b/packages/augur-ui/src/modules/reporting/components/markets-in-dispute.tsx
@@ -22,17 +22,25 @@ const TAB_CURRENT = 'current';
 const TAB_AWAITING = 'awaiting';
 const SORT_REP_STAKED = 'totalRepStakedInMarket';
 const SORT_DISPUTE_ROUND = 'disputeRound';
+const defaultTabs = {
+  [TAB_CURRENT]: [],
+  [TAB_AWAITING]: [],
+};
 const DEFAULT_PAGINATION = {
   limit: ITEMS_PER_SECTION,
   offset: DEFAULT_PAGE,
   isLoadingMarkets: true,
-  filteredData: [],
+  filteredData: defaultTabs,
 };
 
 interface DisputingMarkets {
   [reportingState: string]: MarketData[];
 }
 
+interface FilteredData {
+  [TAB_CURRENT]: MarketData[];
+  [TAB_AWAITING]: MarketData[];
+}
 interface MarketsInDisputeProps {
   isConnected: boolean;
   userAddress: string;
@@ -45,10 +53,7 @@ interface MarketsInDisputeState {
   search: string;
   selectedTab: string;
   tabs: Tab[];
-  filteredData: {
-    [TAB_CURRENT]: MarketData[];
-    [TAB_AWAITING]: MarketData[];
-  };
+  filteredData: FilteredData;
   sortBy: string;
   offset: number;
   limit: number;
@@ -69,10 +74,6 @@ const sortByOptions = [
   },
 ];
 
-const defaultTabs = {
-  [TAB_CURRENT]: [],
-  [TAB_AWAITING]: []
- };
 export default class MarketsInDispute extends Component<
   MarketsInDisputeProps,
   MarketsInDisputeState
@@ -130,6 +131,10 @@ export default class MarketsInDispute extends Component<
     if (markets !== prevProps.markets) {
       this.getFilteredDataMarkets(markets);
     }
+  }
+
+  componentWillUnmount() {
+    console.log("component has unmounted");
   }
 
   componentDidMount() {
@@ -207,7 +212,11 @@ export default class MarketsInDispute extends Component<
   };
 
   setOffset = offset => {
-    this.setState({ offset, isLoadingMarkets: true, filteredData: defaultTabs });
+    this.setState({
+      offset,
+      isLoadingMarkets: true,
+      filteredData: defaultTabs,
+    });
   };
 
   selectTab = (selectedTab: string) => {
@@ -234,8 +243,8 @@ export default class MarketsInDispute extends Component<
   getFilteredDataMarkets = (markets: DisputingMarkets) => {
     const filteredData = {
       [TAB_CURRENT]: markets[REPORTING_STATE.CROWDSOURCING_DISPUTE],
-      [TAB_AWAITING]: markets[REPORTING_STATE.AWAITING_NEXT_WINDOW]
-    }
+      [TAB_AWAITING]: markets[REPORTING_STATE.AWAITING_NEXT_WINDOW],
+    };
     this.setState({ filteredData });
   };
 

--- a/packages/augur-ui/src/modules/reporting/components/markets-in-dispute.tsx
+++ b/packages/augur-ui/src/modules/reporting/components/markets-in-dispute.tsx
@@ -45,7 +45,10 @@ interface MarketsInDisputeState {
   search: string;
   selectedTab: string;
   tabs: Tab[];
-  filteredData: MarketData[];
+  filteredData: {
+    [TAB_CURRENT]: MarketData[];
+    [TAB_AWAITING]: MarketData[];
+  };
   sortBy: string;
   offset: number;
   limit: number;
@@ -66,6 +69,10 @@ const sortByOptions = [
   },
 ];
 
+const defaultTabs = {
+  [TAB_CURRENT]: [],
+  [TAB_AWAITING]: []
+ };
 export default class MarketsInDispute extends Component<
   MarketsInDisputeProps,
   MarketsInDisputeState
@@ -88,7 +95,7 @@ export default class MarketsInDispute extends Component<
           num: 0,
         },
       ],
-      filteredData: [],
+      filteredData: defaultTabs,
       isLoadingMarkets: true,
       marketCount: 0,
       showPagination: false,
@@ -134,7 +141,12 @@ export default class MarketsInDispute extends Component<
     const { tabs } = this.state;
     const filterOptions = this.getLoadMarketsFiltersOptions();
     this.getLoadMarketsMethods().map(loader =>
-      this.loadDisputeTypeMarkets(loader.method, filterOptions, tabs, loader.tabName)
+      this.loadDisputeTypeMarkets(
+        loader.method,
+        filterOptions,
+        tabs,
+        loader.tabName
+      )
     );
   };
 
@@ -174,13 +186,7 @@ export default class MarketsInDispute extends Component<
 
   getLoadMarketsFiltersOptions = () => {
     const { userAddress } = this.props;
-    const {
-      limit,
-      offset,
-      filterByMyPortfolio,
-      sortBy,
-      search,
-    } = this.state;
+    const { limit, offset, filterByMyPortfolio, sortBy, search } = this.state;
 
     let filterOptions = {
       limit,
@@ -201,7 +207,7 @@ export default class MarketsInDispute extends Component<
   };
 
   setOffset = offset => {
-    this.setState({ offset, isLoadingMarkets: true, filteredData: [] });
+    this.setState({ offset, isLoadingMarkets: true, filteredData: defaultTabs });
   };
 
   selectTab = (selectedTab: string) => {
@@ -226,10 +232,10 @@ export default class MarketsInDispute extends Component<
   };
 
   getFilteredDataMarkets = (markets: DisputingMarkets) => {
-    const { selectedTab } = this.state;
-    let filteredData = markets[REPORTING_STATE.CROWDSOURCING_DISPUTE];
-    if (selectedTab === TAB_AWAITING)
-      filteredData = markets[REPORTING_STATE.AWAITING_NEXT_WINDOW];
+    const filteredData = {
+      [TAB_CURRENT]: markets[REPORTING_STATE.CROWDSOURCING_DISPUTE],
+      [TAB_AWAITING]: markets[REPORTING_STATE.AWAITING_NEXT_WINDOW]
+    }
     this.setState({ filteredData });
   };
 
@@ -287,7 +293,7 @@ export default class MarketsInDispute extends Component<
         }
         content={
           <div className={Styles.MarketCards}>
-            {!isLoadingMarkets && filteredData.length === 0 && (
+            {!isLoadingMarkets && filteredData[selectedTab].length === 0 && (
               <EmptyDisplay
                 selectedTab={label}
                 filterLabel={''}
@@ -295,14 +301,14 @@ export default class MarketsInDispute extends Component<
               />
             )}
             {isLoadingMarkets &&
-              filteredData.length === 0 &&
+              filteredData[selectedTab].length === 0 &&
               new Array(NUM_LOADING_CARDS)
                 .fill(null)
                 .map((prop, index) => (
                   <LoadingMarketCard key={`${index}-loading`} />
                 ))}
-            {filteredData.length > 0 &&
-              filteredData.map(market => (
+            {filteredData[selectedTab].length > 0 &&
+              filteredData[selectedTab].map(market => (
                 <MarketCard key={market.id} market={market} />
               ))}
             {showPagination && (

--- a/packages/augur-ui/src/modules/reporting/components/markets-in-dispute.tsx
+++ b/packages/augur-ui/src/modules/reporting/components/markets-in-dispute.tsx
@@ -134,7 +134,7 @@ export default class MarketsInDispute extends Component<
   }
 
   componentWillUnmount() {
-    console.log("component has unmounted");
+    console.log('component has unmounted');
   }
 
   componentDidMount() {

--- a/packages/augur-ui/src/modules/reporting/containers/participation-tokens-view.ts
+++ b/packages/augur-ui/src/modules/reporting/containers/participation-tokens-view.ts
@@ -9,7 +9,7 @@ import { AppState } from 'store';
 const mapStateToProps = (state: AppState) => {
   const {address, fees, purchased} = state.universe && state.universe.disputeWindow;
   const {participationTokens} = state.loginAccount && state.loginAccount.reporting;
-  const tokenAmount = address && participationTokens && participationTokens.totalClaimable || ZERO;
+  const tokenAmount = address && participationTokens && (participationTokens.contracts.find(c => !c.isClaimable) || {}).amount || ZERO;
   const purchasedTokens = purchased || 0;
   const purchasedParticipationTokens = formatAttoRep(purchasedTokens);
   const ONE_HUNDRED_BECAUSE_PERCENTAGES = 100;

--- a/packages/augur-ui/src/modules/reporting/containers/participation-tokens-view.ts
+++ b/packages/augur-ui/src/modules/reporting/containers/participation-tokens-view.ts
@@ -1,24 +1,29 @@
 import { connect } from 'react-redux';
 import { ParticipationTokensView } from 'modules/reporting/common';
 import { updateModal } from "modules/modal/actions/update-modal";
-import { MODAL_PARTICIPATE } from 'modules/common/constants';
+import { MODAL_PARTICIPATE, ZERO } from 'modules/common/constants';
 import { formatAttoDai, formatAttoRep, formatPercent } from "utils/format-number";
 import { createBigNumber } from 'utils/create-big-number';
+import { AppState } from 'store';
 
-const mapStateToProps = state => {
+const mapStateToProps = (state: AppState) => {
   const {address, fees, purchased} = state.universe && state.universe.disputeWindow;
   const {participationTokens} = state.loginAccount && state.loginAccount.reporting;
-  const tokenAmount = address && participationTokens ? (participationTokens.contracts.find(contract => contract.address === address) || {}).amount || 0 : 0;
+  const tokenAmount = address && participationTokens.totalClaimable || ZERO;
   const purchasedTokens = purchased || 0;
   const purchasedParticipationTokens = formatAttoRep(purchasedTokens);
   const ONE_HUNDRED_BECAUSE_PERCENTAGES = 100;
   const percentageOfTotalFees = formatPercent(purchasedParticipationTokens.value ? createBigNumber(tokenAmount).dividedBy(createBigNumber(purchasedTokens)).times(ONE_HUNDRED_BECAUSE_PERCENTAGES) : 0);
+  const participationTokensClaimable = participationTokens && participationTokens.totalClaimable || ZERO;
+  const participationTokensClaimableFees = participationTokens && participationTokens.totalFees || ZERO;
+
   return {
     disputeWindowFees: formatAttoDai(fees || 0),
     purchasedParticipationTokens,
     tokensOwned: formatAttoRep(tokenAmount),
-    participationTokens,
     percentageOfTotalFees,
+    participationTokensClaimable: formatAttoRep(participationTokensClaimable),
+    participationTokensClaimableFees: formatAttoDai(participationTokensClaimableFees),
   };
 };
 

--- a/packages/augur-ui/src/modules/reporting/containers/participation-tokens-view.ts
+++ b/packages/augur-ui/src/modules/reporting/containers/participation-tokens-view.ts
@@ -9,7 +9,7 @@ import { AppState } from 'store';
 const mapStateToProps = (state: AppState) => {
   const {address, fees, purchased} = state.universe && state.universe.disputeWindow;
   const {participationTokens} = state.loginAccount && state.loginAccount.reporting;
-  const tokenAmount = address && participationTokens.totalClaimable || ZERO;
+  const tokenAmount = address && participationTokens && participationTokens.totalClaimable || ZERO;
   const purchasedTokens = purchased || 0;
   const purchasedParticipationTokens = formatAttoRep(purchasedTokens);
   const ONE_HUNDRED_BECAUSE_PERCENTAGES = 100;

--- a/packages/augur-ui/src/modules/reporting/containers/participation-tokens-view.ts
+++ b/packages/augur-ui/src/modules/reporting/containers/participation-tokens-view.ts
@@ -1,21 +1,39 @@
 import { connect } from 'react-redux';
 import { ParticipationTokensView } from 'modules/reporting/common';
-import { updateModal } from "modules/modal/actions/update-modal";
+import { updateModal } from 'modules/modal/actions/update-modal';
 import { MODAL_PARTICIPATE, ZERO } from 'modules/common/constants';
-import { formatAttoDai, formatAttoRep, formatPercent } from "utils/format-number";
+import {
+  formatAttoDai,
+  formatAttoRep,
+  formatPercent,
+} from 'utils/format-number';
 import { createBigNumber } from 'utils/create-big-number';
 import { AppState } from 'store';
 
 const mapStateToProps = (state: AppState) => {
-  const {address, fees, purchased} = state.universe && state.universe.disputeWindow;
-  const {participationTokens} = state.loginAccount && state.loginAccount.reporting;
-  const tokenAmount = address && participationTokens && (participationTokens.contracts.find(c => !c.isClaimable) || {}).amount || ZERO;
+  const { address, fees, purchased } =
+    state.universe && state.universe.disputeWindow;
+  const { participationTokens } =
+    state.loginAccount && state.loginAccount.reporting;
+  const tokenAmount =
+    (address &&
+      participationTokens &&
+      (participationTokens.contracts.find(c => !c.isClaimable) || {}).amount) ||
+    ZERO;
   const purchasedTokens = purchased || 0;
   const purchasedParticipationTokens = formatAttoRep(purchasedTokens);
   const ONE_HUNDRED_BECAUSE_PERCENTAGES = 100;
-  const percentageOfTotalFees = formatPercent(purchasedParticipationTokens.value ? createBigNumber(tokenAmount).dividedBy(createBigNumber(purchasedTokens)).times(ONE_HUNDRED_BECAUSE_PERCENTAGES) : 0);
-  const participationTokensClaimable = participationTokens && participationTokens.totalClaimable || ZERO;
-  const participationTokensClaimableFees = participationTokens && participationTokens.totalFees || ZERO;
+  const percentageOfTotalFees = formatPercent(
+    purchasedParticipationTokens.value
+      ? createBigNumber(tokenAmount)
+          .dividedBy(createBigNumber(purchasedTokens))
+          .times(ONE_HUNDRED_BECAUSE_PERCENTAGES)
+      : 0
+  );
+  const participationTokensClaimable =
+    (participationTokens && participationTokens.totalClaimable) || ZERO;
+  const participationTokensClaimableFees =
+    (participationTokens && participationTokens.totalFees) || ZERO;
 
   return {
     disputeWindowFees: formatAttoDai(fees || 0),
@@ -23,7 +41,9 @@ const mapStateToProps = (state: AppState) => {
     tokensOwned: formatAttoRep(tokenAmount),
     percentageOfTotalFees,
     participationTokensClaimable: formatAttoRep(participationTokensClaimable),
-    participationTokensClaimableFees: formatAttoDai(participationTokensClaimableFees),
+    participationTokensClaimableFees: formatAttoDai(
+      participationTokensClaimableFees
+    ),
   };
 };
 

--- a/packages/augur-ui/src/modules/reporting/containers/releasable-rep-notice.ts
+++ b/packages/augur-ui/src/modules/reporting/containers/releasable-rep-notice.ts
@@ -18,16 +18,18 @@ const mapStateToProps = (state: AppState) => {
     if (reporting) {
       if (
         (reporting.reporting &&
-          createBigNumber(reporting.reporting.totalAmount).gt(ZERO)) ||
+          createBigNumber(reporting.reporting.totalStaked).gt(ZERO)) ||
         (reporting.disputing &&
-          createBigNumber(reporting.disputing.totalAmount).gt(ZERO)) ||
+          createBigNumber(reporting.disputing.totalStaked).gt(ZERO)) ||
         (reporting.participationTokens &&
-          createBigNumber(reporting.participationTokens.totalAmount).gt(ZERO))
+          createBigNumber(reporting.participationTokens.totalStaked).gt(ZERO))
       )
         hasStakedRep = true;
     }
   }
   if (hasForked  && hasStakedRep) show = true;
+
+  if (!show) return null;
 
   return {
     show,

--- a/packages/augur-ui/src/modules/reporting/containers/reporting-bonds-view.ts
+++ b/packages/augur-ui/src/modules/reporting/containers/reporting-bonds-view.ts
@@ -17,7 +17,7 @@ const mapStateToProps = (state: AppState, ownProps) => {
     hasForked && !!universe.forkingInfo.winningChildUniverseId;
   const initialReport = !migrateMarket && !migrateRep;
   const openReporting = market.reportingState === REPORTING_STATE.OPEN_REPORTING;
-  const owesRep = !openReporting && !isSameAddress(market.designatedReporter, loginAccount.address);
+  const owesRep = migrateMarket || (!openReporting && !isSameAddress(market.designatedReporter, loginAccount.address));
 
   return {
     owesRep,

--- a/packages/augur-ui/src/store/select-state.ts
+++ b/packages/augur-ui/src/store/select-state.ts
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import { LoginAccount, MarketInfos, MarketsList, AccountBalances, ReportingList } from 'modules/types';
+import { LoginAccount, MarketInfos, MarketsList, AccountBalances, ReportingListState } from 'modules/types';
 import { AppState } from 'store';
 import { Getters } from '@augurproject/sdk/build';
 
@@ -16,7 +16,7 @@ export const selectLoginAccountReportingState = (
 ): Getters.Accounts.AccountReportingHistory => state.loginAccount.reporting;
 export const selectReportingListState = (
   state: AppState
-): ReportingList => state.reportingListState;
+): ReportingListState => state.reportingListState;
 export const selectLoginAccountBalancesState = (
   state: AppState
 ): AccountBalances => state.loginAccount.balances;


### PR DESCRIPTION
changed participation tokens to use new structure from getter. 


so these values show
![image](https://user-images.githubusercontent.com/3970376/66259287-c80c9080-e774-11e9-99b8-c7c126c6dd48.png)


using isClaimable it auto filters out current dispute window and markets not resolved.
![image](https://user-images.githubusercontent.com/3970376/66259385-03f42580-e776-11e9-8cf3-f0e95f7f810a.png)
