### PR TITLE
margin change and remove background color for bottom bar

### DIFF
--- a/packages/augur-ui/src/modules/market-cards/common.styles.less
+++ b/packages/augur-ui/src/modules/market-cards/common.styles.less
@@ -278,7 +278,7 @@
 
   @media @breakpoint-max-tablet {
     grid-column: 1 / span 2;
-    margin-right: -@size-14;
+    margin: -@size-14 0;
   }
 
   @media @breakpoint-mobile-mid {

--- a/packages/augur-ui/src/modules/market-cards/market-card.styles.less
+++ b/packages/augur-ui/src/modules/market-cards/market-card.styles.less
@@ -229,7 +229,6 @@
 			justify-content: space-between;
 			margin: @size-42 -@size-12 -@size-12 -@size-12;
 			padding: @size-12;
-			background-color: @color-dark-grey;
 
 			> div:nth-of-type(2) {
 				display: none;


### PR DESCRIPTION
small tweaks to market card style. seems we are caught between the mocks being updated and market cards spacing looking a bit different on desktop and mobile. 

desktop, outcomes go to the edges
![image](https://user-images.githubusercontent.com/3970376/66358102-0fdb1580-e937-11e9-8941-f89752085c15.png)

mobile, outcomes have a gap to the edge to line up with bottom bar stats.
![image](https://user-images.githubusercontent.com/3970376/66358113-1c5f6e00-e937-11e9-97aa-27664997684a.png)
