### PR TITLE
Fix FB comments section width

### DIFF
--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.styles.less
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.styles.less
@@ -83,7 +83,7 @@
     flex: unset;
     margin: 0 0 @size-4;
     min-height: fit-content;
-  
+
     @media @breakpoint-mobile {
       padding: 0;
     }
@@ -196,7 +196,7 @@
 
 .MarketView__priceHistoryChart {
   background-color: @color-module-background;
-  border: 1px solid @color-dark-grey;  
+  border: 1px solid @color-dark-grey;
   border-radius: 1px;
   margin-top: @size-16;
 
@@ -216,6 +216,14 @@
   flex-grow: 1;
   justify-content: center;
   margin: 0 22.5625rem;
+
+  > div {
+    > span {
+      > frame {
+        width: 100%;
+      }
+    }
+  }
 }
 
 .Hide {
@@ -332,7 +340,7 @@ div.OutcomeNameDisplay {
 
   .MarketView__comments {
     justify-content: center;
-    margin: 0rem;
+    margin: 0;
     width: 100%;
   }
 }


### PR DESCRIPTION
The FB comments section at the bottom of the market page sometimes loads with a very short width. This makes it a consistent width.