### PR TITLE
design review updates

### DIFF
--- a/packages/augur-ui/src/modules/app/components/app.tsx
+++ b/packages/augur-ui/src/modules/app/components/app.tsx
@@ -120,7 +120,13 @@ export default class AppView extends Component<AppProps> {
       updateModal,
       useWeb3Transport,
       updateCurrentBasePath,
+      updateConnectionTray
     } = this.props;
+
+    window.addEventListener('click', (e) => {
+      updateConnectionTray(false);
+    });
+
     initAugur(
       history,
       {

--- a/packages/augur-ui/src/modules/auth/components/connect-account/connect-account.tsx
+++ b/packages/augur-ui/src/modules/auth/components/connect-account/connect-account.tsx
@@ -52,6 +52,7 @@ export default class ConnectAccount extends Component<ConnectAccountProps> {
 
     return (
       <div
+        onClick={(event) => event.stopPropagation()}
         className={classNames(Styles.ConnectAccount, {
           [Styles.selected]: isConnectionTrayOpen,
         })}

--- a/packages/augur-ui/src/modules/auth/components/connect-dropdown/connect-dropdown.tsx
+++ b/packages/augur-ui/src/modules/auth/components/connect-dropdown/connect-dropdown.tsx
@@ -107,7 +107,7 @@ const ConnectDropdown = (props: ConnectDropdownProps) => {
   ];
 
   return (
-    <div>
+    <div onClick={(event) => event.stopPropagation()}>
       {showMetaMaskHelper && <ModalMetaMaskFinder handleClick={() => setShowMetaMaskHelper(false)} />}
       <div className={Styles.AccountInfo}>
         <div className={Styles.AddFunds}>

--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -116,49 +116,6 @@ export const ERROR_TYPES = {
   },
 };
 
-const DEFAULT_ITEM_INDEX = 0;
-export const ITEMS = [
-  {
-    param: ACCOUNT_TYPES.PORTIS,
-    title: 'Portis',
-    icon: Portis,
-    type: WALLET_TYPE.SOFTWARE,
-  },
-  {
-    param: ACCOUNT_TYPES.FORTMATIC,
-    title: 'Fortmatic',
-    icon: Fortmatic,
-    type: WALLET_TYPE.SOFTWARE,
-  },
-  {
-    param: ACCOUNT_TYPES.METAMASK,
-    title: 'Metamask / Web 3 Provider',
-    icon: MetaMask,
-    type: WALLET_TYPE.SOFTWARE,
-  },
-  {
-    param: ACCOUNT_TYPES.TREZOR,
-    title: 'Trezor',
-    icon: Trezor,
-    type: WALLET_TYPE.HARDWARE,
-  },
-  {
-    param: ACCOUNT_TYPES.LEDGER,
-    title: 'Ledger',
-    icon: Ledger,
-    type: WALLET_TYPE.HARDWARE,
-  },
-];
-if (!process.env.AUGUR_HOSTED) {
-  ITEMS.unshift({
-    param: ACCOUNT_TYPES.EDGE,
-    title: 'Edge',
-    icon: Edge,
-    type: WALLET_TYPE.SOFTWARE,
-  });
-}
-ITEMS[DEFAULT_ITEM_INDEX].default = true;
-
 // sidebar related constants
 export const MOBILE_MENU_STATES = {
   CLOSED: 0,

--- a/packages/augur-ui/src/modules/market/components/trading-form/trading-form.styles.less
+++ b/packages/augur-ui/src/modules/market/components/trading-form/trading-form.styles.less
@@ -10,7 +10,7 @@
 
   > div {
     .text-24;
-    
+
     align-items: center;
     background: fade(@color-dark-grey, 80%);
     bottom: 0;
@@ -27,6 +27,12 @@
 
     > p {
       line-height: @size-24;
+    }
+
+    > div {
+      > button:last-of-type {
+        margin-left: @size-12;
+      }
     }
   }
 }

--- a/packages/augur-ui/src/modules/market/components/trading-form/trading-form.tsx
+++ b/packages/augur-ui/src/modules/market/components/trading-form/trading-form.tsx
@@ -36,6 +36,9 @@ interface TradingFormProps {
   updateLiquidity?: Function;
   initialLiquidity?: boolean;
   orderBook: OutcomeOrderBook;
+  addFundsModal: Function;
+  loginModal: Function;
+  signupModal: Function;
 }
 
 interface TradingFormState {
@@ -106,6 +109,9 @@ class TradingForm extends Component<TradingFormProps, TradingFormState> {
       updateLiquidity,
       initialLiquidity,
       orderBook,
+      addFundsModal,
+      loginModal,
+      signupModal,
     } = this.props;
     const s = this.state;
 
@@ -115,7 +121,7 @@ class TradingForm extends Component<TradingFormProps, TradingFormState> {
 
     switch (true) {
       case !isLogged:
-        initialMessage = 'Connect a wallet to place an order.';
+        initialMessage = 'Login or Signup to place an order.';
         break;
       case isLogged && !hasFunds:
         initialMessage = 'Add funds to begin trading.';
@@ -158,20 +164,25 @@ class TradingForm extends Component<TradingFormProps, TradingFormState> {
           <div>
             {initialMessage && <p>{initialMessage}</p>}
             {!isLogged && (
-              <PrimaryButton
-                id='login-button'
-                action={() => toggleConnectionTray(!isConnectionTrayOpen)}
-                text='Connect a Wallet'
-              />
+              <div>
+                <PrimaryButton
+                  id='login-button'
+                  action={() => loginModal()}
+                  text='Login'
+                />
+                <PrimaryButton
+                  id='login-button'
+                  action={() => signupModal()}
+                  text='Signup'
+                />
+              </div>
             )}
             {!hasFunds && isLogged && (
-              <Link to={makePath(ACCOUNT_SUMMARY)}>
-                <PrimaryButton
-                  id='add-funds'
-                  action={() => {}}
-                  text='Add Funds'
-                />
-              </Link>
+              <PrimaryButton
+                id='add-funds'
+                action={() => addFundsModal()}
+                text='Add Funds'
+              />
             )}
           </div>
         )}

--- a/packages/augur-ui/src/modules/market/containers/trading-form.ts
+++ b/packages/augur-ui/src/modules/market/containers/trading-form.ts
@@ -8,6 +8,9 @@ import {
   MODAL_MARKET_REVIEW_TRADE,
   DISCLAIMER_SEEN,
   MODAL_DISCLAIMER,
+  MODAL_ADD_FUNDS,
+  MODAL_LOGIN,
+  MODAL_SIGNUP,
 } from 'modules/common/constants';
 import { updateModal } from 'modules/modal/actions/update-modal';
 import { getGasPrice } from 'modules/auth/selectors/get-gas-price';
@@ -83,6 +86,9 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         ...modal,
       })
     ),
+  addFundsModal: () => dispatch(updateModal({ type: MODAL_ADD_FUNDS })),
+  loginModal: () => dispatch(updateModal({ type: MODAL_LOGIN })),
+  signupModal: () => dispatch(updateModal({ type: MODAL_SIGNUP })),
   onSubmitPlaceTrade: (
     marketId,
     outcomeId,

--- a/packages/augur-ui/src/modules/markets-list/components/markets-header.styles.less
+++ b/packages/augur-ui/src/modules/markets-list/components/markets-header.styles.less
@@ -63,7 +63,6 @@
       .text-24-bold;
 
       color: @color-primary-text;
-      letter-spacing: 0.125rem;
       margin-bottom: 0;
       text-transform: capitalize;
 
@@ -75,6 +74,7 @@
 
     > article {
       max-width: @search-bar-width;
+      min-width: @search-bar-width;
 
       @media @breakpoint-mobile {
         display: none;

--- a/packages/augur-ui/src/modules/modal/add-funds.tsx
+++ b/packages/augur-ui/src/modules/modal/add-funds.tsx
@@ -1,31 +1,69 @@
 import React, { useState } from 'react';
-
 import {
   ExternalLinkButton,
   PrimaryButton,
   CloseButton,
   BackButton,
 } from 'modules/common/buttons';
-import { AccountAddressDisplay, FundsHelp } from 'modules/modal/common';
-
-import Styles from 'modules/modal/modal.styles.less';
+import {
+  AccountAddressDisplay,
+  FundsHelp,
+  DaiEthSelector,
+} from 'modules/modal/common';
 import { RadioTwoLineBarGroup, TextInput } from 'modules/common/form';
 import classNames from 'classnames';
+import ReactTooltip from 'react-tooltip';
+
 import { ACCOUNT_TYPES } from 'modules/common/constants';
 import { LoginAccount } from 'modules/types';
+
+import TooltipStyles from 'modules/common/tooltip.styles.less';
+import Styles from 'modules/modal/modal.styles.less';
+import { helpIcon } from 'modules/common/icons';
+import noop from 'utils/noop';
 
 interface AddFundsProps {
   closeAction: Function;
   address: string;
   accountMeta: LoginAccount['meta'];
+  isGnosis: boolean;
+  autoSelect?: boolean;
 }
+
+export const generateDaiTooltip = (
+  tipText = 'Augur requires deposits in DAI ($), a currency pegged 1 to 1 to the US Dollar.'
+) => {
+  return (
+    <span className={Styles.AddFundsToolTip}>
+      <label
+        className={classNames(TooltipStyles.TooltipHint)}
+        data-tip
+        data-for='tooltip--confirm'
+      >
+        {helpIcon}
+      </label>
+      <ReactTooltip
+        id='tooltip--confirm'
+        className={TooltipStyles.Tooltip}
+        effect='solid'
+        place='top'
+        type='light'
+      >
+        <p>{tipText}</p>
+      </ReactTooltip>
+    </span>
+  );
+};
 
 export const AddFunds = ({
   closeAction,
   accountMeta,
   address,
+  isGnosis = false,
+  autoSelect = false,
 }: AddFundsProps) => {
-  const [selectedOption, setSelectedOption] = useState(null);
+  const [selectedOption, setSelectedOption] = useState(autoSelect ? [ACCOUNT_TYPES.TORUS, ACCOUNT_TYPES.PORTIS].includes(accountMeta.accountType) ? '0' : '1' : null);
+  const [daiSelected, setDaiSelected] = useState(true);
 
   let addFundsOptions = [
     {
@@ -56,6 +94,8 @@ export const AddFunds = ({
     <div
       className={classNames(Styles.AddFunds, {
         [Styles.ShowSelected]: selectedOption,
+        [Styles.hideOnMobile]: autoSelect,
+        [Styles.hideOnDesktop]: !autoSelect,
       })}
     >
       <div>
@@ -86,20 +126,31 @@ export const AddFunds = ({
             <>
               <h1>Credit/debit card</h1>
               {accountMeta.accountType === ACCOUNT_TYPES.PORTIS && (
-                <h2>Add up to $250 worth of DAI/ETH instantly</h2>
+                <h2>
+                  Add up to $250 worth of DAI {generateDaiTooltip()} instantly
+                </h2>
               )}
               {accountMeta.accountType === ACCOUNT_TYPES.TORUS && (
-                <h2>Add DAI/ETH instantly</h2>
+                <h2>Add DAI {generateDaiTooltip()} instantly</h2>
               )}
 
-              {accountMeta.accountType === ACCOUNT_TYPES.PORTIS && (
-                <h3>Amount</h3>
+              {!isGnosis && <h3>Asset to buy</h3>}
+              {!isGnosis && (
+                <DaiEthSelector
+                  handleClick={isSelected => setDaiSelected(isSelected)}
+                  daiSelected={daiSelected}
+                />
               )}
+
+              <h3>Amount</h3>
+              <TextInput
+                placeholder='0'
+                onChange={noop}
+                innerLabel={daiSelected ? 'DAI' : 'ETH'}
+              />
+
               {accountMeta.accountType === ACCOUNT_TYPES.PORTIS && (
-                <TextInput placeholder="0" onChange={null} innerLabel="DAI" />
-              )}
-              {accountMeta.accountType === ACCOUNT_TYPES.PORTIS && (
-                <a href="https://wallet.portis.io/buy/" target="_blank">
+                <a href='https://wallet.portis.io/buy/' target='_blank'>
                   <PrimaryButton
                     action={() => null}
                     text={`Buy with ${accountMeta.accountType}`}
@@ -131,11 +182,14 @@ export const AddFunds = ({
           {selectedOption === '1' && (
             <>
               <h1>Coinbase</h1>
-              <h2>Add up to $25,000 worth of DAI using a Coinbase account</h2>
+              <h2>
+                Add up to $25,000 worth of DAI ($) {generateDaiTooltip()} using
+                a Coinbase account
+              </h2>
               <ol>
                 <li>
                   Login to your account at{' '}
-                  <a href="https://www.coinbase.com" target="blank">
+                  <a href='https://www.coinbase.com' target='blank'>
                     www.coinbase.com
                   </a>
                 </li>
@@ -153,12 +207,14 @@ export const AddFunds = ({
                 Send funds to your account address from any external service
               </h2>
               <ol>
-                <li>Buy DAI using any external service</li>
+                <li>
+                  Buy DAI {generateDaiTooltip()} using any external service
+                </li>
                 <li>Transfer the DAI to your account address</li>
               </ol>
               <h3>Your Account Address</h3>
               <AccountAddressDisplay copyable address={address} />
-              <ExternalLinkButton label="popular services for buying dai" />
+              <ExternalLinkButton label='popular services for buying dai' />
             </>
           )}
         </div>

--- a/packages/augur-ui/src/modules/modal/common.tsx
+++ b/packages/augur-ui/src/modules/modal/common.tsx
@@ -12,6 +12,9 @@ import {
   CheckCircleIcon,
   LargeDollarIcon,
   LargeDaiIcon,
+  DaiLogoIcon,
+  DaiLogoIcon,
+  EthIcon,
 } from 'modules/common/icons';
 import {
   DefaultButtonProps,
@@ -29,7 +32,7 @@ import {
 import Styles from 'modules/modal/modal.styles.less';
 import { PENDING, SUCCESS } from 'modules/common/constants';
 import { LinkContent } from 'modules/types';
-import formatAddress from 'modules/auth/helpers/format-address';
+import { generateDaiTooltip } from 'modules/modal/add-funds';
 
 export interface TitleProps {
   title: string;
@@ -360,6 +363,18 @@ export const DaiGraphic = () => (
   </div>
 );
 
+export interface DaiEthSelectorProps {
+  daiSelected: boolean;
+  handleClick: Function;
+}
+
+export const DaiEthSelector = ({ handleClick, daiSelected}: DaiEthSelectorProps) => (
+  <div className={Styles.DaiEthSelector}>
+    <div onClick={() => handleClick(true)} className={classNames({ [Styles.selected]: daiSelected })}>{DaiLogoIcon} DAI</div>
+    <div onClick={() => handleClick(false)} className={classNames({ [Styles.selected]: !daiSelected })}>{EthIcon} ETH</div>
+  </div>
+);
+
 export const TestBet = () => (
   <div className={Styles.TestBet}>
     <img src='assets/images/test-bet-placeholder.png' />
@@ -546,7 +561,7 @@ interface FundsHelpProps {}
 export const FundsHelp = (props: FundsHelpProps) => (
   <div className={Styles.FundsHelp}>
     <span>Need help?</span>
-    <span>Learn how to buy DAI and transfer it into your account.</span>
+    <span>Learn how to buy DAI {generateDaiTooltip()} and transfer it into your account.</span>
     <ExternalLinkButton label="Learn More" />
   </div>
 );

--- a/packages/augur-ui/src/modules/modal/common.tsx
+++ b/packages/augur-ui/src/modules/modal/common.tsx
@@ -33,6 +33,7 @@ import Styles from 'modules/modal/modal.styles.less';
 import { PENDING, SUCCESS } from 'modules/common/constants';
 import { LinkContent } from 'modules/types';
 import { generateDaiTooltip } from 'modules/modal/add-funds';
+import formatAddress from 'modules/auth/helpers/format-address';
 
 export interface TitleProps {
   title: string;

--- a/packages/augur-ui/src/modules/modal/components/modal-view.tsx
+++ b/packages/augur-ui/src/modules/modal/components/modal-view.tsx
@@ -37,9 +37,9 @@ import ModalMarketType from 'modules/modal/containers/modal-market-type';
 import ModalDrQuickGuide from 'modules/modal/containers/modal-dr-quick-guide';
 import ModalMigrateMarket from 'modules/modal/containers/modal-migrate-market';
 import ModalAddFunds from 'modules/modal/containers/modal-add-funds';
-import ModalSignin from "modules/modal/containers/modal-signin";
-import ModalConnect from "modules/modal/containers/modal-connect";
-import ModalLoading from "modules/modal/containers/modal-loading";
+import ModalSignin from 'modules/modal/containers/modal-signin';
+import ModalConnect from 'modules/modal/containers/modal-connect';
+import ModalLoading from 'modules/modal/containers/modal-loading';
 import ModalUniverseSelector from 'modules/modal/containers/modal-universe-selector';
 import ModalTestBet from 'modules/modal/containers/modal-test-bet';
 
@@ -72,7 +72,15 @@ function selectModal(type, props, closeModal, modal) {
     case TYPES.MODAL_CREATE_MARKET:
       return <ModalCreateMarket />;
     case TYPES.MODAL_ADD_FUNDS:
-      return <ModalAddFunds />;
+      return (
+        <>
+          {/* MOBILE */}
+          <ModalAddFunds />
+
+          {/* DESKTOP */}
+          <ModalAddFunds {...props} autoSelect />
+        </>
+      );
     case TYPES.MODAL_DAI_FAUCET:
       return <ModalDaiFaucet />;
     case TYPES.MODAL_CREATION_HELP:
@@ -127,17 +135,17 @@ function selectModal(type, props, closeModal, modal) {
     case TYPES.MODAL_MIGRATE_MARKET:
       return <ModalMigrateMarket {...modal} />;
     case TYPES.MODAL_LOGIN:
-      return <ModalSignin isLogin />;
+      return <ModalSignin {...props} isLogin />;
     case TYPES.MODAL_SIGNUP:
-      return <ModalSignin isLogin={false} />;
+      return <ModalSignin {...props} isLogin={false} />;
     case TYPES.MODAL_CONNECT:
       return <ModalConnect />;
     case TYPES.MODAL_LOADING:
-      return <ModalLoading />
+      return <ModalLoading />;
     case TYPES.MODAL_UNIVERSE_SELECTOR:
-      return <ModalUniverseSelector />
+      return <ModalUniverseSelector />;
     case TYPES.MODAL_TEST_BET:
-      return <ModalTestBet />
+      return <ModalTestBet />;
     default:
       return <div />;
   }

--- a/packages/augur-ui/src/modules/modal/containers/modal-add-funds.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-add-funds.ts
@@ -10,6 +10,7 @@ import getValue from 'utils/get-value';
 const mapStateToProps = (state: AppState) => ({
   modal: state.modal,
   address: getValue(state, 'loginAccount.address'),
+  isGnosis: getValue(state, 'loginAccount.isGnosis'),
   accountMeta: getValue(state, 'loginAccount.meta'),
 });
 

--- a/packages/augur-ui/src/modules/modal/containers/modal-buy-dai.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-buy-dai.ts
@@ -19,7 +19,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({
 });
 
 const mergeProps = (sP: any, dP: any, oP: any) => ({
-  largeHeader: 'Finally, buy DAI & start betting',
+  largeHeader: 'Buy DAI to start betting',
   smallHeader: 'DAI is the currency Augur uses',
   daiGraphic: true,
   mediumHeader: 'What is DAI?',

--- a/packages/augur-ui/src/modules/modal/modal.styles.less
+++ b/packages/augur-ui/src/modules/modal/modal.styles.less
@@ -143,9 +143,8 @@
   color: @color-secondary-text;
   line-height: 140%;
 
-  > a {
+  > div > a {
     color: @color-primary-action;
-    margin-left: @size-4;
   }
 }
 
@@ -240,6 +239,12 @@ div.ButtonsRow:last-of-type {
     color: @color-secondary-text;
     line-height: 140%;
     margin-bottom: @size-3;
+
+    > span {
+      width: @size-16;
+      height: @size-16;
+      margin: 0 @size-2;
+    }
   }
 
   @media @breakpoint-mobile-new {
@@ -255,6 +260,22 @@ div.ButtonsRow:last-of-type {
 }
 
 .AddFunds {
+
+
+  &.hideOnMobile {
+    @media @breakpoint-mobile-new {
+      display: none;
+    }
+  }
+
+  &.hideOnDesktop {
+    display: none;
+
+    @media @breakpoint-mobile-new {
+      display: flex;
+    }
+  }
+
   .Container;
 
   flex-direction: row;
@@ -451,6 +472,49 @@ div.ButtonsRow:last-of-type {
   }
 }
 
+.AddFundsToolTip {
+  > label {
+    display: inline;
+  }
+}
+
+.DaiEthSelector {
+  display: flex;
+
+  > div {
+    .text-16-bold;
+
+    align-items: center;
+    background: @color-secondary-action;
+    border: 2px solid @color-secondary-action-outline;
+    border-radius: @border-radius-rounded;
+    cursor: pointer;
+    color: @color-primary-text;
+    display: flex;
+    height: 54px;
+    justify-content: center;
+    padding: @size-16 @size-14;
+
+    &.selected {
+      border: 2px solid @color-primary-action;
+      }
+
+    > svg {
+      height: @size-32;
+      width: @size-32;
+      fill: @color-primary-text;
+    }
+  }
+
+  > div:last-of-type {
+    margin-left: @size-12;
+
+    > svg {
+      height: @size-24;
+    }
+  }
+}
+
 .CondensedContainer {
   .Container;
 
@@ -480,7 +544,7 @@ div.ButtonsRow:last-of-type {
   max-width: @login-signup-modal-width;
   padding: 48px 56px;
 
-  @media @breakpoint-mobile {
+  @media @breakpoint-mobile-new {
     padding: @size-24;
     flex: 1;
     max-width: unset;
@@ -496,7 +560,7 @@ div.ButtonsRow:last-of-type {
   top: 17px;
   width: @size-12;
 
-  @media @breakpoint-mobile {
+  @media @breakpoint-mobile-new {
     height: @size-16;
     width: @size-16;
   }
@@ -507,7 +571,7 @@ div.ButtonsRow:last-of-type {
 }
 
 .SignIn {
-  @media @breakpoint-mobile {
+  @media @breakpoint-mobile-new {
     padding-top: 57px;
   }
 
@@ -521,7 +585,7 @@ div.ButtonsRow:last-of-type {
     justify-content: space-between;
     margin-bottom: @size-32;
 
-    @media @breakpoint-mobile {
+    @media @breakpoint-mobile-new {
       align-items: end;
       flex-direction: column;
     }
@@ -531,7 +595,7 @@ div.ButtonsRow:last-of-type {
 
       color: @color-primary-text;
 
-      @media @breakpoint-mobile {
+      @media @breakpoint-mobile-new {
         margin-bottom: @size-4;
       }
     }


### PR DESCRIPTION
#### Updates to Add Funds
- Show tooltip for "DAI" throughout the Add Funds screens
<img src="https://user-images.githubusercontent.com/1683736/66512481-0cff3280-eaa7-11e9-935f-c23578ddac7b.png" width="222" />

- Show Asset Type selector for Portis/Torus
<img src="https://user-images.githubusercontent.com/1683736/66512532-2a340100-eaa7-11e9-812a-75b98d32c7b7.png" width="222" />

- On desktop PRESELECT the first Add Funds option.

#### Updates to Trading form
- Add Funds on Trading page form should now show the Add Funds modal
<img width="229" src="https://user-images.githubusercontent.com/1683736/66512419-e4773880-eaa6-11e9-8eb5-dbf35dc4244a.png">

- Show Login/Signup buttons on the Trading form when not logged in
<img src="https://user-images.githubusercontent.com/1683736/66512268-93ffdb00-eaa6-11e9-80e7-5b3869d95c09.png" width="222" />


#### Updates to Search
- Searching long names should break on two lines now
<img src="https://user-images.githubusercontent.com/1683736/66512383-ca3d5a80-eaa6-11e9-940a-e95fa05a258e.png" width="722" />

#### Misc
- Close Account/Connection Menu when the user clicks outside of it