### PR TITLE
fix disputing markets counts, added check for calling update child un…

### DIFF
--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -533,6 +533,7 @@ export const handleTokensMintedLog = (
   log: Logs.TokensMinted
 ) => (dispatch: ThunkDispatch<void, any, Action>, getState: () => AppState) => {
   const userAddress = getState().loginAccount.address;
+  const isForking = getState().universe.forkingInfo !== null;
   if(log.tokenType === Logs.TokenType.ParticipationToken) {
     const isUserDataUpdate = isSameAddress(
       log.target,
@@ -543,7 +544,7 @@ export const handleTokensMintedLog = (
     }
     dispatch(loadDisputeWindow());
   }
-  if (log.tokenType === Logs.TokenType.ReputationToken) {
+  if (log.tokenType === Logs.TokenType.ReputationToken && isForking) {
     const isUserDataUpdate = isSameAddress(
       log.target,
       userAddress

--- a/packages/augur-ui/src/modules/reporting/containers/markets-in-dispute.ts
+++ b/packages/augur-ui/src/modules/reporting/containers/markets-in-dispute.ts
@@ -7,8 +7,10 @@ import {
   loadNextWindowDisputingMarkets,
 } from 'modules/markets/actions/load-markets';
 import { disputingMarkets } from 'modules/markets/selectors/select-reporting-markets';
+import { AppState } from 'store';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state: AppState) => ({
+  disputingMarketsMeta: state.reportingListState,
   isConnected: state.connection.isConnected,
   userAddress: state.loginAccount.mixedCaseAddress,
   markets: disputingMarkets(state),


### PR DESCRIPTION
…iverse data when forking only when rep is minted.

updated disputing markets counts correctly when market dispute bond is filled and when disputing window is created. 

also fixes issue when nav off disputing page and getting react error that component was unmounted but then updated state.