### PR TITLE
fix getPlatformActivityStats test

### DIFF
--- a/packages/augur-test/src/tests/state/getter/Platform.test.ts
+++ b/packages/augur-test/src/tests/state/getter/Platform.test.ts
@@ -82,7 +82,7 @@ describe('State API :: get-platform-activity-stats :: ', () => {
     });
     expect(stats.amountStaked.toString()).toEqual('4650537188053131103515648');
     expect(stats.openInterest.toString()).toEqual('2040000000000000');
-    expect(stats.volume.toString()).toEqual('6093000000000000');
+    expect(stats.volume.toString()).toEqual('0.006093');
   }, 200000);
 });
 


### PR DESCRIPTION
If this passes CI's test phase in a typical amount of time(40-50 minutes) then we know this was the culprit for the tests taking forever. This doesn't solve the issue where failing tests can hang forever but it will unblock CI.