### PR TITLE
changes comment count check in mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,6 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
-      - "#commented-reviews-by=0"
       - status-success=AugurProject.augur
       - base=master
       - label!=work-in-progress


### PR DESCRIPTION
In the past mergify was ignoring bot comments, but a recent commit on
their end changed this. sneakpeek always leaves a comment so PRs were
not getting auto merged.