### PR TITLE
account-menu-keep-open

### DIFF
--- a/packages/augur-ui/src/modules/modal/add-funds.tsx
+++ b/packages/augur-ui/src/modules/modal/add-funds.tsx
@@ -92,6 +92,7 @@ export const AddFunds = ({
 
   return (
     <div
+      onClick={event => event.stopPropagation()}
       className={classNames(Styles.AddFunds, {
         [Styles.ShowSelected]: selectedOption,
         [Styles.hideOnMobile]: autoSelect,

--- a/packages/augur-ui/src/modules/modal/gas.tsx
+++ b/packages/augur-ui/src/modules/modal/gas.tsx
@@ -73,7 +73,7 @@ export class Gas extends React.Component<GasProps, GasState> {
     ];
 
     return (
-      <div className={Styles.Gas}>
+      <div onClick={event => event.stopPropagation()} className={Styles.Gas}>
         <Title title="Gas Price (gwei)" closeAction={closeAction} />
         <main>
           {showLowAlert && (


### PR DESCRIPTION
If the Account Details menu is open, don't close it if the user interacts with either the Gas or Add Funds modal.

