### PR TITLE
Fix last price log order

### DIFF
--- a/packages/augur-sdk/src/state/getter/Markets.ts
+++ b/packages/augur-sdk/src/state/getter/Markets.ts
@@ -1017,7 +1017,14 @@ async function getMarketsInfo(
   const orderFilledLogsByMarket = _.groupBy(orderFilledLogs, "market");
 
   return _.map(markets, (marketData) => {
-    const orderFilledLogs = orderFilledLogsByMarket[marketData.market] || [];
+    const orderFilledLogs = (orderFilledLogsByMarket[marketData.market] || []).sort((a, b) => {
+      // Same block, need to sort by logIndex.
+      if(a.blockNumber === b.blockNumber) {
+        return b.logIndex - a.logIndex;
+      }
+
+      return b.blockNumber - a.blockNumber;
+    });
 
     const minPrice = new BigNumber(marketData.prices[0]);
     const maxPrice = new BigNumber(marketData.prices[1]);


### PR DESCRIPTION
fixes <https://github.com/AugurProject/augur/issues/4419>

needed to sort filled logs for market and outcome