### PR TITLE
Adjusted chart sizing/xy margins

### DIFF
--- a/packages/augur-ui/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.styles.less
+++ b/packages/augur-ui/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.styles.less
@@ -7,7 +7,7 @@
   flex-direction: column;
   max-height: @charts-max-height;
   min-height: @charts-min-height;
-  padding: @size-8;
+  padding: @size-8 0 0;
   position: relative;
 
   @media @breakpoint-mobile {
@@ -21,6 +21,7 @@
   grid-template-columns: minmax(92px, 130px) 1fr minmax(130px, 155px);
   grid-template-rows: 1fr;
   margin-bottom: @size-8;
+  padding: 0 @size-8;
 
   @media @breakpoint-mobile {
     grid-gap: @size-8;
@@ -65,6 +66,9 @@
   & > div {
     display: flex;
     flex: 1 100%;
+    max-height: @charts-max-height;
+    height: @charts-min-height;
+    min-height: @charts-min-height;
   }
 }
 

--- a/packages/augur-ui/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts-candlestick-highchart.tsx
+++ b/packages/augur-ui/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts-candlestick-highchart.tsx
@@ -8,13 +8,6 @@ import { PriceTimeSeriesData } from 'modules/types';
 
 NoDataToDisplay(Highcharts);
 
-const HIGH_CHART_CONFIG = {
-  ShowNavigator: 350,
-  YLableXposition: -15,
-  YLableYposition: -8,
-  MobileMargin: [30, 0, 0, 0],
-};
-
 interface HighChartsWrapperProps {
   priceTimeSeries: PriceTimeSeriesData[];
   selectedPeriod: number;
@@ -108,7 +101,6 @@ export default class MarketOutcomeChartsCandlestickHighchart extends Component<
 
     const { range, format, crosshair } = PERIOD_RANGES[selectedPeriod];
 
-    const max = marketMax.toNumber();
     const options = {
       lang: {
         noData: 'No Completed Trades',
@@ -116,7 +108,7 @@ export default class MarketOutcomeChartsCandlestickHighchart extends Component<
       credits: { enabled: false },
       tooltip: { enabled: false },
       scrollbar: { enabled: false },
-      navigator: { enabled: true, height: 20, margin: 12 },
+      navigator: { enabled: false },
       rangeSelector: { enabled: false },
       plotOptions: {
         candlestick: {
@@ -137,7 +129,7 @@ export default class MarketOutcomeChartsCandlestickHighchart extends Component<
         panning: isMobile,
         styledMode: false,
         animation: false,
-        spacing: [15, 0, 0, 0],
+        spacing: [10, 0, 4, 0],
       },
       xAxis: {
         ordinal: false,
@@ -145,7 +137,6 @@ export default class MarketOutcomeChartsCandlestickHighchart extends Component<
         labels: {
           format,
           align: 'center',
-          reserveSpace: true,
         },
         range,
         crosshair: {
@@ -155,9 +146,10 @@ export default class MarketOutcomeChartsCandlestickHighchart extends Component<
           label: {
             enabled: true,
             format: crosshair,
-            align: 'center',
+            shape: 'square',
+            padding: 4,
             y: 0,
-            x: -5,
+            x: 0,
           },
         },
       },
@@ -171,23 +163,21 @@ export default class MarketOutcomeChartsCandlestickHighchart extends Component<
             .minus(marketMin)
             .dividedBy(2)
             .toNumber(),
-          showFirstLabel: true,
+          showFirstLabel: false,
           showLastLabel: true,
           labels: {
             format: '${value:.2f}',
-            align: 'center',
             style: Styles.Candlestick_display_yLables,
-            x:
-              max > 1
-                ? HIGH_CHART_CONFIG.YLableXposition - 15
-                : HIGH_CHART_CONFIG.YLableXposition,
-            y: HIGH_CHART_CONFIG.YLableYposition,
+            x: 0,
+            y: 16,
           },
           crosshair: {
             snap: false,
             label: {
               enabled: true,
               format: '${value:.2f}',
+              shape: 'square',
+              padding: 4
             },
           },
         },

--- a/packages/augur-ui/src/modules/market-charts/components/market-outcomes-chart/market-outcome-chart-highchart.tsx
+++ b/packages/augur-ui/src/modules/market-charts/components/market-outcomes-chart/market-outcome-chart-highchart.tsx
@@ -55,8 +55,9 @@ export default class MarketOutcomesChartHighchart extends Component<
           type: 'line',
           styledMode: false,
           animation: false,
-          marginTop: 40,
-          marginRight: 45,
+          marginTop: 20,
+          marginRight: 0,
+          spacing: [0, 0, 4, 0]
         },
         credits: {
           enabled: false,
@@ -100,13 +101,13 @@ export default class MarketOutcomesChartHighchart extends Component<
           opposite: true,
           max: createBigNumber(props.maxPrice).toFixed(props.pricePrecision),
           min: createBigNumber(props.minPrice).toFixed(props.pricePrecision),
-          showFirstLabel: true,
+          showFirstLabel: false,
           showLastLabel: true,
           labels: {
             format: props.isScalar ? '{value:.4f}' : '${value:.2f}',
             style: null,
-            x: 35,
-            y: -2,
+            x: 0,
+            y: 16,
           },
           height: '100%',
           resize: {
@@ -115,7 +116,9 @@ export default class MarketOutcomesChartHighchart extends Component<
           crosshair: {
             snap: true,
             label: {
+              padding: 4,
               enabled: true,
+              shape: 'square',
               format: props.isScalar ? '{value:.4f}' : '${value:.2f}',
             },
           },
@@ -205,6 +208,8 @@ export default class MarketOutcomesChartHighchart extends Component<
         snap: true,
         label: {
           enabled: true,
+          shape: 'square',
+          padding: 4,
         },
       },
     };
@@ -239,8 +244,6 @@ export default class MarketOutcomesChartHighchart extends Component<
       width: this.container.clientWidth,
     };
 
-    const useArea =
-      priceTimeSeries && Object.keys(priceTimeSeries).length === 1;
     const hasData =
       priceTimeSeries &&
       Object.keys(priceTimeSeries) &&

--- a/packages/augur-ui/src/modules/market-charts/components/market-outcomes-chart/market-outcomes-chart.styles.less
+++ b/packages/augur-ui/src/modules/market-charts/components/market-outcomes-chart/market-outcomes-chart.styles.less
@@ -5,7 +5,8 @@
   flex: 1 100%;
   flex-direction: column;
   max-height: @charts-max-height;
-  min-height: @charts-min-height;
+  height: @charts-max-height;
+  min-height: @charts-max-height;
   position: relative;
 
   svg {
@@ -71,6 +72,7 @@
 
       .highcharts-crosshair-label {
         background-color: @color-module-background;
+        border-radius: 5px;
         color: @color-primary-text;
         font-size: @size-10;
         z-index: @above-all-content;

--- a/yarn.lock
+++ b/yarn.lock
@@ -17848,7 +17848,7 @@ node-releases@^1.1.38:
   dependencies:
     semver "^6.3.0"
 
-node-sass@4.3.3:
+node-sass@4.13.0:
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.0.tgz#b647288babdd6a1cb726de4545516b31f90da066"
   integrity sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==
@@ -21008,7 +21008,7 @@ pull-window@^2.1.4:
   dependencies:
     looper "^2.0.0"
 
-"pull-ws@github:hugomrdias/pull-ws#fix/bundle-size":
+pull-ws@hugomrdias/pull-ws#fix/bundle-size:
   version "3.3.1"
   resolved "https://codeload.github.com/hugomrdias/pull-ws/tar.gz/8e2ce0bb3b1cd6804828316e937fff8e0bef6225"
   dependencies:


### PR DESCRIPTION
adjusted the priceTimeHistory and Candlestick charts to more closely match the mocks and keep sizing consistent across all chart content boxes, updated labels on crosshairs

https://github.com/augurproject/augur/issues/4415