### PR TITLE
add user's created markets to login getter

### DIFF
--- a/packages/augur-sdk/src/state/getter/Users.ts
+++ b/packages/augur-sdk/src/state/getter/Users.ts
@@ -210,6 +210,11 @@ export class Users {
       orderState: OrderState.OPEN,
     });
 
+    const marketList = await Markets.getMarkets(augur, db, {
+      creator: params.account,
+      universe: params.universe,
+    });
+
     // user created markets are included, REP staked as no-show bond
     const userStakedRep: AccountReportingHistory = await Accounts.getAccountRepStakeSummary(augur, db, {
       account: params.account,
@@ -269,7 +274,7 @@ export class Users {
       userStakedRep,
       userPositions,
       userPositionTotals,
-      marketsInfo
+      marketsInfo: [...marketList.markets, ...marketsInfo]
     };
   }
 


### PR DESCRIPTION
I thought get staked rep getter returned user's created markets b/c of no-show REP bond, but doesn't seem to be the case. added explicit call to get user's created markets