### PR TITLE
fill-price-time-history

### DIFF
--- a/packages/augur-ui/src/modules/market-charts/components/market-outcomes-chart/market-outcome-chart-highchart.tsx
+++ b/packages/augur-ui/src/modules/market-charts/components/market-outcomes-chart/market-outcome-chart-highchart.tsx
@@ -19,7 +19,6 @@ interface MarketOutcomeChartsHighchartsProps {
   selectedOutcomeId: number;
   pricePrecision: number;
   daysPassed: number;
-  currentAugurTimestamp: number;
 }
 
 interface MarketOutcomeChartsHighchartsState {
@@ -135,13 +134,11 @@ export default class MarketOutcomesChartHighchart extends Component<
       bucketedPriceTimeSeries,
       selectedOutcomeId,
       daysPassed,
-      currentAugurTimestamp,
     } = this.props;
     this.buidOptions(
       daysPassed,
       bucketedPriceTimeSeries,
-      selectedOutcomeId,
-      currentAugurTimestamp
+      selectedOutcomeId
     );
   }
 
@@ -160,8 +157,7 @@ export default class MarketOutcomesChartHighchart extends Component<
       this.buidOptions(
         nextProps.daysPassed,
         nextProps.bucketedPriceTimeSeries,
-        nextProps.selectedOutcomeId,
-        nextProps.currentAugurTimestamp
+        nextProps.selectedOutcomeId
       );
     }
   }
@@ -201,7 +197,6 @@ export default class MarketOutcomesChartHighchart extends Component<
     daysPassed,
     bucketedPriceTimeSeries,
     selectedOutcomeId,
-    currentAugurTimestamp
   ) {
     const { options } = this.state;
     const { isScalar, scalarDenomination } = this.props;

--- a/packages/augur-ui/src/modules/market-charts/containers/market-outcomes-chart.ts
+++ b/packages/augur-ui/src/modules/market-charts/containers/market-outcomes-chart.ts
@@ -28,7 +28,6 @@ const mapStateToProps = (state, ownProps) => {
     bucketedPriceTimeSeries,
     isScalar,
     scalarDenomination,
-    currentAugurTimestamp: state.blockchain.currentAugurTimestamp;
   };
 };
 

--- a/packages/augur-ui/src/modules/market-charts/containers/market-outcomes-chart.ts
+++ b/packages/augur-ui/src/modules/market-charts/containers/market-outcomes-chart.ts
@@ -28,6 +28,7 @@ const mapStateToProps = (state, ownProps) => {
     bucketedPriceTimeSeries,
     isScalar,
     scalarDenomination,
+    currentAugurTimestamp: state.blockchain.currentAugurTimestamp;
   };
 };
 

--- a/packages/augur-ui/src/modules/markets/selectors/select-bucketed-price-time-series.ts
+++ b/packages/augur-ui/src/modules/markets/selectors/select-bucketed-price-time-series.ts
@@ -78,19 +78,27 @@ const bucketedPriceTimeSeriesInternal = (
       bnCreationTimestamp.plus(createBigNumber(index).times(bucket)).toNumber()
     )
   );
-
+  
   timeBuckets.push(currentTimestamp);
   const priceTimeSeries = outcomes.reduce((p, o) => {
-    p[o.id] = splitTradesByTimeBucket(o.priceTimeSeries, timeBuckets);
+    p[o.id] = splitTradesByTimeBucket(o.priceTimeSeries, timeBuckets, creationTime);
     return p;
   }, {});
-
   return {
     priceTimeSeries,
   };
 };
 
-function splitTradesByTimeBucket(priceTimeSeries, timeBuckets) {
+function splitTradesByTimeBucket(priceTimeSeries, timeBuckets, creationTime) {
+  // make sure we start the series with a 0 at the startTime for chart rendering.
+  if (!priceTimeSeries.find(item => item[0] === creationTime) || priceTimeSeries.length === 0) {
+     priceTimeSeries.push({
+      price: "0",
+      amount: "0",
+      logIndex: 0,
+      timestamp: creationTime
+    });
+  }
   if (!priceTimeSeries || priceTimeSeries.length === 0) return [];
   if (!timeBuckets || timeBuckets.length === 0) return [];
   let timeSeries = priceTimeSeries


### PR DESCRIPTION
ensured we always have a 0 price at start time and a latest price for outcomes on the most recent trade time when rendering price time history chart. this ensures the chart stays full without breaks in the line data

https://github.com/augurproject/augur/issues/4479