### PR TITLE
Fixed for desktop. Mobile would require some work

### DIFF
--- a/packages/augur-ui/src/modules/global-chat/components/global-chat.styles.less
+++ b/packages/augur-ui/src/modules/global-chat/components/global-chat.styles.less
@@ -7,6 +7,14 @@
   right: @size-22;
   z-index: @mask-modal;
 
+  > div:first-of-type {
+    display: none;
+  }
+
+  > div.ShowGlobalChat {
+    display: block;
+  }
+
   // Closed global chat window
   > button {
     .mono-9-bold;

--- a/packages/augur-ui/src/modules/global-chat/components/global-chat.tsx
+++ b/packages/augur-ui/src/modules/global-chat/components/global-chat.tsx
@@ -4,6 +4,7 @@ import { SecondaryButton } from 'modules/common/buttons';
 import { Chevron, Close } from 'modules/common/icons';
 
 import Styles from 'modules/global-chat/components/global-chat.styles.less';
+import classNames = require('classnames');
 
 export interface GlobalChatProps {
   show: boolean;
@@ -21,17 +22,17 @@ export const GlobalChat = (props: GlobalChatProps) => {
           icon={Chevron}
         />
       }
-      {show &&
+      <div className={classNames({
+        [Styles.ShowGlobalChat]: show
+      })}>
         <div>
-          <div>
-            <span>Global Chat</span>
-            <button onClick={() => setShow(!show)}>
-              {Close}
-            </button>
-          </div>
-          <iframe src='./chat/index.html#/channel/augur' />
+          <span>Global Chat</span>
+          <button onClick={() => setShow(!show)}>
+            {Close}
+          </button>
         </div>
-      }
+        <iframe src='./chat/index.html#/channel/augur' />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
This fixes the chat for desktop, so the iframe is not recreated every time.

Since the mobile version is a modal, the modal altogether is recreated every time, so a different approach would have to take place in order for it to work, most likely using display toggle for none/block, position fixed and a big z-index.