### PR TITLE
fix warning with input in TextInput

### DIFF
--- a/packages/augur-ui/src/modules/common/form.tsx
+++ b/packages/augur-ui/src/modules/common/form.tsx
@@ -1261,7 +1261,7 @@ export class TextInput extends React.Component<TextInputProps, TextInputState> {
   };
 
   state: TextInputState = {
-    value: this.props.value === null ? '' : this.props.value,
+    value: !this.props.value ? '' : this.props.value,
     showList: false,
   };
   refDropdown: any = null;


### PR DESCRIPTION
Fixed warning where input wasn't getting a value from this.state.value because of initial state.

to test: create a market via template that has a text input.

![image](https://user-images.githubusercontent.com/3970376/68251672-431dcc80-ffe9-11e9-8c37-cf6ec975b31a.png)
