### PR TITLE
dont hide onboarding modals when syncing is compelete

### DIFF
--- a/packages/augur-ui/src/modules/app/actions/init-augur.ts
+++ b/packages/augur-ui/src/modules/app/actions/init-augur.ts
@@ -55,7 +55,7 @@ function pollForAccount(
   let intervalId = null;
 
   async function attemptLogin() {
-    const { connection } = getState();
+    const { connection, modal } = getState();
     if (attemptedLogin) {
       clearInterval(intervalId);
     }
@@ -69,14 +69,25 @@ function pollForAccount(
       );
 
       const showModal = accountType => {
-        dispatch(
-          updateModal({
-            type: MODAL_LOADING,
-            callback: () => setTimeout(() => dispatch(closeModal())),
-            message: `Syncing 📡 ${accountType} account...`,
-            showCloseAfterDelay: true,
-          })
-        );
+        const onboardingShown = [
+          'MODAL_ACCOUNT_CREATED',
+          'MODAL_AUGUR_USES_DAI',
+          'MODAL_BUY_DAI',
+          'MODAL_TEST_BET',
+        ].includes(modal.type);
+        if (!onboardingShown) {
+          dispatch(
+            updateModal({
+              type: MODAL_LOADING,
+              callback: () =>
+                setTimeout(() => {
+                  dispatch(closeModal());
+                }),
+              message: `Syncing 📡 ${accountType} account...`,
+              showCloseAfterDelay: true,
+            })
+          );
+        }
       };
 
       const errorModal = () => {
@@ -257,7 +268,12 @@ interface initAugurParams {
 
 export function initAugur(
   history: History,
-  { ethereumNodeHttp, ethereumNodeWs, sdkEndpoint, useWeb3Transport }: initAugurParams,
+  {
+    ethereumNodeHttp,
+    ethereumNodeWs,
+    sdkEndpoint,
+    useWeb3Transport,
+  }: initAugurParams,
   callback: NodeStyleCallback = logError
 ) {
   return (

--- a/packages/augur-ui/src/modules/app/actions/init-augur.ts
+++ b/packages/augur-ui/src/modules/app/actions/init-augur.ts
@@ -83,7 +83,7 @@ function pollForAccount(
                 setTimeout(() => {
                   dispatch(closeModal());
                 }),
-              message: `Syncing 📡 ${accountType} account...`,
+              message: `Syncing ${accountType} account...`,
               showCloseAfterDelay: true,
             })
           );

--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -618,12 +618,12 @@ export default class MarketView extends Component<
                         updateSelectedOrderProperties={
                           this.updateSelectedOrderProperties
                         }
-                        marketId={tradingTutorial && marketId}
+                        marketId={marketId}
                         market={preview && market}
                         preview={preview}
                         tradingTutorial={tradingTutorial}
                         orders={orders}
-                        fills={fillls}
+                        fills={fills}
                       />
                     </div>
                   </ModulePane>


### PR DESCRIPTION
Don't show a synching modal when a new user is going through onboarding.