### PR TITLE
fix mobile errors

### DIFF
--- a/packages/augur-ui/src/modules/market-charts/components/market-outcomes-chart/market-outcome-chart-highchart.tsx
+++ b/packages/augur-ui/src/modules/market-charts/components/market-outcomes-chart/market-outcome-chart-highchart.tsx
@@ -19,6 +19,7 @@ interface MarketOutcomeChartsHighchartsProps {
   selectedOutcomeId: number;
   pricePrecision: number;
   daysPassed: number;
+  isTradingTutorial?: boolean;
 }
 
 interface MarketOutcomeChartsHighchartsState {
@@ -134,12 +135,16 @@ export default class MarketOutcomesChartHighchart extends Component<
       bucketedPriceTimeSeries,
       selectedOutcomeId,
       daysPassed,
+      isTradingTutorial,
     } = this.props;
-    this.buidOptions(
-      daysPassed,
-      bucketedPriceTimeSeries,
-      selectedOutcomeId
-    );
+
+    if (!isTradingTutorial) {
+      this.buidOptions(
+        daysPassed,
+        bucketedPriceTimeSeries,
+        selectedOutcomeId
+      );
+    }
   }
 
   UNSAFE_componentWillUpdate(nextProps) {

--- a/packages/augur-ui/src/modules/market-charts/containers/market-outcomes-chart.ts
+++ b/packages/augur-ui/src/modules/market-charts/containers/market-outcomes-chart.ts
@@ -4,30 +4,32 @@ import MarketOutcomesChartHighchart from "modules/market-charts/components/marke
 
 import { selectMarket } from "modules/markets/selectors/market";
 import selectBucketedPriceTimeSeries from "modules/markets/selectors/select-bucketed-price-time-series";
-import { SCALAR } from "modules/common/constants";
+import { SCALAR, TRADING_TUTORIAL } from "modules/common/constants";
 
 const mapStateToProps = (state, ownProps) => {
+  const isTradingTutorial = ownProps.marketId === TRADING_TUTORIAL;
   const {
     maxPriceBigNumber,
     minPriceBigNumber,
     outcomes = [],
     marketType,
     scalarDenomination,
-  } = ownProps.marketId ? selectMarket(ownProps.marketId) : ownProps.market;
+  } = ownProps.marketId && !isTradingTutorial ? selectMarket(ownProps.marketId) : ownProps.market;
   const isScalar = marketType === SCALAR;
-  const bucketedPriceTimeSeries = selectBucketedPriceTimeSeries(
-    ownProps.marketId,
-  );
+
+
+  const bucketedPriceTimeSeries = !isTradingTutorial ? selectBucketedPriceTimeSeries(ownProps.marketId) : [];
 
   return {
-    maxPrice: maxPriceBigNumber.toNumber(),
-    minPrice: minPriceBigNumber.toNumber(),
+    maxPrice: !isTradingTutorial ? maxPriceBigNumber.toNumber() : 0,
+    minPrice: !isTradingTutorial ? minPriceBigNumber.toNumber() : 0,
     fixedPrecision: 4,
     pricePrecision: 4,
     outcomes,
     bucketedPriceTimeSeries,
     isScalar,
     scalarDenomination,
+    isTradingTutorial,
   };
 };
 

--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -47,6 +47,8 @@ import { formatShares, formatDai } from 'utils/format-number';
 import { convertUnixToFormattedDate } from 'utils/format-date';
 import { createBigNumber } from 'utils/create-big-number';
 import { TXEventName } from '@augurproject/sdk/src';
+import makePath from 'modules/routes/helpers/make-path';
+import { MARKETS } from 'modules/routes/constants/views';
 
 interface MarketViewProps {
   isMarketLoading: boolean;
@@ -156,6 +158,8 @@ export default class MarketView extends Component<
       loadMarketTradingHistory,
       tradingTutorial,
     } = this.props;
+    this.tradingTutorialWidthCheck();
+
     if (isConnected && !!marketId && !tradingTutorial) {
       loadFullMarket(marketId);
       loadMarketTradingHistory(marketId);
@@ -184,6 +188,7 @@ export default class MarketView extends Component<
       tradingTutorial,
       updateModal,
     } = this.props;
+    this.tradingTutorialWidthCheck();
 
     if (tradingTutorial) {
       if (
@@ -211,6 +216,14 @@ export default class MarketView extends Component<
     if (isMarketLoading !== nextProps.isMarketLoading) {
       closeMarketLoadingModal();
       this.showMarketDisclaimer();
+    }
+  }
+
+  tradingTutorialWidthCheck() {
+    if (this.props.tradingTutorial && window.innerWidth <= 1280) { // TEMP_TABLET
+      // Don't show tradingTutorial on mobile,
+      // redirect to markets when we enter tablet breakpoints
+      this.props.history.push({ pathname: makePath(MARKETS) });
     }
   }
 
@@ -376,6 +389,7 @@ export default class MarketView extends Component<
         />
       );
     }
+
     let outcomeId =
       selectedOutcomeId === null || selectedOutcomeId === undefined
         ? market.defaultSelectedOutcomeId
@@ -597,7 +611,7 @@ export default class MarketView extends Component<
 
                       <TradingForm
                         market={market}
-                        initialLiquidity={preview && !initialLiquidity}
+                        initialLiquidity={preview && !tradingTutorial}
                         tradingTutorial={tradingTutorial}
                         selectedOrderProperties={selectedOrderProperties}
                         selectedOutcomeId={outcomeId}


### PR DESCRIPTION
Trading Tutorial doesn't support mobile layout. The tutorial would crash if you resized the window to a tablet or below while on the Trading Tutorial.

To fix this, we will redirect users to the markets page when they resize their tutorial window to small.