### PR TITLE
in css change h1 to span, market title wasn't getting bolded

### DIFF
--- a/packages/augur-ui/src/modules/market/components/market-header/market-header.styles.less
+++ b/packages/augur-ui/src/modules/market/components/market-header/market-header.styles.less
@@ -49,7 +49,7 @@
       }
 
       > div {
-        > h1 {
+        > span {
           .text-18-bold;
 
           color: @color-primary-text;


### PR DESCRIPTION
fix bolding market title
![image](https://user-images.githubusercontent.com/3970376/68778512-e88ffc00-05f8-11ea-85a8-c3f07d569b7d.png)



old broken
![image](https://user-images.githubusercontent.com/3970376/68778690-1d9c4e80-05f9-11ea-81ee-36d491c726a1.png)
