### PR TITLE
use new preview market title to display title on review page

### DIFF
--- a/packages/augur-ui/src/modules/create-market/components/common.tsx
+++ b/packages/augur-ui/src/modules/create-market/components/common.tsx
@@ -48,6 +48,7 @@ import {
 } from '@augurproject/artifacts';
 import { TemplateBannerText } from 'modules/create-market/constants';
 import { DismissableNotice, DISMISSABLE_NOTICE_BUTTON_TYPES } from 'modules/reporting/common';
+import PreviewMarketTitle from 'modules/market/components/common/PreviewMarketTitle';
 
 export interface HeaderProps {
   text: string;
@@ -174,6 +175,16 @@ export const SmallSubheaders = (props: SubheadersProps) => (
     <h1>{props.header}</h1>
     {props.renderMarkdown && <MarkdownRenderer text={props.subheader} />}
     {!props.renderMarkdown && <span>{props.subheader}</span>}
+  </div>
+);
+
+interface PreviewMarketTitleHeaderProps {
+  market: NewMarket;
+}
+export const PreviewMarketTitleHeader = (props: PreviewMarketTitleHeaderProps) => (
+  <div className={Styles.SmallSubheaders}>
+    <h1>Market Question</h1>
+    <PreviewMarketTitle market={props.market} />
   </div>
 );
 

--- a/packages/augur-ui/src/modules/create-market/components/review.tsx
+++ b/packages/augur-ui/src/modules/create-market/components/review.tsx
@@ -12,7 +12,8 @@ import {
   OutcomesList,
   SmallSubheadersTooltip,
   NoFundsErrors,
-  DateTimeHeaders
+  DateTimeHeaders,
+  PreviewMarketTitleHeader
 } from "modules/create-market/components/common";
 import { LinearPropertyLabel, LinearPropertyLabelTooltip } from "modules/common/labels";
 import {
@@ -254,7 +255,8 @@ export default class Review extends React.Component<
           <SmallSubheaders header="Primary Category" subheader={categories[0]} />
           <SmallSubheaders header="Secondary category" subheader={categories[1]} />
           <SmallSubheaders header="Sub category" subheader={categories[2] === "" ? "–" : categories[2]} />
-          <SmallSubheaders header="Market Question" subheader={description} />
+          <PreviewMarketTitleHeader market={newMarket} />
+
           {marketType === SCALAR &&
             <>
               <SmallSubheaders header="Unit of Measurement" subheader={scalarDenomination} />


### PR DESCRIPTION
closes <https://github.com/augurproject/augur/issues/4702>

need to use new preview market title on market creation review page.
constructed template market title
![image](https://user-images.githubusercontent.com/3970376/68779650-9bad2500-05fa-11ea-930f-b772dd7141bf.png)



simple custom market creation title
![image](https://user-images.githubusercontent.com/3970376/68779783-d4e59500-05fa-11ea-8db6-ced3658625dd.png)


simple template market title
![image](https://user-images.githubusercontent.com/3970376/68779913-0a8a7e00-05fb-11ea-8c17-f5e201a89337.png)
