### PR TITLE
fix template picker selection when nav to different tertiary category

### DIFF
--- a/packages/augur-ui/src/modules/common/form.tsx
+++ b/packages/augur-ui/src/modules/common/form.tsx
@@ -210,9 +210,9 @@ export const Error = (props: ErrorProps) => (
 export interface BaseRadioButtonProp {
   id: string;
   checked: boolean;
+  value?: string;
 }
 export interface RadioCardProps extends BaseRadioButtonProp {
-  value: string;
   header: string;
   description: string;
   onChange?: Function;
@@ -246,7 +246,6 @@ export interface RadioGroupState {
 
 export interface RadioBarProps extends BaseRadioButtonProp {
   header: string;
-  value: string;
   onChange?: Function;
   expandable?: boolean;
   error?: boolean;
@@ -261,7 +260,6 @@ export interface RadioBarProps extends BaseRadioButtonProp {
 export interface ReportingRadioBarProps extends BaseRadioButtonProp {
   market: MarketData;
   header: string;
-  value: string | null;
   updateChecked?: Function;
   expandable?: boolean;
   error?: boolean;
@@ -280,7 +278,6 @@ export interface ReportingRadioBarProps extends BaseRadioButtonProp {
 export interface RadioTwoLineBarProps extends BaseRadioButtonProp {
   header: string;
   description: string;
-  value: string;
   onChange: Function;
   error?: boolean;
   hideRadioButton?: boolean;
@@ -289,7 +286,6 @@ export interface RadioTwoLineBarProps extends BaseRadioButtonProp {
 
 interface CheckboxBarProps extends BaseRadioButtonProp {
   header: string;
-  value: string;
   onChange: Function;
   error?: boolean;
 }

--- a/packages/augur-ui/src/modules/create-market/components/template-picker.tsx
+++ b/packages/augur-ui/src/modules/create-market/components/template-picker.tsx
@@ -70,14 +70,6 @@ export const TemplatePicker = ({ newMarket, updateNewMarket }) => {
               })}
               onClick={() => {
                 setTertiary(option);
-                updateNewMarket({
-                  ...newMarket,
-                  categories: [
-                    newMarket.categories[0],
-                    newMarket.categories[1],
-                    option.label,
-                  ],
-                });
                 setDefaultValue(null);
               }}
             >

--- a/packages/augur-ui/src/modules/create-market/components/template-picker.tsx
+++ b/packages/augur-ui/src/modules/create-market/components/template-picker.tsx
@@ -33,7 +33,7 @@ export const TemplatePicker = ({ newMarket, updateNewMarket }) => {
   const [tertiary, setTertiary] = useState(
     tertiaryOptions.length === 0 ? { value: '', label: '' } : tertiaryOptions[0]
   );
-
+  const [defaultValue, setDefaultValue] = useState(null);
   const categoriesFormatted = {
     primary: categories[0],
     secondary: categories[1],
@@ -78,6 +78,7 @@ export const TemplatePicker = ({ newMarket, updateNewMarket }) => {
                     option.label,
                   ],
                 });
+                setDefaultValue(null);
               }}
             >
               {option.label}
@@ -87,33 +88,37 @@ export const TemplatePicker = ({ newMarket, updateNewMarket }) => {
       )}
       <section>
         <RadioTwoLineBarGroup
+          defaultSelected={defaultValue}
           radioButtons={templateOptions}
           onChange={value => {
+            setDefaultValue(value);
+            if (!value) return;
+            const template = templates[value];
             updateNewMarket({
               ...deepClone<NewMarket>(EMPTY_STATE),
               description: buildMarketDescription(
-                templates[value].question,
-                templates[value].inputs
+                template.question,
+                template.inputs
               ),
               outcomes:
                 newMarket.marketType === CATEGORICAL
-                  ? createTemplateOutcomes(templates[value].inputs)
+                  ? createTemplateOutcomes(template.inputs)
                   : ['', ''],
               currentStep: newMarket.currentStep,
               tickSize:
-                newMarket.marketType === SCALAR && templates[value].tickSize
-                  ? templates[value].tickSize
+                newMarket.marketType === SCALAR && template.tickSize
+                  ? template.tickSize
                   : DEFAULT_TICK_SIZE,
               scalarDenomination:
                 newMarket.marketType === SCALAR &&
-                templates[value].denomination,
+                template.denomination,
               minPrice:
-                newMarket.marketType === SCALAR && templates[value].minPrice
-                  ? templates[value].minPrice
+                newMarket.marketType === SCALAR && template.minPrice
+                  ? template.minPrice
                   : newMarket.minPrice,
               maxPrice:
-                newMarket.marketType === SCALAR && templates[value].maxPrice
-                  ? templates[value].maxPrice
+                newMarket.marketType === SCALAR && template.maxPrice
+                  ? template.maxPrice
                   : newMarket.maxPrice,
               marketType: newMarket.marketType,
               categories: [
@@ -121,7 +126,7 @@ export const TemplatePicker = ({ newMarket, updateNewMarket }) => {
                 newMarket.categories[1],
                 tertiary.label,
               ],
-              template: templates[value],
+              template: template,
             });
           }}
         />

--- a/packages/augur-ui/src/modules/create-market/components/template-picker.tsx
+++ b/packages/augur-ui/src/modules/create-market/components/template-picker.tsx
@@ -118,7 +118,7 @@ export const TemplatePicker = ({ newMarket, updateNewMarket }) => {
                 newMarket.categories[1],
                 tertiary.label,
               ],
-              template: template,
+              template,
             });
           }}
         />


### PR DESCRIPTION
fixes https://github.com/augurproject/augur/issues/4785

repro:

Choose Sports -> Basketball
Select Yes/No market type

Pick the first template
then navigate to NCAA, notice that the first template is already selected.
click next to enter the market creation form and the initial NBA template is shown

Need to clear the template selected when user nav to different tertiary.