### PR TITLE
add legacy rep faucet button to test v1 rep migration to v2

### DIFF
--- a/packages/augur-ui/src/modules/account/actions/get-rep.ts
+++ b/packages/augur-ui/src/modules/account/actions/get-rep.ts
@@ -1,5 +1,4 @@
 import logError from "utils/log-error";
-import { AppState } from "store";
 import { Action } from "redux";
 import { ThunkDispatch } from "redux-thunk";
 import { NodeStyleCallback } from "modules/types";
@@ -7,7 +6,7 @@ import { getRep } from "modules/contracts/actions/contractCalls";
 import { updateAssets } from "modules/auth/actions/update-assets";
 
 export default function(callback: NodeStyleCallback = logError) {
-  return async (dispatch: ThunkDispatch<void, any, Action>, getState: () => AppState) => {
+  return async (dispatch: ThunkDispatch<void, any, Action>) => {
     await getRep().catch((err: Error) => {
       console.log("error could not get dai", err);
       logError(new Error("get-Dai"));

--- a/packages/augur-ui/src/modules/account/components/transactions.styles.less
+++ b/packages/augur-ui/src/modules/account/components/transactions.styles.less
@@ -65,16 +65,9 @@
     }
 
     &:first-of-type {
-      > p, 
+      > p,
       > button {
         margin-right: @size-12;
-      }
-    }
-
-    &:last-of-type {
-      > p, 
-      > button {
-        margin-left: @size-12;
       }
     }
   }

--- a/packages/augur-ui/src/modules/account/components/transactions.tsx
+++ b/packages/augur-ui/src/modules/account/components/transactions.tsx
@@ -19,6 +19,8 @@ interface TransactionsProps {
   withdraw: Function;
   transactions: Function;
   approval: Function;
+  addFunds: Function;
+  legacyRepFaucet: Function;
 }
 
 export const Transactions = ({
@@ -28,6 +30,7 @@ export const Transactions = ({
   isMainnet,
   repFaucet,
   daiFaucet,
+  legacyRepFaucet,
 }: TransactionsProps) => (
   <QuadBox
     title="Transactions"
@@ -42,6 +45,15 @@ export const Transactions = ({
           <div>
             <p>REP for test net</p>
             <REPFaucetButton action={repFaucet} />
+          </div>
+        )}
+        {!isMainnet && (
+          <div>
+            <p>Legacy REP</p>
+            <REPFaucetButton
+              title="Legacy REP Faucet"
+              action={legacyRepFaucet}
+            />
           </div>
         )}
         {!isMainnet && (

--- a/packages/augur-ui/src/modules/account/containers/transactions.ts
+++ b/packages/augur-ui/src/modules/account/containers/transactions.ts
@@ -9,12 +9,11 @@ import {
   MODAL_ADD_FUNDS,
   MODAL_TRANSACTIONS,
   MODAL_ACCOUNT_APPROVAL,
-  REP,
 } from 'modules/common/constants';
 import { AppState } from 'store';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
-import { getNetworkId } from 'modules/contracts/actions/contractCalls'
+import { getNetworkId, getLegacyRep } from 'modules/contracts/actions/contractCalls'
 
 const mapStateToProps = (state: AppState) => {
   const networkId = getNetworkId();
@@ -30,6 +29,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({
   withdraw: () => dispatch(updateModal({ type: MODAL_WITHDRAW })),
   transactions: () => dispatch(updateModal({ type: MODAL_TRANSACTIONS })),
   approval: () => dispatch(updateModal({ type: MODAL_ACCOUNT_APPROVAL })),
+  legacyRepFaucet: () => getLegacyRep(),
 });
 
 const TransactionsContainer = connect(

--- a/packages/augur-ui/src/modules/common/buttons.tsx
+++ b/packages/augur-ui/src/modules/common/buttons.tsx
@@ -330,7 +330,7 @@ export const REPFaucetButton = (props: DefaultActionButtonProps) => (
     title={props.title || 'REP Faucet'}
   >
     {RepLogoIcon}
-    <span>REP Faucet</span>
+    <span>{props.title ? props.title : "REP Faucet"}</span>
   </button>
 );
 

--- a/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
+++ b/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
@@ -295,6 +295,12 @@ export function getRep() {
   return rep.faucet(createBigNumber('100000000000000000000'));
 }
 
+export function getLegacyRep() {
+  const { contracts } = augurSdk.get();
+  const rep = contracts.legacyReputationToken;
+  return rep.faucet(createBigNumber('10000000000000000000'));
+}
+
 export async function getCreateMarketBreakdown() {
   const { contracts } = augurSdk.get();
   const vBond = await contracts.universe.getOrCacheValidityBond_();


### PR DESCRIPTION
add legacy REP faucet button, to be used to test V1 REP to V2 migration.

![image](https://user-images.githubusercontent.com/3970376/68983034-cbad2180-07ce-11ea-91e1-0624eccbb0c8.png)
