### PR TITLE
fix pre-liquidity link for newly created markets

### DIFF
--- a/packages/augur-ui/src/modules/create-market/helpers/construct-market-params.ts
+++ b/packages/augur-ui/src/modules/create-market/helpers/construct-market-params.ts
@@ -15,6 +15,7 @@ import {
   TEN_TO_THE_EIGHTEENTH_POWER,
 } from 'modules/common/constants';
 import { CreateNewMarketParams } from 'modules/contracts/actions/contractCalls';
+import { generateTxParameterId } from 'utils/generate-tx-parameter-id';
 
 export function constructMarketParams(
   newMarket: CreateNewMarketParams,
@@ -82,51 +83,23 @@ export function constructMarketParams(
   }
 }
 
-export function constructMarketParamsReturn(
+export function getConstructedMarketId(
   newMarket: NewMarket
-): TransactionMetadataParams {
-  const fee = new BigNumber(newMarket.settlementFee || 0).div(
-    new BigNumber(100)
-  );
-  const feePerCashInAttoCash = fee.multipliedBy(TEN_TO_THE_EIGHTEENTH_POWER);
-  const affiliateFeeDivisor = new BigNumber(newMarket.affiliateFee || 0);
-  const marketEndTime = new BigNumber(newMarket.endTime);
-  const extraInfo = JSON.stringify({
-    categories: newMarket.categories,
+): string {
+  const params: TransactionMetadataParams = {
     description: newMarket.description,
-    longDescription: newMarket.detailsText,
-    _scalarDenomination: newMarket.scalarDenomination,
-    offsetName: newMarket.offsetName,
-  });
+  };
+  return generateTxParameterId(params);
+}
 
-  let params: TransactionMetadataParams = {
-    _endTime: marketEndTime,
-    _feePerCashInAttoCash: feePerCashInAttoCash,
-    _affiliateFeeDivisor: affiliateFeeDivisor,
-    _designatedReporterAddress: newMarket.designatedReporterAddress,
-    _extraInfo: extraInfo,
+export function getDeconstructedMarketId(
+  marketParameters
+): string {
+  const extraInfo = JSON.parse(marketParameters._extraInfo);
+
+  const params: TransactionMetadataParams = {
+    description: extraInfo.description,
   };
 
-  if (newMarket.marketType === SCALAR) {
-    const prices = [
-      convertDisplayValuetoAttoValue(new BigNumber(newMarket.minPrice)),
-      convertDisplayValuetoAttoValue(new BigNumber(newMarket.maxPrice)),
-    ];
-    const numTicks = tickSizeToNumTickWithDisplayPrices(
-      new BigNumber(newMarket.tickSize),
-      new BigNumber(newMarket.minPrice),
-      new BigNumber(newMarket.maxPrice)
-    );
-    params = Object.assign(params, {
-      _prices: prices,
-      _numTicks: numTicks,
-    });
-  } else if (newMarket.marketType === CATEGORICAL) {
-    const _outcomes = newMarket.outcomes.map(o => stringTo32ByteHex(o));
-    params = Object.assign(params, {
-      _outcomes,
-    });
-  }
-
-  return params;
+  return generateTxParameterId(params);
 }

--- a/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
+++ b/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
@@ -53,6 +53,7 @@ import {
   deleteLiquidityOrder,
 } from 'modules/events/actions/liquidity-transactions';
 import { addAlert, updateAlert } from 'modules/alerts/actions/alerts';
+import { getDeconstructedMarketId } from 'modules/create-market/helpers/construct-market-params';
 
 export const addUpdateTransaction = (txStatus: Events.TXStatus) => (
   dispatch: ThunkDispatch<void, any, Action>,
@@ -64,10 +65,11 @@ export const addUpdateTransaction = (txStatus: Events.TXStatus) => (
     const { blockchain, alerts } = getState();
 
     if (eventName === TXEventName.Failure) {
+      const genHash = hash ? hash : generateTxParameterId(transaction.params);
       dispatch(
         addAlert({
-          id: hash ? hash : generateTxParameterId(transaction.params),
-          uniqueId: hash ? hash : generateTxParameterId(transaction.params),
+          id: genHash,
+          uniqueId: genHash,
           params: transaction.params,
           status: eventName,
           timestamp: blockchain.currentAugurTimestamp * 1000,
@@ -152,7 +154,7 @@ export const addUpdateTransaction = (txStatus: Events.TXStatus) => (
       case CREATECATEGORICALMARKET:
       case CREATESCALARMARKET:
       case CREATEYESNOMARKET: {
-        const id = generateTxParameterId(transaction.params);
+        const id = getDeconstructedMarketId(transaction.params);
         const data = createMarketData(
           transaction.params,
           id,

--- a/packages/augur-ui/src/modules/modal/containers/modal-unsigned-orders.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-unsigned-orders.ts
@@ -24,7 +24,7 @@ import {
 import { AppState } from 'store';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
-import { BaseAction } from 'modules/types';
+import { BaseAction, CreateLiquidityOrders } from 'modules/types';
 import { Getters } from '@augurproject/sdk';
 
 const mapStateToProps = (state: AppState) => {
@@ -35,20 +35,22 @@ const mapStateToProps = (state: AppState) => {
     liquidity: state.pendingLiquidityOrders[market.transactionHash],
     gasPrice: getGasPrice(state),
     loginAccount: state.loginAccount,
+    chunkOrders: !state.appStatus.zeroXEnabled,
   };
 };
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({
   closeModal: () => dispatch(closeModal()),
-  startOrderSending: (options: object) => dispatch(startOrderSending(options)),
+  startOrderSending: (options: CreateLiquidityOrders) => dispatch(startOrderSending(options)),
   clearMarketLiquidityOrders: (marketId: string) =>
     dispatch(clearMarketLiquidityOrders(marketId)),
-  removeLiquidityOrder: (data: BaseAction) =>
+  removeLiquidityOrder: (data) =>
     dispatch(removeLiquidityOrder(data)),
   sendLiquidityOrder: (data: object) => dispatch(sendLiquidityOrder(data)),
 });
 
 const mergeProps = (sP, dP, oP) => {
+  const { chunkOrders } = sP;
   let numberOfTransactions = 0;
   let totalCost = ZERO;
 
@@ -67,9 +69,9 @@ const mergeProps = (sP, dP, oP) => {
   );
   const bnAllowance = createBigNumber(sP.loginAccount.allowance, 10);
   const needsApproval = bnAllowance.lte(ZERO);
-  const submitAllTxCount = Math.ceil(
+  const submitAllTxCount = chunkOrders ? Math.ceil(
     numberOfTransactions / MAX_BULK_ORDER_COUNT
-  );
+  ) : 1;
   const {
     marketType,
     scalarDenomination,
@@ -128,7 +130,7 @@ const mergeProps = (sP, dP, oP) => {
     buttons: [
       {
         text: 'Submit All',
-        action: () => dP.startOrderSending({ marketId }),
+        action: () => dP.startOrderSending({ marketId, chunkOrders }),
       },
       {
         text: 'Cancel All',

--- a/packages/augur-ui/src/modules/trading/components/form/form.tsx
+++ b/packages/augur-ui/src/modules/trading/components/form/form.tsx
@@ -78,6 +78,7 @@ interface FromProps {
   currentTimestamp: number;
   Ox_ENABLED: boolean;
   tradingTutorial?: boolean;
+  gasCostEst: string;
 }
 
 interface TestResults {

--- a/packages/augur-ui/src/modules/types.ts
+++ b/packages/augur-ui/src/modules/types.ts
@@ -266,6 +266,10 @@ export interface UIOrder {
   minPrice: string;
 }
 
+export interface CreateLiquidityOrders {
+  marketId: string;
+  chunkOrders: boolean;
+}
 export interface LiquidityOrders {
   [txParamHash: string]: {
     [outcome: number]: LiquidityOrder[];


### PR DESCRIPTION
fix issue with generating unique id for market creation so that pre-liquidity orders modal link will show


addresses https://github.com/AugurProject/augur/issues/4743

![Screen Shot 2019-11-29 at 2 02 42 PM](https://user-images.githubusercontent.com/3970376/69888461-936b1000-12b1-11ea-927a-fac855830eae.png)

added check to chunk orders based on 0x trading is enabled.