### PR TITLE
Removes unused member variable shareTokens.

### DIFF
--- a/packages/augur-core/source/contracts/Augur.sol
+++ b/packages/augur-core/source/contracts/Augur.sol
@@ -72,7 +72,6 @@ contract Augur is IAugur, IAugurCreationDataGetter {
     mapping(address => bool) private markets;
     mapping(address => bool) private universes;
     mapping(address => bool) private crowdsourcers;
-    mapping(address => bool) private shareTokens;
     mapping(address => bool) private trustedSender;
 
     mapping(address => MarketCreationData) private marketCreationData;


### PR DESCRIPTION
Someone should probably evaluate if this was _supposed_ to be used somewhere...