### PR TITLE
show user their order failed

### DIFF
--- a/packages/augur-ui/src/modules/common/row-column.tsx
+++ b/packages/augur-ui/src/modules/common/row-column.tsx
@@ -32,6 +32,7 @@ export interface Properties {
   outcome?: string;
   location?: string;
   showExtraNumber?: Boolean;
+  status?: string;
 }
 
 function selectColumn(columnType: string, properties: Properties) {
@@ -83,7 +84,7 @@ function selectColumn(columnType: string, properties: Properties) {
       return properties.pending ? (
         <span>
           {' '}
-          <PendingLabel />{' '}
+          <PendingLabel status={properties.status}/>{' '}
         </span>
       ) : (
         <CancelTextButton

--- a/packages/augur-ui/src/modules/modal/common.tsx
+++ b/packages/augur-ui/src/modules/modal/common.tsx
@@ -26,7 +26,7 @@ import {
   ConfirmedLabel,
 } from 'modules/common/labels';
 import Styles from 'modules/modal/modal.styles.less';
-import { PENDING, SUCCESS, DAI } from 'modules/common/constants';
+import { PENDING, SUCCESS, DAI, FAILURE } from 'modules/common/constants';
 import { LinkContent } from 'modules/types';
 import { generateDaiTooltip } from 'modules/modal/add-funds';
 import { DismissableNotice, DISMISSABLE_NOTICE_BUTTON_TYPES } from 'modules/reporting/common';
@@ -102,7 +102,7 @@ export interface ActionRow {
   value: string;
   notice?: string;
   action: Function;
-  status: typeof PENDING | typeof SUCCESS;
+  status: typeof PENDING | typeof SUCCESS | typeof FAILURE;
   properties: Array<{ value: string; label: string; addExtraSpace: boolean }>;
 }
 
@@ -461,7 +461,7 @@ export const ActionRows = (props: ActionRowsProps) =>
         </div>
       </section>
       <div>
-        {row.status === PENDING && <PendingLabel />}
+        {row.status !== SUCCESS && <PendingLabel status={row.status} />}
         {row.status === SUCCESS && <ConfirmedLabel />}
         <SubmitTextButton
           disabled={row.status === SUCCESS || row.status === PENDING}

--- a/packages/augur-ui/src/modules/orders/selectors/user-open-orders.ts
+++ b/packages/augur-ui/src/modules/orders/selectors/user-open-orders.ts
@@ -1,7 +1,6 @@
 import memoize from 'memoizee';
 import { createBigNumber } from 'utils/create-big-number';
-import createCachedSelector from 're-reselect';
-import store from 'store';
+import store, { AppState } from 'store';
 
 import { isOrderOfUser } from 'modules/orders/helpers/is-order-of-user';
 
@@ -11,18 +10,19 @@ import {
   SELL,
   BUY,
   OPEN,
+  FAILURE,
 } from 'modules/common/constants';
 
 import { convertUnixToFormattedDate } from 'utils/format-date';
-import { formatNone, formatEther, formatShares, formatDai } from 'utils/format-number';
+import { formatNone, formatShares, formatDai } from 'utils/format-number';
 import { cancelOrder } from 'modules/orders/actions/cancel-order';
 import {
   selectMarketInfosState,
   selectUserMarketOpenOrders,
   selectOrderCancellationState,
   selectPendingOrdersState,
-  selectLoginAccountAddress,
 } from 'store/select-state';
+import { createSelector } from 'reselect';
 
 function selectMarketsDataStateMarket(state, marketId) {
   return selectMarketInfosState(state)[marketId];
@@ -33,24 +33,23 @@ function selectUserMarketOpenOrdersMarket(state, marketId) {
 }
 
 function selectPendingOrdersStateMarket(state, marketId) {
-  return selectPendingOrdersState(state)[marketId];
+  const pending = selectPendingOrdersState(state)[marketId];
+  return !!pending ? [...pending] : pending;
 }
 
 export default function(marketId) {
   if (!marketId) return [];
 
-  return selectUserOpenOrders(store.getState(), marketId);
+  return selectUserOpenOrders(store.getState() as AppState, marketId);
 }
 
-export const selectUserOpenOrders = createCachedSelector(
+export const selectUserOpenOrders = createSelector(
   selectMarketsDataStateMarket,
   selectUserMarketOpenOrdersMarket,
   selectOrderCancellationState,
   selectPendingOrdersStateMarket,
-  selectLoginAccountAddress,
-  (market, userMarketOpenOrders, orderCancellation, pendingOrders, account) => {
+  (market, userMarketOpenOrders, orderCancellation, pendingOrders) => {
     if (!market) return [];
-
     let userOpenOrders =
       market.outcomes
         .map(outcome =>
@@ -60,7 +59,7 @@ export const selectUserOpenOrders = createCachedSelector(
             userMarketOpenOrders,
             orderCancellation,
             market.description,
-            outcome.description
+            outcome.description,
           )
         )
         .filter(collection => collection.length !== 0)
@@ -73,13 +72,14 @@ export const selectUserOpenOrders = createCachedSelector(
         unmatchedShares: formatShares(o.amount),
         avgPrice: formatDai(o.fullPrecisionPrice),
         pending: !!o.status, // TODO: can show status of transaction in the future
+        status: o.status,
       }))
       userOpenOrders = formatted.concat(userOpenOrders);
     }
 
     return userOpenOrders || [];
   }
-)((state, marketId) => marketId);
+);
 
 function selectUserOpenOrdersInternal(
   marketId,
@@ -87,9 +87,9 @@ function selectUserOpenOrdersInternal(
   userMarketOpenOrders,
   orderCancellation,
   marketDescription,
-  name
+  name,
 ) {
-  const { loginAccount } = store.getState();
+  const { loginAccount } = store.getState() as AppState;
   if (!loginAccount.address || userMarketOpenOrders == null) return [];
 
   return userOpenOrders(
@@ -99,7 +99,7 @@ function selectUserOpenOrdersInternal(
     userMarketOpenOrders,
     orderCancellation,
     marketDescription,
-    name
+    name,
   );
 }
 
@@ -111,7 +111,7 @@ const userOpenOrders = memoize(
     userMarketOpenOrders,
     orderCancellation,
     marketDescription,
-    name
+    name,
   ) => {
     const orderData = userMarketOpenOrders[outcomeId];
 
@@ -126,7 +126,7 @@ const userOpenOrders = memoize(
             loginAccount.address,
             orderCancellation,
             marketDescription,
-            name
+            name,
           );
     const userAsks =
       orderData == null || orderData[SELL_INDEX] == null
@@ -139,7 +139,7 @@ const userOpenOrders = memoize(
             loginAccount.address,
             orderCancellation,
             marketDescription,
-            name
+            name,
           );
 
     const orders = userAsks.concat(userBids);
@@ -158,7 +158,7 @@ function getUserOpenOrders(
   userId,
   orderCancellation = {},
   marketDescription = '',
-  name = ''
+  name = '',
 ) {
   const typeOrders = orders[orderType];
 
@@ -177,6 +177,7 @@ function getUserOpenOrders(
       outcomeId,
       creationTime: convertUnixToFormattedDate(order.creationTime),
       pending: !!orderCancellation[order.orderId],
+      status: order.status,
       orderCancellationStatus: orderCancellation[order.orderId],
       originalShares: formatNone(),
       avgPrice: formatDai(order.fullPrecisionPrice),

--- a/packages/augur-ui/src/modules/portfolio/containers/open-order.ts
+++ b/packages/augur-ui/src/modules/portfolio/containers/open-order.ts
@@ -66,6 +66,7 @@ const mergeProps = (sP: any, dP: any, oP: any) => {
       disabled: openOrder.pending,
       text: "Cancel",
       pending: openOrder.pending || openOrder.pendingOrder,
+      status: openOrder.status,
       action: (e: Event) => {
         e.stopPropagation();
         openOrder.cancelOrder(openOrder);


### PR DESCRIPTION
addresses <https://github.com/AugurProject/augur/issues/4762>

![image](https://user-images.githubusercontent.com/3970376/70013569-c295b180-153d-11ea-8064-09b42aaf346a.png)

still shows pending orders. failed orders are cleared out when user re-logs in 
![image](https://user-images.githubusercontent.com/3970376/70013582-cd504680-153d-11ea-9175-a03fa4daa207.png)

show successfully created user open orders next to failed
![image](https://user-images.githubusercontent.com/3970376/70013818-6aab7a80-153e-11ea-9e8e-2c99e08cc581.png)


also shows on Portfolio
![image](https://user-images.githubusercontent.com/3970376/70013862-93337480-153e-11ea-8d20-b37f0497a7f0.png)
