### PR TITLE
Dont show market disclaimer

### DIFF
--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -174,8 +174,6 @@ export default class MarketView extends Component<
 
     if (isMarketLoading) {
       showMarketLoadingModal();
-    } else {
-      this.showMarketDisclaimer();
     }
   }
 
@@ -213,10 +211,6 @@ export default class MarketView extends Component<
       this.props.loadFullMarket(this.props.marketId);
       this.props.loadMarketTradingHistory(marketId);
     }
-    if (isMarketLoading !== this.props.isMarketLoading) {
-      closeMarketLoadingModal();
-      this.showMarketDisclaimer();
-    }
   }
 
   tradingTutorialWidthCheck() {
@@ -228,6 +222,7 @@ export default class MarketView extends Component<
     }
   }
 
+  // don't show the market disclaimer when user shows up. TODO: Design to figure out when to show
   showMarketDisclaimer() {
     const { marketReviewSeen, marketReviewModal } = this.props;
     if (!marketReviewSeen && marketReviewModal) {

--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -211,6 +211,9 @@ export default class MarketView extends Component<
       this.props.loadFullMarket(this.props.marketId);
       this.props.loadMarketTradingHistory(marketId);
     }
+    if (isMarketLoading !== this.props.isMarketLoading) {
+      closeMarketLoadingModal();
+    }
   }
 
   tradingTutorialWidthCheck() {


### PR DESCRIPTION
addresses <https://github.com/AugurProject/augur/issues/4875> 

easiest way to test is nav to market trading page. 
clear application data
re-load the market trading page
should not see the market review modal. 

I left the modal. not sure if design wants to display it at a different time. 