### PR TITLE
market-card-outcome-updates

### DIFF
--- a/packages/augur-ui/src/modules/market-cards/common.styles.less
+++ b/packages/augur-ui/src/modules/market-cards/common.styles.less
@@ -22,7 +22,11 @@
 		> span:last-of-type {
 			.mono-12;
 
-			color: @color-secondary-text;
+			color: @color-primary-text;
+
+			&.Zero {
+				color: @color-secondary-text;
+			}
 		}
 	}
 

--- a/packages/augur-ui/src/modules/market-cards/common.tsx
+++ b/packages/augur-ui/src/modules/market-cards/common.tsx
@@ -56,9 +56,9 @@ export const Outcome = (props: OutcomeProps) => {
     >
       <div>
         <span>{props.description}</span>
-        <span>
+        <span className={classNames({[Styles.Zero]: percent === 0})}>
           {percent === 0
-            ? `-${props.isScalar ? '' : '%'}`
+            ? `0.00${props.isScalar ? '' : '%'}`
             : `${formatDai(percent).formatted}%`}
         </span>
       </div>


### PR DESCRIPTION
updated market card outcomes to use primary text for values above 0% (or no trades) and updated no trades from -% to 0.00% and secondary text.

This is related to an item on this checklist: https://github.com/AugurProject/augur/issues/4968