### PR TITLE
input cursor jumping to end

### DIFF
--- a/packages/augur-ui/src/modules/trading/components/form.tsx
+++ b/packages/augur-ui/src/modules/trading/components/form.tsx
@@ -704,7 +704,7 @@ class Form extends Component<FromProps, FormState> {
                     : 1
                 }
                 placeholder="0.00"
-                value={quantityValue}
+                defaultValue={quantityValue}
                 tabIndex={tradingTutorial ? -1 : 1}
                 onChange={e =>
                   this.validateForm(this.INPUT_TYPES.QUANTITY, e.target.value)
@@ -744,7 +744,7 @@ class Form extends Component<FromProps, FormState> {
                 min={min}
                 placeholder="0.00"
                 tabIndex={tradingTutorial ? -1 : 2}
-                value={
+                defaultValue={
                   s[this.INPUT_TYPES.PRICE]
                 }
                 onChange={e =>
@@ -791,7 +791,7 @@ class Form extends Component<FromProps, FormState> {
                 step={MIN_QUANTITY.toFixed()}
                 min={MIN_QUANTITY.toFixed()}
                 placeholder="0.00"
-                tabIndex={tradingTutorial ? "-1" : '2'}
+                tabIndex={tradingTutorial ? -1 : 2}
                 value={
                   s[this.INPUT_TYPES.EST_DAI]
                     ? createBigNumber(s[this.INPUT_TYPES.EST_DAI]).toNumber()

--- a/packages/augur-ui/src/modules/trading/components/wrapper.tsx
+++ b/packages/augur-ui/src/modules/trading/components/wrapper.tsx
@@ -330,7 +330,6 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
               this.updateState(
                 {
                   ...this.state,
-                  ...order,
                   orderDaiEstimate: neworderDaiEstimate,
                   orderEscrowdDai: newOrder.costInDai.formatted,
                   trade: newOrder,
@@ -404,7 +403,6 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
             this.updateState(
               {
                 ...this.state,
-                ...order,
                 orderQuantity: numShares,
                 orderEscrowdDai: newOrder.costInDai.formatted,
                 trade: newOrder,


### PR DESCRIPTION
dom is different than virtual dom for controlled inputs so the input field updates and cursor jumps to the end, use defaultValue to get around it

solution based on <https://stackoverflow.com/questions/28922275/in-reactjs-why-does-setstate-behave-differently-when-called-synchronously/28922465#28922465>