### PR TITLE
update Gnosis loggedAccount info on login

### DIFF
--- a/packages/augur-ui/src/services/augursdk.ts
+++ b/packages/augur-ui/src/services/augursdk.ts
@@ -132,6 +132,7 @@ export class SDK {
         this.sdk.setUseGnosisSafe(true);
         this.sdk.setUseGnosisRelay(true);
         this.sdk.setGnosisSafeAddress(safeAddress);
+        updateUser(safeAddress);
       }
     }
   }


### PR DESCRIPTION
Fixes crash when attempting to login with a Gnosis safe account.

![image](https://user-images.githubusercontent.com/1683736/70284578-7e4f1f00-1792-11ea-8009-9eb2b3ad2c8c.png)
