### PR TITLE
require Portis inline

### DIFF
--- a/packages/augur-ui/src/modules/auth/actions/login-with-portis.ts
+++ b/packages/augur-ui/src/modules/auth/actions/login-with-portis.ts
@@ -3,7 +3,7 @@ import { toChecksumAddress } from 'ethereumjs-util';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
 import { PersonalSigningWeb3Provider } from 'utils/personal-signing-web3-provider';
-import Portis, { INetwork } from '@portis/web3';
+import { INetwork } from '@portis/web3';
 import Web3 from 'web3';
 import {
   ACCOUNT_TYPES,
@@ -37,6 +37,8 @@ export const loginWithPortis = (forceRegisterPage = false) => async (
 
   if (portisNetwork) {
     try {
+      // Only inject Portis if we are using Portis
+      const Portis = require('@portis/web3');
       const portis = new Portis(PORTIS_API_KEY, portisNetwork, {
         scope: ['email'],
         registerPageByDefault: forceRegisterPage,


### PR DESCRIPTION
- Notice Portis was being injected regardless if it was being used. Was eating up a lot of heap memory also.

<img width="1440" alt="Screen Shot 2019-12-05 at 7 10 38 PM" src="https://user-images.githubusercontent.com/1683736/70285395-56ad8600-1795-11ea-9a89-204cefe6836f.png">
