### PR TITLE
fix comparison timestamp with market endTime

### DIFF
--- a/packages/augur-artifacts/src/templates.ts
+++ b/packages/augur-artifacts/src/templates.ts
@@ -310,7 +310,7 @@ function isDependencyOutcomesCorrect(
 
 function estimatedDateTimeAfterMarketEndTime(inputs: ExtraInfoTemplateInput[], endTime: number) {
   const input = inputs.find(i => i.type === TemplateInputType.ESTDATETIME);
-  if (!input) return true;
+  if (!input) return false;
   return Number(input.timestamp) > Number(endTime);
 }
 

--- a/packages/augur-artifacts/src/templates.ts
+++ b/packages/augur-artifacts/src/templates.ts
@@ -321,8 +321,8 @@ function isRetiredAutofail(hash:string) {
 }
 
 export const isTemplateMarket = (title, template: ExtraInfoTemplate, outcomes: string[], longDescription: string, endTime: string, errors: string[] = []) => {
-  if (!template || !template.hash || !template.question || template.inputs.length === 0) {
-    errors.push('value missing template | hash | question | inputs');
+  if (!template || !template.hash || !template.question || template.inputs.length === 0 || !endTime) {
+    errors.push('value missing template | hash | question | inputs | endTime');
     return false;
   }
 

--- a/packages/augur-artifacts/src/templates.ts
+++ b/packages/augur-artifacts/src/templates.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers';
+import { BigNumber } from 'ethers/utils';
 export const REQUIRED = 'REQUIRED';
 export const CHOICE = 'CHOICE';
 // Market templates
@@ -319,7 +320,7 @@ function isRetiredAutofail(hash:string) {
   return found.autoFail;
 }
 
-export const isTemplateMarket = (title, template: ExtraInfoTemplate, outcomes: string[], longDescription: string, endTime: number, errors: string[] = []) => {
+export const isTemplateMarket = (title, template: ExtraInfoTemplate, outcomes: string[], longDescription: string, endTime: string, errors: string[] = []) => {
   if (!template || !template.hash || !template.question || template.inputs.length === 0) {
     errors.push('value missing template | hash | question | inputs');
     return false;
@@ -348,7 +349,7 @@ export const isTemplateMarket = (title, template: ExtraInfoTemplate, outcomes: s
     }
 
     // check ESTDATETIME isn't after market event expiration
-    if (estimatedDateTimeAfterMarketEndTime(template.inputs, endTime)) {
+    if (estimatedDateTimeAfterMarketEndTime(template.inputs, new BigNumber(endTime).toNumber())) {
       errors.push('estimated schedule date time is after market event expiration endTime');
       return false;
     }

--- a/packages/augur-tools/src/flash/template-utils.ts
+++ b/packages/augur-tools/src/flash/template-utils.ts
@@ -1,5 +1,6 @@
 import { TEMPLATES, CategoryTemplate, isTemplateMarket, ExtraInfoTemplate } from '@augurproject/artifacts';
 import { stringTo32ByteHex } from '@augurproject/sdk';
+import { BigNumber } from 'ethers/utils';
 
 export const showTemplateByHash = (hash: string): string => {
   console.log("show template by hash");
@@ -32,8 +33,9 @@ export const validateMarketTemplate = (title: string, templateInfo: string, outc
     const splits = longDescription.split('\\n');
     details = splits.join('\n');
   }
+  const endTimeHex = new BigNumber(endTime).toHexString();
   const errors = [];
-  const result = isTemplateMarket(title, extraInfoTemplate, outcomes, details, endTime, errors);
+  const result = isTemplateMarket(title, extraInfoTemplate, outcomes, details, endTimeHex, errors);
 
   if (result) return 'Yes, this is a templated market';
   const error = errors[0];

--- a/packages/augur-tools/src/templates-template.ts
+++ b/packages/augur-tools/src/templates-template.ts
@@ -310,7 +310,7 @@ function isDependencyOutcomesCorrect(
 
 function estimatedDateTimeAfterMarketEndTime(inputs: ExtraInfoTemplateInput[], endTime: number) {
   const input = inputs.find(i => i.type === TemplateInputType.ESTDATETIME);
-  if (!input) return true;
+  if (!input) return false;
   return Number(input.timestamp) > Number(endTime);
 }
 

--- a/packages/augur-tools/src/templates-template.ts
+++ b/packages/augur-tools/src/templates-template.ts
@@ -321,8 +321,8 @@ function isRetiredAutofail(hash:string) {
 }
 
 export const isTemplateMarket = (title, template: ExtraInfoTemplate, outcomes: string[], longDescription: string, endTime: string, errors: string[] = []) => {
-  if (!template || !template.hash || !template.question || template.inputs.length === 0) {
-    errors.push('value missing template | hash | question | inputs');
+  if (!template || !template.hash || !template.question || template.inputs.length === 0 || !endTime) {
+    errors.push('value missing template | hash | question | inputs | endTime');
     return false;
   }
 

--- a/packages/augur-tools/src/templates-template.ts
+++ b/packages/augur-tools/src/templates-template.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers';
+import { BigNumber } from 'ethers/utils';
 export const REQUIRED = 'REQUIRED';
 export const CHOICE = 'CHOICE';
 // Market templates
@@ -319,7 +320,7 @@ function isRetiredAutofail(hash:string) {
   return found.autoFail;
 }
 
-export const isTemplateMarket = (title, template: ExtraInfoTemplate, outcomes: string[], longDescription: string, endTime: number, errors: string[] = []) => {
+export const isTemplateMarket = (title, template: ExtraInfoTemplate, outcomes: string[], longDescription: string, endTime: string, errors: string[] = []) => {
   if (!template || !template.hash || !template.question || template.inputs.length === 0) {
     errors.push('value missing template | hash | question | inputs');
     return false;
@@ -348,7 +349,7 @@ export const isTemplateMarket = (title, template: ExtraInfoTemplate, outcomes: s
     }
 
     // check ESTDATETIME isn't after market event expiration
-    if (estimatedDateTimeAfterMarketEndTime(template.inputs, endTime)) {
+    if (estimatedDateTimeAfterMarketEndTime(template.inputs, new BigNumber(endTime).toNumber())) {
       errors.push('estimated schedule date time is after market event expiration endTime');
       return false;
     }

--- a/packages/augur-ui/src/modules/common/validations.ts
+++ b/packages/augur-ui/src/modules/common/validations.ts
@@ -228,7 +228,12 @@ export function checkForUserInputFilled(inputs, endTimeFormatted) {
 
         if (input.userInputObject.endTime === null) {
           validations.setEndTime = 'Choose a date';
-        } else if (endTimeFormatted.timestamp && input.userInputObject.endTime > endTimeFormatted.timestamp) {
+        } else if (
+          endTimeFormatted.timestamp &&
+          input.userInputObject.endTimeFormatted &&
+          input.userInputObject.endTimeFormatted.timestamp >
+            endTimeFormatted.timestamp
+        ) {
           validations.setEndTime = 'Date must be before event expiration time';
         }
 

--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -212,6 +212,7 @@ export const handleMarketCreatedLog = (log: any) => (
   if (isUserDataUpdate) {
     handleAlert(log, CREATEMARKET, false, dispatch, getState);
     dispatch(marketCreationCreated(log.market, log.extraInfo));
+    dispatch(loadMarketsInfo([log.market]));
   }
 };
 


### PR DESCRIPTION
issue was comparing the component (endTime) timestamp of user inputs instead of the full processed timestamp (endTimeFormatted.timestamp) to determine if estimated scheduled start time is after market creation endTime
added in loading the market when its created, in log-handlers. 

<https://github.com/augurproject/augur/issues/5062>