### PR TITLE
Use local variable instead of storage.

### DIFF
--- a/packages/augur-core/source/contracts/reporting/ReputationToken.sol
+++ b/packages/augur-core/source/contracts/reporting/ReputationToken.sol
@@ -34,7 +34,7 @@ contract ReputationToken is VariableSupplyToken, IV2ReputationToken {
         universe = _universe;
         parentUniverse = _parentUniverse;
         warpSync = _augur.lookup("WarpSync");
-        legacyRepToken = IERC20(augur.lookup("LegacyReputationToken"));
+        legacyRepToken = IERC20(_augur.lookup("LegacyReputationToken"));
         erc1820Registry = IERC1820Registry(_erc1820RegistryAddress);
         initialize1820InterfaceImplementations();
     }


### PR DESCRIPTION
Minor code cleanup and inconsequential gas savings.