### PR TITLE
Changes to use a storage variable directly rather than a getter.

### DIFF
--- a/packages/augur-core/source/contracts/reporting/Universe.sol
+++ b/packages/augur-core/source/contracts/reporting/Universe.sol
@@ -643,7 +643,7 @@ contract Universe is IUniverse {
     }
 
     function createMarketInternal(uint256 _endTime, uint256 _feePerCashInAttoCash, IAffiliateValidator _affiliateValidator, uint256 _affiliateFeeDivisor, address _designatedReporterAddress, address _sender, uint256 _numOutcomes, uint256 _numTicks) private returns (IMarket _newMarket) {
-        getReputationToken().trustedUniverseTransfer(_sender, address(marketFactory), getOrCacheMarketRepBond());
+        reputationToken.trustedUniverseTransfer(_sender, address(marketFactory), getOrCacheMarketRepBond());
         _newMarket = marketFactory.createMarket(augur, this, _endTime, _feePerCashInAttoCash, _affiliateValidator, _affiliateFeeDivisor, _designatedReporterAddress, _sender, _numOutcomes, _numTicks);
         markets[address(_newMarket)] = true;
         shareToken.initializeMarket(_newMarket, _numOutcomes + 1, _numTicks); // To account for Invalid


### PR DESCRIPTION
Saves on gas and makes the code a bit more clear by removing a layer of indirection.