### PR TITLE
Minor gas savings on drip.

### DIFF
--- a/packages/augur-core/source/contracts/reporting/Universe.sol
+++ b/packages/augur-core/source/contracts/reporting/Universe.sol
@@ -659,8 +659,7 @@ contract Universe is IUniverse {
     }
 
     function withdrawDaiFromDSR(uint256 _amount) private returns (bool) {
-        daiPot.drip();
-        uint256 _chi = daiPot.chi();
+        uint256 _chi = daiPot.drip();
         uint256 _sDaiAmount = _amount.mul(DAI_ONE) / _chi; // sDai may be lower than the amount needed to retrieve `amount` from the VAT. We cover for this rounding error below
         if (_sDaiAmount.mul(_chi) < _amount.mul(DAI_ONE)) {
             _sDaiAmount += 1;


### PR DESCRIPTION
`Pot.drip()` returns `chi` (this was a last-minute change to Maker contracts before launch).