### PR TITLE
only init Gnosis on AVAILABLE event

### DIFF
--- a/packages/augur-sdk/src/api/Gnosis.ts
+++ b/packages/augur-sdk/src/api/Gnosis.ts
@@ -74,7 +74,7 @@ export class Gnosis {
     for (const s of this.safesToCheck) {
       const status = await this.getGnosisSafeDeploymentStatusViaRelay(s);
       this.augur.setGnosisStatus(status.status);
-      if ([GnosisSafeState.AVAILABLE, GnosisSafeState.CREATED].includes(status.status)) {
+      if (status.status === GnosisSafeState.AVAILABLE) {
         const signerAddress = await this.dependencies.signer.getAddress();
         if (signerAddress === s.owner) {
           this.augur.setGnosisSafeAddress(ethUtil.toChecksumAddress(s.safe));


### PR DESCRIPTION
closes #5096

-Before we were initializing the gnosis safe on the events CREATED/AVAILABLE. This should only happen on AVAILABLE.

## Testing/QA
You should be able to create a new safe without console errors. Your safe should be usable also without having to refresh the page OR logout/login.

