### PR TITLE
Update Events.ts

### DIFF
--- a/packages/augur-sdk/src/api/Events.test.ts
+++ b/packages/augur-sdk/src/api/Events.test.ts
@@ -56,7 +56,7 @@ test("get logs", async () => {
     fakeValueIMadeUp: "ddr3",  // not specified in log and cannot be
   };
   const provider = makeProviderMock({ logs, logValues });
-  const events = new Events(provider, "0x0", "0x0", "0x0");
+  const events = new Events(provider, "0xthere", "0x0", "0x0");
 
   const eventName = "some event name";
   const fromBlock = 0;

--- a/packages/augur-sdk/src/api/Events.ts
+++ b/packages/augur-sdk/src/api/Events.ts
@@ -58,7 +58,13 @@ export class Events {
 
   parseLogs = (logs: Log[]): ParsedLog[] => {
     return logs.map((log) => {
-      const logValues = this.provider.parseLogValues(this.contractAddressToName[log.address], log);
+      const contractName: string|undefined = this.contractAddressToName[log.address];
+      if(typeof contractName === "undefined") {
+        console.log("Could not find contract name for log, check ABI", log);
+        throw new Error(`Recieved a log for an unknown contract at address ${log.address}. Double check that deployment is up to date and new ABIs have been committed.`);
+      }
+      
+      const logValues = this.provider.parseLogValues(contractName, log);
       return Object.assign(
         { name: "" },
         logValues,


### PR DESCRIPTION
Throw detailed error if log's contract isn't known in the local ABI.