### PR TITLE
remove adding non timestamp values in timestamp property

### DIFF
--- a/packages/augur-ui/src/modules/markets/actions/submit-new-market.ts
+++ b/packages/augur-ui/src/modules/markets/actions/submit-new-market.ts
@@ -72,7 +72,7 @@ export function submitNewMarket(
                     i.type === TemplateInputType.DATETIME && !!i.userInputObject
                       ? (i.userInputObject as UserInputDateTime)
                           .endTimeFormatted.timestamp
-                      : i.userInput,
+                      : null,
                 },
               ]
             : p,


### PR DESCRIPTION
remove putting user inputted values in timestamp property on extra info template object. it can be confusing for documentation and to the user