### PR TITLE
relayer fallback - TXs

### DIFF
--- a/packages/augur-sdk/src/Augur.ts
+++ b/packages/augur-sdk/src/Augur.ts
@@ -71,6 +71,7 @@ export class Augur<TProvider extends Provider = Provider> {
   private txAwaitingSigningCallback: TXStatusCallback;
   private txPendingCallback: TXStatusCallback;
   private txFailureCallback: TXStatusCallback;
+  private txRelayerDownCallback: TXStatusCallback;
 
   constructor(
     provider: TProvider,
@@ -285,6 +286,8 @@ export class Augur<TProvider extends Provider = Provider> {
       this.txSuccessCallback = callback;
     } else if (eventName === TXEventName.Failure) {
       this.txFailureCallback = callback;
+    } else if (eventName === TXEventName.RelayerDown) {
+      this.txRelayerDownCallback = callback;
     }
   }
 
@@ -301,6 +304,8 @@ export class Augur<TProvider extends Provider = Provider> {
       this.txSuccessCallback = null;
     } else if (eventName === TXEventName.Failure) {
       this.txFailureCallback = null;
+    } else if (eventName === TXEventName.RelayerDown) {
+      this.txRelayerDownCallback = null;
     }
   }
 
@@ -536,6 +541,16 @@ export class Augur<TProvider extends Provider = Provider> {
             hash,
           } as TXStatus;
           this.txFailureCallback(txn);
+        } else if (
+          status === TransactionStatus.RELAYER_DOWN &&
+          this.txRelayerDownCallback
+        ) {
+          const txn: TXStatus = {
+            transaction,
+            eventName: TXEventName.RelayerDown,
+            hash,
+          } as TXStatus;
+          this.txRelayerDownCallback(txn);
         }
       }
     );

--- a/packages/augur-sdk/src/constants.ts
+++ b/packages/augur-sdk/src/constants.ts
@@ -56,6 +56,7 @@ export enum TXEventName {
   Pending = "Pending",
   Success = "Success",
   Failure = "Failure",
+  RelayerDown = "RelayerDown",
 }
 
 export function isSubscriptionEventName(eventName: string): string | null {

--- a/packages/augur-ui/src/modules/app/actions/init-augur.ts
+++ b/packages/augur-ui/src/modules/app/actions/init-augur.ts
@@ -20,7 +20,7 @@ import {
   ACCOUNT_TYPES,
   NETWORK_NAMES,
   MODAL_LOADING,
-  MODA_WALLET_ERROR,
+  MODAL_WALLET_ERROR,
   MODAL_ACCOUNT_CREATED,
   MODAL_AUGUR_USES_DAI,
   MODAL_BUY_DAI,
@@ -101,7 +101,7 @@ function pollForAccount(
         dispatch(logout());
         dispatch(
           updateModal({
-            type: MODA_WALLET_ERROR,
+            type: MODAL_WALLET_ERROR,
           })
         );
       };

--- a/packages/augur-ui/src/modules/auth/actions/login-with-portis.ts
+++ b/packages/augur-ui/src/modules/auth/actions/login-with-portis.ts
@@ -9,7 +9,7 @@ import {
   ACCOUNT_TYPES,
   PORTIS_API_KEY,
   NETWORK_IDS,
-  MODA_WALLET_ERROR,
+  MODAL_WALLET_ERROR,
 } from 'modules/common/constants';
 import { getNetworkId } from 'modules/contracts/actions/contractCalls';
 import { windowRef } from 'utils/window-ref';
@@ -76,8 +76,8 @@ export const loginWithPortis = (forceRegisterPage = false) => async (
         document.querySelector('.por_portis-container').remove();
         dispatch(
           updateModal({
-            type: MODA_WALLET_ERROR,
-            error: error.toString(),
+            type: MODAL_WALLET_ERROR,
+            error: JSON.stringify(error),
           })
         );
       });

--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -540,7 +540,7 @@ export const MODAL_SIGNUP = 'MODAL_SIGNUP';
 export const MODAL_CONNECT = 'MODAL_CONNECT';
 export const MODAL_LOADING = 'MODAL_LOADING';
 export const MODAL_ACCOUNT_CREATED = 'MODAL_ACCOUNT_CREATED';
-export const MODA_WALLET_ERROR = 'MODA_WALLET_ERROR';
+export const MODAL_WALLET_ERROR = 'MODAL_WALLET_ERROR';
 
 // transactions parameter names
 export const TX_ORDER_ID = '_orderId';

--- a/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
+++ b/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
@@ -22,7 +22,8 @@ import {
   PUBLICCREATEORDER,
   PUBLICCREATEORDERS,
   PUBLICFILLORDER,
-  BUYPARTICIPATIONTOKENS
+  BUYPARTICIPATIONTOKENS,
+  MODAL_WALLET_ERROR,
 } from 'modules/common/constants';
 import { UIOrder, CreateMarketData } from 'modules/types';
 import { convertTransactionOrderToUIOrder } from 'modules/events/actions/transaction-conversions';
@@ -51,24 +52,37 @@ import {
 import { addAlert, updateAlert } from 'modules/alerts/actions/alerts';
 import { getDeconstructedMarketId } from 'modules/create-market/helpers/construct-market-params';
 import { orderCreated } from 'services/analytics/helpers';
+import { updateModal } from 'modules/modal/actions/update-modal';
 
-export const addUpdateTransaction = (txStatus: Events.TXStatus) => (
+export const addUpdateTransaction = (txStatus: Events.TXStatus) => async (
   dispatch: ThunkDispatch<void, any, Action>,
   getState: () => AppState
 ) => {
   const { eventName, transaction, hash } = txStatus;
   if (transaction) {
     const methodCall = transaction.name.toUpperCase();
-    const { blockchain, alerts } = getState();
+    const { blockchain, alerts, loginAccount } = getState();
 
-    if (eventName === TXEventName.Failure) {
+    if (eventName === TXEventName.RelayerDown) {
+      const hasEth = (await loginAccount.meta.signer.provider.getBalance(loginAccount.meta.signer._address)).gt(0);
+      const errorMessage = `${hasEth ? `If you need to make the transaction now transaction costs will be paid in ETH from your ${loginAccount.meta.accountType} wallet.` : `If you need to make the transaction now please add ETH to your ${loginAccount.meta.accountType} wallet: ${loginAccount.meta.signer._address}.`}`;
+      dispatch(updateModal({
+        type: MODAL_WALLET_ERROR,
+        error: errorMessage,
+        title: 'We\'re having trouble processing transactions',
+        heading: 'We\'re currently experiencing a technical difficulty processing transaction fees in Dai. If possible please come back later to process this transaction.',
+      }));
+    }
+
+    if (eventName === TXEventName.Failure || eventName === TXEventName.RelayerDown) {
       const genHash = hash ? hash : generateTxParameterId(transaction.params);
+
       dispatch(
         addAlert({
           id: genHash,
           uniqueId: genHash,
           params: transaction.params,
-          status: eventName,
+          status: TXEventName.Failure,
           timestamp: blockchain.currentAugurTimestamp * 1000,
           name: methodCall,
         })
@@ -132,7 +146,7 @@ export const addUpdateTransaction = (txStatus: Events.TXStatus) => (
             })
           );
         }
-        
+
         break;
       }
       case PUBLICCREATEORDERS: {
@@ -178,6 +192,9 @@ export const addUpdateTransaction = (txStatus: Events.TXStatus) => (
           dispatch(orderCreated(marketId, order));
           dispatch(removePendingOrder(tradeGroupId, marketId));
         }
+        if (eventName === TXEventName.Failure || eventName === TXEventName.RelayerDown) {
+          dispatch(removePendingOrder(tradeGroupId, marketId));
+        }
         break;
       }
       case CREATEMARKET:
@@ -200,7 +217,7 @@ export const addUpdateTransaction = (txStatus: Events.TXStatus) => (
         if (hash && eventName === TXEventName.Success) {
           dispatch(removePendingData(id, CREATE_MARKET));
         }
-        if (hash && eventName === TXEventName.Failure) {
+        if (hash && eventName === TXEventName.Failure || eventName === TXEventName.RelayerDown) {
           // if tx fails, revert hash to generated tx id, for retry
           dispatch(
             updateLiqTransactionParamHash({ txParamHash: hash, txHash: id })

--- a/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
+++ b/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
@@ -65,12 +65,12 @@ export const addUpdateTransaction = (txStatus: Events.TXStatus) => async (
 
     if (eventName === TXEventName.RelayerDown) {
       const hasEth = (await loginAccount.meta.signer.provider.getBalance(loginAccount.meta.signer._address)).gt(0);
-      const errorMessage = `${hasEth ? `If you need to make the transaction now transaction costs will be paid in ETH from your ${loginAccount.meta.accountType} wallet.` : `If you need to make the transaction now please add ETH to your ${loginAccount.meta.accountType} wallet: ${loginAccount.meta.signer._address}.`}`;
+      const errorMessage = `We\'re currently experiencing a technical difficulty processing transaction fees in Dai.\n${hasEth ? `If you need to make the transaction now transaction costs will be paid in ETH from your ${loginAccount.meta.accountType} wallet.` : `If you need to make the transaction now please add ETH to your ${loginAccount.meta.accountType} wallet: ${loginAccount.meta.signer._address}.`}`;
       dispatch(updateModal({
         type: MODAL_WALLET_ERROR,
         error: errorMessage,
-        title: 'We\'re having trouble processing transactions',
-        heading: 'We\'re currently experiencing a technical difficulty processing transaction fees in Dai. If possible please come back later to process this transaction.',
+        showDiscordLink: false,
+        title: 'We\'re having trouble processing transactions!',
       }));
     }
 

--- a/packages/augur-ui/src/modules/events/actions/listen-to-updates.ts
+++ b/packages/augur-ui/src/modules/events/actions/listen-to-updates.ts
@@ -4,7 +4,6 @@ import {
   handleDisputeCrowdsourcerCreatedLog,
   handleDisputeCrowdsourcerRedeemedLog,
   handleDisputeWindowCreatedLog,
-  handleGnosisStateUpdate,
   handleInitialReporterRedeemedLog,
   handleInitialReporterTransferredLog,
   handleInitialReportSubmittedLog,
@@ -21,9 +20,7 @@ import {
   handleParticipationTokensRedeemedLog,
   handleProfitLossChangedLog,
   handleReportingParticipantDisavowedLog,
-  handleSDKReadyEvent,
   handleTokenBalanceChangedLog,
-  handleTokensMintedLog,
   handleTokensTransferredLog,
   handleTradingProceedsClaimedLog,
   handleTxAwaitingSigning,
@@ -31,6 +28,10 @@ import {
   handleTxPending,
   handleTxSuccess,
   handleUniverseForkedLog,
+  handleTxRelayerDown,
+  handleSDKReadyEvent,
+  handleTokensMintedLog,
+  handleGnosisStateUpdate,
 } from 'modules/events/actions/log-handlers';
 import { wrapLogHandler } from 'modules/events/actions/wrap-log-handler';
 import { ThunkDispatch } from 'redux-thunk';
@@ -124,6 +125,7 @@ const EVENTS = {
   [TXEventName.Success]: wrapLogHandler(handleTxSuccess),
   [TXEventName.Pending]: wrapLogHandler(handleTxPending),
   [TXEventName.Failure]: wrapLogHandler(handleTxFailure),
+  [TXEventName.RelayerDown]: wrapLogHandler(handleTxRelayerDown),
 };
 
 export const listenToUpdates = (Augur: Augur<Provider>) => (

--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -33,7 +33,7 @@ import {
   DOINITIALREPORT,
   PUBLICFILLORDER,
   PUBLICTRADE,
-  MODA_WALLET_ERROR,
+  MODAL_WALLET_ERROR,
 } from 'modules/common/constants';
 import { loadAccountReportingHistory } from 'modules/auth/actions/load-account-reporting';
 import { loadDisputeWindow } from 'modules/auth/actions/load-dispute-window';
@@ -171,12 +171,12 @@ export const handleNewBlockLog = (log: Events.NewBlock) => async (
       dispatch(updateAppStatus(GNOSIS_STATUS, status));
       if (appStatus.gnosisStatus !== GnosisSafeState.ERROR && status === GnosisSafeState.ERROR) {
         const hasEth = (await loginAccount.meta.signer.provider.getBalance(loginAccount.meta.signer._address)).gt(0);
-        const errorMessage = `${hasEth ? `If you need to make the transaction now transaction costs will be paid in ETH from your ${loginAccount.meta.accountType} wallet.` : `If you need to make the transaction now please add ETH to your ${loginAccount.meta.accountType} wallet: ${loginAccount.meta.signer._address}.`}`;
+        const errorMessage = `We\'re currently experiencing a technical difficulty processing transaction fees in Dai.\n${hasEth ? `If you need to make the transaction now transaction costs will be paid in ETH from your ${loginAccount.meta.accountType} wallet.` : `If you need to make the transaction now please add ETH to your ${loginAccount.meta.accountType} wallet: ${loginAccount.meta.signer._address}.`}`;
         dispatch(updateModal({
-          type: MODA_WALLET_ERROR,
+          type: MODAL_WALLET_ERROR,
           error: errorMessage,
+          showDiscordLink: false,
           title: 'We\'re having trouble processing transactions',
-          heading: 'We\'re currently experiencing a technical difficulty processing transaction fees in Dai. If possible please come back later to process this transaction.',
         }));
       }
     }

--- a/packages/augur-ui/src/modules/modal/common.tsx
+++ b/packages/augur-ui/src/modules/modal/common.tsx
@@ -271,12 +271,13 @@ export const Title = (props: TitleProps) => (
   </header>
 );
 
-export const Description = (props: DescriptionProps) =>
-  props.description.map((descriptionText: string) => (
+export const Description = (props: DescriptionProps) => {
+  return props.description.toString().split('\n').map((descriptionText: string) => (
     <p key={descriptionText.slice(20).replace(/\s+/g, '-')}>
       {descriptionText}
     </p>
   ));
+}
 
 export const ButtonsRow = (props: ButtonsRowProps) => (
   <div className={Styles.ButtonsRow}>

--- a/packages/augur-ui/src/modules/modal/components/modal-view.tsx
+++ b/packages/augur-ui/src/modules/modal/components/modal-view.tsx
@@ -163,7 +163,7 @@ function selectModal(type, props, closeModal, modal) {
       return <ModalAccountCreated />
     case TYPES.MODAL_AUGUR_USES_DAI:
       return <ModalAugurUsesDai />
-    case TYPES.MODA_WALLET_ERROR:
+    case TYPES.MODAL_WALLET_ERROR:
       return <ModalWalletError />
     case TYPES.MODAL_SCALAR_MARKET:
       return <ModalScalar {...modal} />
@@ -197,7 +197,7 @@ export default class ModalView extends Component<ModalViewProps> {
     window.addEventListener('keydown', this.handleKeyDown);
 
     trackModalViewed(modal.type, {
-      modal: modal.type, 
+      modal: modal.type,
       from: window.location.href
     })
   }

--- a/packages/augur-ui/src/modules/modal/containers/modal-connect.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-connect.ts
@@ -16,7 +16,7 @@ import {
   SIGNIN_LOADING_TEXT_PORTIS,
   SIGNIN_LOADING_TEXT_TORUS,
   SIGNIN_LOADING_TEXT_FORTMATIC,
-  MODA_WALLET_ERROR,
+  MODAL_WALLET_ERROR,
 } from 'modules/common/constants';
 import { loginWithInjectedWeb3 } from 'modules/auth/actions/login-with-injected-web3';
 import { loginWithPortis } from 'modules/auth/actions/login-with-portis';
@@ -53,7 +53,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({
     dispatch(loginWithFortmatic()),
   errorModal: (error) => dispatch(
     updateModal({
-      type: MODA_WALLET_ERROR,
+      type: MODAL_WALLET_ERROR,
       error: error ? JSON.stringify(error) : ''
     })
   ),

--- a/packages/augur-ui/src/modules/modal/containers/modal-signin.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-signin.ts
@@ -21,7 +21,7 @@ import {
   SIGNIN_SIGN_WALLET,
   ONBOARDING_SEEN_KEY,
   MODAL_ACCOUNT_CREATED,
-  MODA_WALLET_ERROR,
+  MODAL_WALLET_ERROR,
 } from 'modules/common/constants';
 import { loginWithInjectedWeb3 } from 'modules/auth/actions/login-with-injected-web3';
 import { loginWithPortis } from 'modules/auth/actions/login-with-portis';
@@ -68,7 +68,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({
     dispatch(loginWithFortmatic()),
   errorModal: () => dispatch(
     updateModal({
-      type: MODA_WALLET_ERROR,
+      type: MODAL_WALLET_ERROR,
     })
   ),
 });

--- a/packages/augur-ui/src/modules/modal/containers/modal-wallet-error.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-wallet-error.ts
@@ -16,10 +16,10 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({
 
 const mergeProps = (sP, dP, oP) => {
   return {
-    title: 'Something went wrong',
+    title: sP.modal.title ? sP.modal.title : 'Something went wrong',
     buttons: [{ text: 'Close', action: () => dP.closeModal() }],
     description: [sP.modal.error ? sP.modal.error : ''],
-    showDiscordLink: true,
+    showDiscordLink: sP.modal.showDiscordLink,
     closeAction: () => dP.closeModal(),
   };
 };

--- a/packages/augur-ui/src/modules/modal/modal.styles.less
+++ b/packages/augur-ui/src/modules/modal/modal.styles.less
@@ -283,7 +283,7 @@ div.Onboarding {
   justify-content: space-between;
   padding: @size-24;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 2fr 1fr;
 
   &.Bright {
     > h1 {

--- a/packages/contract-dependencies-ethers/src/ContractDependenciesEthers.ts
+++ b/packages/contract-dependencies-ethers/src/ContractDependenciesEthers.ts
@@ -26,7 +26,8 @@ export enum TransactionStatus {
   AWAITING_SIGNING,
   PENDING,
   SUCCESS,
-  FAILURE
+  FAILURE,
+  RELAYER_DOWN,
 }
 
 export type TransactionStatusCallback = (transaction: TransactionMetadata, status: TransactionStatus, hash?: string) => void;

--- a/packages/contract-dependencies-gnosis/src/ContractDependenciesGnosis.ts
+++ b/packages/contract-dependencies-gnosis/src/ContractDependenciesGnosis.ts
@@ -8,7 +8,7 @@ import {
   RelayTxEstimateResponse,
 } from '@augurproject/gnosis-relay-api';
 import { BigNumber } from 'bignumber.js';
-import { Transaction } from 'contract-dependencies';
+import { Transaction, TransactionReceipt } from 'contract-dependencies';
 import {
   ContractDependenciesEthers,
   EthersProvider,
@@ -23,6 +23,7 @@ import * as _ from 'lodash';
 const DEFAULT_GAS_PRICE = new BigNumber(10 ** 9);
 const BASE_GAS_ESTIMATE = new BigNumber(75000);
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
+const GWEI_CONVERSION = 1000000000;
 
 export class ContractDependenciesGnosis extends ContractDependenciesEthers {
   useRelay = true;
@@ -65,15 +66,8 @@ export class ContractDependenciesGnosis extends ContractDependenciesEthers {
     this.gnosisSafe = null;
   }
 
-  setSafeAddress(safeAddress: string): void {
-    this.safeAddress = safeAddress;
-    this.gnosisSafe = new ethers.Contract(
-      safeAddress,
-      abi['GnosisSafe'],
-      this.signer
-    );
-
-    this._currentSignRequest = this.gnosisSafe
+  initCurrentSignRequest() {
+    return this.gnosisSafe
       .nonce()
       .then(nonce => ({
         to: '0x0',
@@ -107,6 +101,17 @@ export class ContractDependenciesGnosis extends ContractDependenciesEthers {
       });
   }
 
+  setSafeAddress(safeAddress: string): void {
+    this.safeAddress = safeAddress;
+    this.gnosisSafe = new ethers.Contract(
+      safeAddress,
+      abi['GnosisSafe'],
+      this.signer
+    );
+
+    this._currentSignRequest = this.initCurrentSignRequest();
+  }
+
   setStatus(status: GnosisSafeState): void {
     this.status = status;
   }
@@ -127,6 +132,35 @@ export class ContractDependenciesGnosis extends ContractDependenciesEthers {
     this.gasPrice = gasPrice;
   }
 
+  async submitTransaction(transaction: Transaction<BigNumber>): Promise<TransactionReceipt> {
+    if (!this.signer) throw new Error("Attempting to sign a transaction while not providing a signer");
+    const tx = this.transactionToEthersTransaction(transaction);
+    const txMetadataKey = `0x${transaction.data.substring(10)}`;
+    const txMetadata = this.transactionDataMetaData[txMetadataKey];
+    this.onTransactionStatusChanged(txMetadata, TransactionStatus.AWAITING_SIGNING);
+    let hash = undefined;
+    try {
+      const receipt = await this.sendTransaction(tx, txMetadata);
+      hash = receipt.transactionHash;
+      const status = receipt.status == 1 ? TransactionStatus.SUCCESS : TransactionStatus.FAILURE;
+      this.onTransactionStatusChanged(txMetadata, status, hash);
+      // ethers has `status` on the receipt as optional, even though it isn't and never will be undefined if using a modern network (which this is designed for)
+      return <TransactionReceipt>receipt;
+    } catch (e) {
+      this._currentSignRequest = await this.initCurrentSignRequest();
+
+      if (e === TransactionStatus.RELAYER_DOWN) {
+        this.onTransactionStatusChanged(txMetadata, TransactionStatus.RELAYER_DOWN, hash);
+        throw Error('Relayer down');
+      } else {
+        this.onTransactionStatusChanged(txMetadata, TransactionStatus.FAILURE, hash);
+        throw e;
+      }
+    } finally {
+      delete this.transactionDataMetaData[txMetadataKey];
+    }
+  }
+
   async sendTransaction(
     tx: Transaction<ethers.utils.BigNumber>,
     txMetadata: TransactionMetadata
@@ -136,25 +170,51 @@ export class ContractDependenciesGnosis extends ContractDependenciesEthers {
       return super.sendTransaction(tx, txMetadata);
     }
     let txHash: string;
+
     // If the Relay Service is not being used so we'll execute the TX directly
     const prevTransaction = await this._currentSignRequest;
     const relayTransaction = await this.ethersTransactionToRelayTransaction(tx);
 
-    if (prevTransaction === relayTransaction)
+    if (prevTransaction === relayTransaction) {
       throw new Error('Message signature failed.');
+    }
 
     if (this.useRelay) {
-      txHash = await this.gnosisRelay.execTransaction(relayTransaction);
+      try {
+        txHash = await this.gnosisRelay.execTransaction(relayTransaction);
+      } catch (error) {
+        this.setUseRelay(false);
+        throw TransactionStatus.RELAYER_DOWN;
+      }
     } else {
       txHash = await this.execTransactionDirectly(relayTransaction);
     }
 
-    this.onTransactionStatusChanged(
-      txMetadata,
-      TransactionStatus.PENDING,
-      txHash
-    );
-    const response = await this.provider.getTransaction(txHash);
+    let response = await this.provider.getTransaction(txHash);
+
+    if (response) {
+      this.onTransactionStatusChanged(
+        txMetadata,
+        TransactionStatus.PENDING,
+        txHash
+      );
+
+      return response.wait();
+    }
+
+    // TODO - current worrkaround / explore a better fix
+    // loop getTransaction calls until we get back a response
+    for (let i = 0; i >= 0; i++) {
+      response = await this.provider.getTransaction(txHash);
+      if (response !== null) {
+        this.onTransactionStatusChanged(
+          txMetadata,
+          TransactionStatus.PENDING,
+          txHash
+        );
+        break;
+      }
+    }
     return response.wait();
   }
 
@@ -254,6 +314,15 @@ export class ContractDependenciesGnosis extends ContractDependenciesEthers {
     );
     const v = relayTransaction.signatures[0].v!.toString(16);
     const signatures = `0x${r}${s}${v}`;
+    const gasLimit = new ethers.utils.BigNumber(
+      Number(relayTransaction.safeTxGas).toFixed()
+    ).add(
+      new ethers.utils.BigNumber(Number(relayTransaction.dataGas).toFixed())
+    );
+    const gasPrice = new ethers.utils.BigNumber(
+      this.gasPrice.multipliedBy(GWEI_CONVERSION).toFixed()
+    );
+
     const response = await this.gnosisSafe.execTransaction(
       relayTransaction.to,
       new ethers.utils.BigNumber(Number(relayTransaction.value).toFixed()),
@@ -264,7 +333,11 @@ export class ContractDependenciesGnosis extends ContractDependenciesEthers {
       new ethers.utils.BigNumber(Number(relayTransaction.gasPrice).toFixed()),
       relayTransaction.gasToken,
       relayTransaction.refundReceiver,
-      signatures
+      signatures,
+      {
+        gasLimit,
+        gasPrice,
+      }
     );
     return response.hash;
   }
@@ -307,7 +380,6 @@ export class ContractDependenciesGnosis extends ContractDependenciesEthers {
     const gasPrice = this.gasPrice;
     const gasToken = this.gasToken;
     const refundReceiver = NULL_ADDRESS;
-
     const txHashBytes = await this.gnosisSafe.getTransactionHash(
       to,
       value,

--- a/packages/contract-dependencies-gnosis/src/ContractDependenciesGnosis.ts
+++ b/packages/contract-dependencies-gnosis/src/ContractDependenciesGnosis.ts
@@ -192,29 +192,12 @@ export class ContractDependenciesGnosis extends ContractDependenciesEthers {
 
     let response = await this.provider.getTransaction(txHash);
 
-    if (response) {
-      this.onTransactionStatusChanged(
-        txMetadata,
-        TransactionStatus.PENDING,
-        txHash
-      );
+    this.onTransactionStatusChanged(
+      txMetadata,
+      TransactionStatus.PENDING,
+      txHash
+    );
 
-      return response.wait();
-    }
-
-    // TODO - current worrkaround / explore a better fix
-    // loop getTransaction calls until we get back a response
-    for (let i = 0; i >= 0; i++) {
-      response = await this.provider.getTransaction(txHash);
-      if (response !== null) {
-        this.onTransactionStatusChanged(
-          txMetadata,
-          TransactionStatus.PENDING,
-          txHash
-        );
-        break;
-      }
-    }
     return response.wait();
   }
 


### PR DESCRIPTION
@justinbarry Lets chat before you review, i wanna bring some things to your attention.

<img width="455" alt="Screen Shot 2019-12-10 at 9 24 45 AM" src="https://user-images.githubusercontent.com/1683736/70538427-100eb180-1b30-11ea-8a39-c5170dc8f4e5.png">

#5059 

- If relayer TX fails we will fall back to using regular transactions. The flow will be a) Use signs transactions b) user sends transactions.
- Updated middleware to use gasPrice/gasLimit for non-relayer transactions
- Added transaction event RELAYER_DOWN to notify the UI when to show an informational modal about the service disruption.

# Testing 
1) Run locally and add a broken payload to the Gnosis API for transactions
2) Run locally and in the console run ```AugurSDK.dependencies.setUseRelay(false)```. After that, all transaction will bypass the relayer