### PR TITLE
Fixes reducer method of empty array

### DIFF
--- a/packages/augur-ui/src/modules/reporting/containers/participation-tokens-view.ts
+++ b/packages/augur-ui/src/modules/reporting/containers/participation-tokens-view.ts
@@ -39,7 +39,7 @@ const mapStateToProps = (state: AppState) => {
           const bigAccumulator = createBigNumber(accumulator) || ZERO;
           const bigCurrentValue = createBigNumber(currentValue) || ZERO;
           return bigCurrentValue.plus(bigAccumulator);
-        })
+        }, ZERO)
     : ZERO;
 
   const hasRedeemable = isLoggedIn && pastParticipationTokensPurchased.gt(ZERO);


### PR DESCRIPTION
For some reason I removed the initial value of ZERO from the reducer on the code cleanup. Adding it back up to prevent this error: `Uncaught TypeError: Reduce of empty array with no initial value`.