### PR TITLE
trade-history-updates

### DIFF
--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -876,6 +876,11 @@ export const COLUMN_TYPES = {
   [PLAIN]: PLAIN,
 };
 
+export const BINARY_CATEGORICAL_SHARE_OPTIONS = {
+  decimals: 2,
+  decimalsRounded: 2,
+};
+
 // Login method variables
 export const TREZOR_MANIFEST_EMAIL = 'team@augur.net';
 export const TREZOR_MANIFEST_APPURL = 'https://dev.augur.net';

--- a/packages/augur-ui/src/modules/common/labels.tsx
+++ b/packages/augur-ui/src/modules/common/labels.tsx
@@ -475,22 +475,26 @@ export class HoverValueLabel extends React.Component<
           <span>
             {useFull && value.full}
             {!useFull && (
-              <span>
-                {firstHalfFull}
-                {secondHalfFull && '.'}
-              </span>
-              <span>{secondHalfFull}</span>
+              <>
+                <span>
+                  {firstHalfFull}
+                  {secondHalfFull && '.'}
+                </span>
+                <span>{secondHalfFull}</span>
+              </>
             )}
           </span>
         ) : (
           <span>
             {useFull && value.formatted}
             {!useFull && (
-              <span>
-                {firstHalf}
-                {secondHalf && '.'}
-              </span>
-              <span>{secondHalf} {postfix}</span>
+              <>
+                <span>
+                  {firstHalf}
+                  {secondHalf && '.'}
+                </span>
+                <span>{secondHalf} {postfix}</span>
+              </>
             )}
           </span>
         )}

--- a/packages/augur-ui/src/modules/common/labels.tsx
+++ b/packages/augur-ui/src/modules/common/labels.tsx
@@ -438,11 +438,12 @@ export class HoverValueLabel extends React.Component<
     hover: false,
   };
   render() {
-    if (!this.props.value || this.props.value === null) return <span />;
+    const { value, showDenomination, useFull } = this.props;
+    if (!value || value === null) return <span />;
 
     const expandedValues = formatExpandedValue(
-      this.props.value,
-      this.props.showDenomination,
+      value,
+      showDenomination,
       true,
       '99999'
     );
@@ -472,22 +473,25 @@ export class HoverValueLabel extends React.Component<
       >
         {this.state.hover && postfix.length !== 0 ? (
           <span>
-            <span>
-              {firstHalfFull}
-              {secondHalfFull && '.'}
-            </span>
-            <span>{secondHalfFull}</span>
+            {useFull && value.full}
+            {!useFull && (
+              <span>
+                {firstHalfFull}
+                {secondHalfFull && '.'}
+              </span>
+              <span>{secondHalfFull}</span>
+            )}
           </span>
         ) : (
           <span>
-            <span>
-              {firstHalf}
-              {secondHalf && '.'}
-            </span>
-            <span>
-              {secondHalf}
-              {postfix}
-            </span>
+            {useFull && value.formatted}
+            {!useFull && (
+              <span>
+                {firstHalf}
+                {secondHalf && '.'}
+              </span>
+              <span>{secondHalf} {postfix}</span>
+            )}
           </span>
         )}
       </span>

--- a/packages/augur-ui/src/modules/market-charts/components/order-book/order-book.tsx
+++ b/packages/augur-ui/src/modules/market-charts/components/order-book/order-book.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 import OrderHeader from 'modules/market-charts/components/order-header/order-header';
 import { HoverValueLabel } from 'modules/common/labels';
-import { ASKS, BIDS, BUY, SELL } from 'modules/common/constants';
+import { ASKS, BIDS, BUY, SELL, SCALAR, BINARY_CATEGORICAL_SHARE_OPTIONS } from 'modules/common/constants';
 
 import Styles from 'modules/market-charts/components/order-book/order-book.styles.less';
 import { OutcomeOrderBook } from 'modules/types';
@@ -19,6 +19,7 @@ interface OrderBookSideProps {
   pricePrecision: number;
   setHovers: Function;
   type: string;
+  marketType: string;
   scrollToTop: boolean;
   hoveredSide?: string;
   hoveredOrderIndex?: number;
@@ -71,8 +72,10 @@ class OrderBookSide extends Component<OrderBookSideProps, {}> {
       hoveredOrderIndex,
       setHovers,
       type,
+      marketType,
     } = this.props;
     const isAsks = type === ASKS;
+    const opts = marketType === SCALAR ? {} : BINARY_CATEGORICAL_SHARE_OPTIONS;
 
     const orderBookOrders = isAsks
       ? orderBook.asks || []
@@ -129,7 +132,8 @@ class OrderBookSide extends Component<OrderBookSideProps, {}> {
                 />
               </div>
               <HoverValueLabel
-                value={formatShares(order.shares)}
+                value={formatShares(order.shares, opts)}
+                useFull={true}
                 showEmptyDash={true}
                 showDenomination={false}
               />

--- a/packages/augur-ui/src/modules/market-charts/containers/order-book.ts
+++ b/packages/augur-ui/src/modules/market-charts/containers/order-book.ts
@@ -42,6 +42,7 @@ const mapStateToProps = (state, ownProps) => {
       !isEmpty(cumulativeOrderBook[ASKS]),
     minPrice,
     maxPrice,
+    marketType: market.marketType,
   };
 };
 

--- a/packages/augur-ui/src/modules/market/components/market-trade-history/market-trade-history.styles.less
+++ b/packages/augur-ui/src/modules/market/components/market-trade-history/market-trade-history.styles.less
@@ -15,94 +15,68 @@
     flex-direction: column;
     flex-grow: 1;
     overflow: overlay;
-    overflow-y: auto;
     max-height: 50vh;
   }
 }
 
 .TradeHistoryTable {
-  > ul:first-of-type {
-    background-color: fade(@color-module-background, 70%);
-    color: @color-inactive-text;
-    display: flex;
-    width: 100%;
-    top: 0;
-    z-index: @above-all-content;
+  display: flex;
+  flex-flow: column nowrap;
 
-    > li {
-      display: table-cell;
-      padding-bottom: @size-6;
-      padding-top: @size-6;
-      text-align: right;
-
-      &:first-child {
-        .mono-9-bold;
-
-        padding-left: @size-16;
-        text-align: left;
-        text-transform: uppercase;
-      }
-
-      &:nth-of-type(2) {
-        .mono-9;
-
-        margin: 0 @size-4;
-      }
-
-      &:last-child {
-        .mono-9;
-        
-        padding-right: @size-24;
-      }
-    }
+  &:not(:first-of-type) {
+    border-top: 2px solid @color-dark-grey;
   }
 
-  > ul:not(:first-of-type) {
-    .mono-9;
+  > span {
+    .mono-10-bold;
 
-    background-color: @color-module-background;
-    color: @color-primary-text;
-    display: flex;
-    position: relative;
+    color: fade(@color-secondary-text, 75%);
+    height: 100%;
+    max-height: @size-20;
+    min-height: @size-20;
+    padding: @size-4 @size-8;
+    text-transform: uppercase;
     width: 100%;
+  }
 
-    > li {
-      padding-bottom: @size-6;
-      padding-top: @size-6;
+  > ul {
+    .mono-10-medium;
 
-      &:first-of-type {
-        background-color: @color-positive;
-        width: 1px;
+    align-items: center;
+    height: @size-20;
+    max-height: @size-20;
+    min-height: @size-20;
+    margin-bottom: 1px;
+    border-left: 1px solid @color-positive;
+    width: 100%;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-rows: auto;
+    grid-gap: 0 @size-16;
 
-        &.Neg {
-          background-color: @color-negative;
-        }
+    &.Sell {
+      border-left: 1px solid @color-negative;
+
+      > li:nth-of-type(2) {
+        color: @color-negative;
       }
+    }
 
-      &:first-child {
-        text-align: left;
-        margin-bottom: 1px;
-      }
+    > li:first-of-type {
+      color: @color-primary-text;
+      margin-left: auto;
+      text-align: right;
+    }
 
-      &:nth-child(2) {
-        color: @color-primary-text;
-        flex: 1;
-        justify-content: right;
-        padding-left: @size-10;
-      }
+    > li:nth-of-type(2) {
+      color: @color-positive;
+      text-align: right;
+    }
 
-      &:nth-child(3) {
-        flex: 1;
-        justify-content: right;
-        padding-left: @size-16;
-      }
-
-      &:last-child {
-        color: @color-primary-text;
-        opacity: 0.8;
-        padding-right: @size-16;
-        text-align: right;
-      }
+    > li:last-of-type {
+      color: fade(@color-secondary-text, 80%);
+      text-align: right;
+      padding-right: @size-16;
     }
   }
 }
@@ -115,22 +89,14 @@
   position: relative;
 }
 
-.Buy {
-  color: @color-positive;
-}
-
-.Sell {
-  color: @color-negative;
-}
-
 .Up {
-  border-bottom-color: fade(@color-positive, 50%);
-  border-width: 0 3.5px @size-6;
+  border-bottom-color: fade(@color-secondary-text, 50%);
+  border-width: 0 @size-4 @size-5;
   top: -@size-8;
 }
 
 .Down {
-  border-top-color: fade(@color-negative, 50%);
-  border-width: @size-6 3.5px 0;
+  border-top-color: fade(@color-secondary-text, 50%);
+  border-width: @size-5 @size-4 0;
   top: @size-9
 }

--- a/packages/augur-ui/src/modules/market/components/market-trade-history/market-trade-history.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-trade-history/market-trade-history.tsx
@@ -1,38 +1,42 @@
 /* eslint react/no-array-index-key: 0 */
 
-import React, { Component } from "react";
-import classNames from "classnames";
+import React, { Component } from 'react';
+import classNames from 'classnames';
 
-import { formatShares } from "utils/format-number";
-import { SELL } from "modules/common/constants";
-import { HoverValueLabel } from "modules/common/labels";
-import OrderHeader from "modules/market-charts/components/order-header/order-header";
+import { formatShares } from 'utils/format-number';
+import { SELL, SCALAR, BINARY_CATEGORICAL_SHARE_OPTIONS } from 'modules/common/constants';
+import { HoverValueLabel } from 'modules/common/labels';
+import OrderHeader from 'modules/market-charts/components/order-header/order-header';
 
-import Styles from "modules/market/components/market-trade-history/market-trade-history.styles";
+import Styles from 'modules/market/components/market-trade-history/market-trade-history.styles';
 
 interface MarketTradeHistoryProps {
   groupedTradeHistoryVolume: object;
   groupedTradeHistory: object;
   toggle: Function;
-  extend: boolean;
   hide: boolean;
+  marketType: string;
 }
 
-export default class MarketTradeHistory extends Component<MarketTradeHistoryProps> {
+export default class MarketTradeHistory extends Component<
+  MarketTradeHistoryProps
+> {
   render() {
     const {
       groupedTradeHistory,
       groupedTradeHistoryVolume,
       toggle,
-      extend,
-      hide
+      hide,
+      marketType
     } = this.props;
+
+    const opts = marketType === SCALAR ? {} : BINARY_CATEGORICAL_SHARE_OPTIONS;
 
     return (
       <section className={Styles.TradeHistory}>
         <OrderHeader
           title="Trade History"
-          headers={["quantity", "price", "time"]}
+          headers={['quantity', 'price', 'time']}
           toggle={toggle}
           hide={hide}
         />
@@ -40,44 +44,37 @@ export default class MarketTradeHistory extends Component<MarketTradeHistoryProp
           {groupedTradeHistory &&
             Object.keys(groupedTradeHistory).map((date, index) => (
               <div className={Styles.TradeHistoryTable} key={index}>
-                <ul>
-                  <li>{groupedTradeHistoryVolume[date]} Shares</li>
-                  <li>—</li>
-                  <li>{date}</li>
-                </ul>
-                {groupedTradeHistory[date].map((priceTime, indexJ) => (
-                  <ul key={index + indexJ}>
-                    <li
-                      className={classNames({
-                        [Styles.Neg]: priceTime.type === SELL
-                      })}
-                    />
-                    <li>
-                      <HoverValueLabel
-                        value={formatShares(priceTime.amount)}
-                      />
-                    </li>
-                    <li
-                      className={classNames({
-                        [Styles.Buy]:
-                          priceTime.type !== SELL,
-                        [Styles.Sell]:
-                          priceTime.type === SELL
-                      })}
+                <span>
+                  {`${
+                    formatShares(groupedTradeHistoryVolume[date], opts).full
+                  } - ${date}`}
+                </span>
+                {groupedTradeHistory[date].map((priceTime, indexJ) => {
+                  const isSell = priceTime.type === SELL;
+                  return (
+                    <ul
+                      className={classNames({ [Styles.Sell]: isSell })}
+                      key={index + indexJ}
                     >
-                      {priceTime.price.toFixed(4)}
-                      <span
-                        className={classNames({
-                          [Styles.Up]:
-                            priceTime.type !== SELL,
-                          [Styles.Down]:
-                            priceTime.type === SELL
-                        })}
-                      />
-                    </li>
-                    <li>{priceTime.time}</li>
-                  </ul>
-                ))}
+                      <li>
+                        <HoverValueLabel
+                          value={formatShares(priceTime.amount, opts)}
+                          useFull
+                        />
+                      </li>
+                      <li>
+                        {priceTime.price.toFixed(4)}
+                        <span
+                          className={classNames({
+                            [Styles.Up]: !isSell,
+                            [Styles.Down]: isSell,
+                          })}
+                        />
+                      </li>
+                      <li>{priceTime.time}</li>
+                    </ul>
+                  );
+                })}
               </div>
             ))}
         </div>

--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -660,6 +660,7 @@ export default class MarketView extends Component<
                                   toggle={this.toggleTradeHistory}
                                   extend={extendTradeHistory}
                                   hide={extendOrderBook}
+                                  marketType={market.marketType}
                                 />
                               )}
                             </div>
@@ -988,6 +989,7 @@ export default class MarketView extends Component<
                             outcome={outcomeId}
                             toggle={this.toggleTradeHistory}
                             extend={extendTradeHistory}
+                            marketType={market.marketType}
                             hide={extendOrderBook}
                             tradingTutorial={tradingTutorial}
                             groupedTradeHistory={market.groupedTradeHistory}


### PR DESCRIPTION
updated market trade history component to use new styling, updated order book to display only 2 decimals for binary/categorical market shares

Closes this: https://github.com/augurproject/augur/issues/4707

starts work on this: https://github.com/AugurProject/augur/issues/5035 (want to clarify what needs updating besides order book and trade history)