### PR TITLE
Updates ZeroXExchange mainnet address to v3.

### DIFF
--- a/packages/augur-core/source/libraries/DeployerConfiguration.ts
+++ b/packages/augur-core/source/libraries/DeployerConfiguration.ts
@@ -69,7 +69,7 @@ const EXTERNAL_ADDRESSES: NetworksToExternalAddresses = {
     LegacyReputationToken: "0x1985365e9f78359a9B6AD760e32412f4a445E862",
     GnosisSafe: "0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A",
     ProxyFactory: "0x12302fE9c02ff50939BaAaaf415fc226C078613C",
-    ZeroXExchange: "0x080bf510FCbF18b91105470639e9561022937712",
+    ZeroXExchange: "0x61935cbdd02287b511119ddb11aeb42f1593b7ef",
   },
 };
 


### PR DESCRIPTION
Just in case someone forgets to update this before deployment, better to have latest than an old version that we know is incompatible.

Pulled address from https://github.com/0xProject/0x-monorepo/blob/development/packages/contract-addresses/addresses.json#L4