### PR TITLE
Renames variables to be more accurate.

### DIFF
--- a/packages/augur-core/source/contracts/trading/FillOrder.sol
+++ b/packages/augur-core/source/contracts/trading/FillOrder.sol
@@ -515,8 +515,8 @@ contract FillOrder is Initializable, ReentrancyGuard, IFillOrder {
 
         sellCompleteSets(_tradeData);
 
-        uint256 _amountRemainingFillerWants = _tradeData.filler.sharesToSell.add(_tradeData.filler.sharesToBuy);
-        uint256 _amountFilled = _amountFillerWants.sub(_amountRemainingFillerWants);
+        uint256 _tradeSize = _tradeData.filler.sharesToSell.add(_tradeData.filler.sharesToBuy);
+        uint256 _amountFillerWantsRemaining = _amountFillerWants.sub(_tradeSize);
         if (_tradeData.order.orderId != bytes32(0)) {
             _tradeData.contracts.orders.recordFillOrder(_tradeData.order.orderId, _tradeData.getMakerSharesDepleted(), _tradeData.getMakerTokensDepleted(), _amountFilled);
         }
@@ -529,12 +529,12 @@ contract FillOrder is Initializable, ReentrancyGuard, IFillOrder {
             _tradeData.contracts.profitLoss.adjustTraderProfitForFees(_tradeData.contracts.market, _tradeData.getLongShareBuyerDestination(), _tradeData.order.outcome, _longFees);
             _tradeData.contracts.profitLoss.adjustTraderProfitForFees(_tradeData.contracts.market, _tradeData.getShortShareBuyerDestination(), _tradeData.order.outcome, _shortFees);
         }
-        updateProfitLoss(_tradeData, _amountFilled);
+        updateProfitLoss(_tradeData, _tradeSize);
         if (_tradeData.creator.participantAddress == _tradeData.filler.participantAddress) {
             _tradeData.contracts.profitLoss.recordFrozenFundChange(_tradeData.contracts.universe, _tradeData.contracts.market, _tradeData.creator.participantAddress, _tradeData.order.outcome, -int256(_tokensRefunded));
         }
 
-        return _amountRemainingFillerWants;
+        return _tradeSize;
     }
 
     function sellCompleteSets(Trade.Data memory _tradeData) internal returns (bool) {


### PR DESCRIPTION
I spent a lot of time trying to figure out what this code did because the variable name `_amountRemainingFillerWants` implies something different from what the variable actually contains.  In reality, this value is the min of "number of shares the order filler wants to trade" and "number of shares the order creator wants to trade".  The variable name previously implied that it was the amount that the filler wants only, which isn't true.  It is worth noting that the code `uint256 _amountFilled = _amountFillerWants.sub(_tradeSize);` is now more clearly incorrect, really that variable holds `_amountFillerWantsRemaining`, so it shouldn't be passed to `updateProfitLoss`!  I have fixed this as well.