### PR TITLE
Trivial gas savings and minor clarity improvement.

### DIFF
--- a/packages/augur-core/source/contracts/reporting/RepPriceOracle.sol
+++ b/packages/augur-core/source/contracts/reporting/RepPriceOracle.sol
@@ -106,12 +106,12 @@ contract RepPriceOracle is IRepPriceOracle, Initializable {
 
     function getInitialPrice(IV2ReputationToken _reputationToken) private view returns (uint256) {
         IUniverse _parentUniverse = _reputationToken.getUniverse().getParentUniverse();
-        uint256 _initialPrice = genesisInitialRepPriceinAttoCash;
         if (_parentUniverse != IUniverse(0)) {
             IV2ReputationToken _parentReputationToken = _parentUniverse.getReputationToken();
-            _initialPrice = exchangeData[address(_parentReputationToken)].price;
+            return exchangeData[address(_parentReputationToken)].price;
+        } else {
+            return genesisInitialRepPriceinAttoCash;
         }
-        return _initialPrice;
     }
 
     function getOrCreateUniswapExchange(IV2ReputationToken _reputationToken) public returns (IUniswapV2) {


### PR DESCRIPTION
The primary purpose of this change is to make it a bit more clear to the reader that the price of the parent universe token will be used if a parent universe exists, otherwise the genesis universe price will be used.  As a side effect, I believe we'll save a trivial amount of gas in one of the code paths (but that is inconsequential).