### PR TITLE
Removes unnecessary local variable.

### DIFF
--- a/packages/augur-core/source/contracts/reporting/RepPriceOracle.sol
+++ b/packages/augur-core/source/contracts/reporting/RepPriceOracle.sol
@@ -99,8 +99,7 @@ contract RepPriceOracle is IRepPriceOracle, Initializable {
 
     function initializeUniverse(IV2ReputationToken _reputationToken) private {
         exchangeData[address(_reputationToken)].exchange = getOrCreateUniswapExchange(_reputationToken);
-        uint256 _initialPrice = getInitialPrice(_reputationToken);
-        exchangeData[address(_reputationToken)].price = _initialPrice;
+        exchangeData[address(_reputationToken)].price = getInitialPrice(_reputationToken);
         exchangeData[address(_reputationToken)].blockNumber = block.number;
     }
 


### PR DESCRIPTION
This is a total nitpick and would not be offended if closed with prejudice.  The local variable wasn't adding any clarity, and it wasn't saving any gas, so I removed it to make it epsilon easier to see what this function was doing.