### PR TITLE
fix-module-header-background

### DIFF
--- a/packages/augur-ui/src/modules/market/components/common/module-tabs/module-tabs.style.less
+++ b/packages/augur-ui/src/modules/market/components/common/module-tabs/module-tabs.style.less
@@ -1,13 +1,13 @@
 @import (reference) '~assets/styles/shared';
 
 .Headers {
-  background: @color-dark-grey;
+  background: @color-table-header;
+  border-bottom: 1px solid @color-dark-grey;
   display: flex;
   overflow-x: auto;
   min-height: @size-32;
 
   > ul {
-    border-bottom: 1px solid @color-dark-grey;
     display: flex;
     flex: 1;
     width: @size-40;


### PR DESCRIPTION
fixed the background color for module-headers so that it uses table background instead of dark grey

https://github.com/AugurProject/augur/issues/5030