### PR TITLE
remove-commas-orderbook-tradehistory

### DIFF
--- a/packages/augur-ui/src/modules/market-charts/components/order-book/order-book.tsx
+++ b/packages/augur-ui/src/modules/market-charts/components/order-book/order-book.tsx
@@ -3,7 +3,14 @@ import classNames from 'classnames';
 
 import OrderHeader from 'modules/market-charts/components/order-header/order-header';
 import { HoverValueLabel } from 'modules/common/labels';
-import { ASKS, BIDS, BUY, SELL, SCALAR, BINARY_CATEGORICAL_SHARE_OPTIONS } from 'modules/common/constants';
+import {
+  ASKS,
+  BIDS,
+  BUY,
+  SELL,
+  SCALAR,
+  BINARY_CATEGORICAL_SHARE_OPTIONS,
+} from 'modules/common/constants';
 
 import Styles from 'modules/market-charts/components/order-book/order-book.styles.less';
 import { OutcomeOrderBook } from 'modules/types';
@@ -75,16 +82,22 @@ class OrderBookSide extends Component<OrderBookSideProps, {}> {
       marketType,
     } = this.props;
     const isAsks = type === ASKS;
-    const opts = marketType === SCALAR ? {} : BINARY_CATEGORICAL_SHARE_OPTIONS;
-
+    const opts =
+      marketType === SCALAR
+        ? { removeComma: true }
+        : { ...BINARY_CATEGORICAL_SHARE_OPTIONS, removeComma: true };
     const orderBookOrders = isAsks
       ? orderBook.asks || []
       : orderBook.bids || [];
 
-    const isScrollable = this.side && (orderBookOrders.length * 20) >= this.side.clientHeight;
+    const isScrollable =
+      this.side && orderBookOrders.length * 20 >= this.side.clientHeight;
     return (
       <div
-        className={classNames(Styles.Side, { [Styles.Asks]: isAsks, [Styles.Scrollable]: isScrollable })}
+        className={classNames(Styles.Side, {
+          [Styles.Asks]: isAsks,
+          [Styles.Scrollable]: isScrollable,
+        })}
         ref={side => {
           this.side = side;
         }}
@@ -106,6 +119,7 @@ class OrderBookSide extends Component<OrderBookSideProps, {}> {
               hoveredSide === BIDS &&
               i < hoveredOrderIndex);
           const isHovered = i === hoveredOrderIndex && hoveredSide === type;
+
           return (
             <div
               key={order.cumulativeShares + i}

--- a/packages/augur-ui/src/modules/market/components/market-trade-history/market-trade-history.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-trade-history/market-trade-history.tsx
@@ -4,7 +4,11 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 
 import { formatShares } from 'utils/format-number';
-import { SELL, SCALAR, BINARY_CATEGORICAL_SHARE_OPTIONS } from 'modules/common/constants';
+import {
+  SELL,
+  SCALAR,
+  BINARY_CATEGORICAL_SHARE_OPTIONS,
+} from 'modules/common/constants';
 import { HoverValueLabel } from 'modules/common/labels';
 import OrderHeader from 'modules/market-charts/components/order-header/order-header';
 
@@ -27,10 +31,13 @@ export default class MarketTradeHistory extends Component<
       groupedTradeHistoryVolume,
       toggle,
       hide,
-      marketType
+      marketType,
     } = this.props;
 
-    const opts = marketType === SCALAR ? {} : BINARY_CATEGORICAL_SHARE_OPTIONS;
+    const opts =
+      marketType === SCALAR
+        ? { removeComma: true }
+        : { ...BINARY_CATEGORICAL_SHARE_OPTIONS, removeComma: true };
 
     return (
       <section className={Styles.TradeHistory}>

--- a/packages/augur-ui/src/modules/types.ts
+++ b/packages/augur-ui/src/modules/types.ts
@@ -174,6 +174,7 @@ export interface FormattedNumberOptions {
   minimized?: boolean;
   blankZero?: boolean;
   bigUnitPostfix?: boolean;
+  removeComma?: boolean;
 }
 
 export interface CreateMarketData {

--- a/packages/augur-ui/src/utils/add-commas-to-number.ts
+++ b/packages/augur-ui/src/utils/add-commas-to-number.ts
@@ -1,8 +1,8 @@
-export default function(num: number | string): string {
+export default function(num: number | string, removeComma: boolean = false): string {
   let sides: Array<string> = [];
 
   sides = num.toString().split(".");
-  sides[0] = sides[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  sides[0] = removeComma ? sides[0] : sides[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 
   return sides.join(".");
 }

--- a/packages/augur-ui/src/utils/format-number.ts
+++ b/packages/augur-ui/src/utils/format-number.ts
@@ -361,6 +361,7 @@ export function formatNumber(
     positiveSign,
     zeroStyled,
     blankZero,
+    removeComma = false,
   } = opts;
 
   decimals = decimals || 0;
@@ -428,7 +429,7 @@ export function formatNumber(
     const zeroFixed = ZERO.toFixed(USUAL_NUMBER_DECIMAL_PLACES);
 
     if (bigUnitPostfix && !formatSigFig) {
-      o.formatted = addBigUnitPostfix(value, o.formattedValue);
+      o.formatted = addBigUnitPostfix(value, o.formattedValue, removeComma);
     } else if (formatSigFig) {
       // for numbers smaller than the set number of decimals - ie ones with scientific notation
       let formatted = value.toFixed(decimals || USUAL_NUMBER_DECIMAL_PLACES);
@@ -449,7 +450,7 @@ export function formatNumber(
       }
       o.formatted = formatted;
     } else {
-      o.formatted = addCommas(o.formattedValue);
+      o.formatted = addCommas(o.formattedValue, removeComma);
     }
     o.fullPrecision = value.toFixed();
     o.roundedValue = value
@@ -457,9 +458,9 @@ export function formatNumber(
       .integerValue(roundingMode)
       .dividedBy(decimalsRoundedValue);
     o.roundedFormatted = bigUnitPostfix
-      ? addBigUnitPostfix(value, o.roundedValue.toFixed(decimalsRounded))
-      : addCommas(o.roundedValue.toFixed(decimalsRounded));
-    o.minimized = addCommas(encodeNumberAsBase10String(o.formattedValue));
+      ? addBigUnitPostfix(value, o.roundedValue.toFixed(decimalsRounded), removeComma)
+      : addCommas(o.roundedValue.toFixed(decimalsRounded), removeComma);
+    o.minimized = addCommas(encodeNumberAsBase10String(o.formattedValue), removeComma);
     o.rounded = encodeNumberAsBase10String(o.roundedValue);
     o.formattedValue = encodeNumberAsJSNumber(o.formattedValue, false);
     o.roundedValue = o.roundedValue;
@@ -491,7 +492,7 @@ export function formatNumber(
   return o;
 }
 
-function addBigUnitPostfix(value, formattedValue) {
+function addBigUnitPostfix(value, formattedValue, removeComma = false) {
   let postfixed;
   if (value.gt(createBigNumber('1000000000000', 10))) {
     postfixed = '> 1T';
@@ -504,7 +505,7 @@ function addBigUnitPostfix(value, formattedValue) {
   } else if (value.gt(createBigNumber('10000', 10))) {
     postfixed = value.dividedBy(createBigNumber('1000', 10)).toFixed(0) + 'K';
   } else {
-    postfixed = addCommas(formattedValue);
+    postfixed = addCommas(formattedValue, removeComma);
   }
   return postfixed;
 }


### PR DESCRIPTION
removed commas for the trade history and order book. did this by adding a new option to format-number called `removeComma` which defaults to false.
https://github.com/AugurProject/augur/issues/5271