### PR TITLE
Removes shadowed variable.

### DIFF
--- a/packages/augur-tools/src/flash/generate-templates.ts
+++ b/packages/augur-tools/src/flash/generate-templates.ts
@@ -217,11 +217,6 @@ function getValidationValues(input: TemplateInput) {
   }
 }
 
-interface SearchReplace {
-  find: RegExp;
-  rep: string;
-}
-
 const specialCharacters: SearchReplace[] = [
   {
     find: /\(/g,

--- a/packages/augur-tools/src/flash/generate-templates.ts
+++ b/packages/augur-tools/src/flash/generate-templates.ts
@@ -217,7 +217,7 @@ function getValidationValues(input: TemplateInput) {
   }
 }
 
-const specialCharacters: SearchReplace[] = [
+const specialCharacters = [
   {
     find: /\(/g,
     rep: `\\(`,

--- a/packages/augur-tools/src/flash/generate-templates.ts
+++ b/packages/augur-tools/src/flash/generate-templates.ts
@@ -239,11 +239,10 @@ const specialCharacters: SearchReplace[] = [
     find: /\//g,
     rep: `\\/`,
   },
-];
+] as const;
 
 function escapeSpecialCharacters(value: string) {
   let replacementValue = value;
-  let i: SearchReplace = null;
   specialCharacters.forEach(i => {
     replacementValue = replacementValue.replace(i.find, i.rep);
   });


### PR DESCRIPTION
The `i` in the lambda is a local function parameter, which will shadow the outer parameter.  Also, the outer parameter wasn't used.

Made `specialCharacters` `as const` so that the `i` is strongly typed in the Lambda.