### PR TITLE
Add 32 character input limits when creating market outcomes.

### DIFF
--- a/packages/augur-ui/src/modules/common/form.tsx
+++ b/packages/augur-ui/src/modules/common/form.tsx
@@ -81,6 +81,7 @@ interface TextInputProps {
   placeholder?: string;
   onChange: Function;
   value?: string;
+  maxLength?: string;
   trailingLabel?: string;
   innerLabel?: string;
   autoCompleteList?: SortedGroup[];
@@ -1308,6 +1309,7 @@ export class TextInput extends React.Component<TextInputProps, TextInputState> {
       type,
       trailingLabel,
       innerLabel,
+      maxLength,
     } = this.props;
     const { autoCompleteList = [] } = this.props;
     const { showList } = this.state;
@@ -1336,6 +1338,7 @@ export class TextInput extends React.Component<TextInputProps, TextInputState> {
                 onFocus={() => this.toggleList()}
                 placeholder={placeholder}
                 disabled={disabled}
+                maxLength={maxLength}
               />
               {innerLabel && <span className={Styles.Inner}>{innerLabel}</span>}
               <div

--- a/packages/augur-ui/src/modules/create-market/components/common.tsx
+++ b/packages/augur-ui/src/modules/create-market/components/common.tsx
@@ -572,6 +572,7 @@ export const NumberedInput = ({
           onChange={value => onChange(value, number)}
           value={value}
           placeholder={placeholder}
+          maxLength="32"
           errorMessage={errorMessage}
         />
         {removable && <button onClick={e => onRemove(number)}>{XIcon}</button>}


### PR DESCRIPTION
## Description

The market creation inputs allowed users to add more than 32 characters. This adds the maxLength prop to the common/TextInput, and uses it in the NumberedInput component.

## Issue
#5230