### PR TITLE
Use "Football" instead of "Soccer" in market templates.

### DIFF
--- a/packages/augur-tools/src/templates-source.ts
+++ b/packages/augur-tools/src/templates-source.ts
@@ -1197,8 +1197,8 @@ export const TEMPLATES = {
             templates: [
               {
                 marketType: CATEGORICAL,
-                question: `Men's Soccer: Which team will win: [0] vs. [1]?`,
-                example: `Men's Soccer: Which team will win: Real Madrid vs. Manchester United?\nEstimated schedule start time: Sept 19, 2019 8:20 pm EST`,
+                question: `Men's Football (Soccer): Which team will win: [0] vs. [1]?`,
+                example: `Men's Football (Soccer): Which team will win: Real Madrid vs. Manchester United?\nEstimated schedule start time: Sept 19, 2019 8:20 pm EST`,
                 inputs: [
                   {
                     id: 0,
@@ -1242,8 +1242,8 @@ export const TEMPLATES = {
               },
               {
                 marketType: CATEGORICAL,
-                question: `Men's Soccer (Point Spread): [0] to win by more than [1].5 goals over [2]?`,
-                example: `Men's Soccer (Point Spread): Real Madrid to win by more than 1.5 goals over Manchester United?\nEstimated schedule start time: Sept 19, 2019 1:00 pm EST`,
+                question: `Men's Football (Soccer) (Point Spread): [0] to win by more than [1].5 goals over [2]?`,
+                example: `Men's Football (Soccer) (Point Spread): Real Madrid to win by more than 1.5 goals over Manchester United?\nEstimated schedule start time: Sept 19, 2019 1:00 pm EST`,
                 inputs: [
                   {
                     id: 0,
@@ -1295,8 +1295,8 @@ export const TEMPLATES = {
               },
               {
                 marketType: CATEGORICAL,
-                question: `Men's Soccer (O/U): [0] vs. [1]: Total goals scored; Over/Under [2].5?`,
-                example: `Men's Soccer (O/U): Real Madrid vs. Manchester United: Total goals scored Over/Under 4.5?\nEstimated schedule start time: Sept 19, 2019 1:00 pm EST`,
+                question: `Men's Football (Soccer) (O/U): [0] vs. [1]: Total goals scored; Over/Under [2].5?`,
+                example: `Men's Football (Soccer) (O/U): Real Madrid vs. Manchester United: Total goals scored Over/Under 4.5?\nEstimated schedule start time: Sept 19, 2019 1:00 pm EST`,
                 inputs: [
                   {
                     id: 0,
@@ -1352,8 +1352,8 @@ export const TEMPLATES = {
             templates: [
               {
                 marketType: CATEGORICAL,
-                question: `Women's Soccer: Which team will win: [0] vs. [1]?`,
-                example: `Women's Soccer: Which team will win: Real Madrid vs. Manchester United?\nEstimated schedule start time: Sept 19, 2019 8:20 pm EST`,
+                question: `Women's Football (Soccer): Which team will win: [0] vs. [1]?`,
+                example: `Women's Football (Soccer): Which team will win: Real Madrid vs. Manchester United?\nEstimated schedule start time: Sept 19, 2019 8:20 pm EST`,
                 inputs: [
                   {
                     id: 0,
@@ -1397,8 +1397,8 @@ export const TEMPLATES = {
               },
               {
                 marketType: CATEGORICAL,
-                question: `Women's Soccer (Point Spread): [0] to win by more than [1].5 goals over [2]?`,
-                example: `Women's Soccer (Point Spread): Real Madrid to win by more than 1.5 goals over Manchester United?\nEstimated schedule start time: Sept 19, 2019 1:00 pm EST`,
+                question: `Women's Football (Soccer) (Point Spread): [0] to win by more than [1].5 goals over [2]?`,
+                example: `Women's Football (Soccer) (Point Spread): Real Madrid to win by more than 1.5 goals over Manchester United?\nEstimated schedule start time: Sept 19, 2019 1:00 pm EST`,
                 inputs: [
                   {
                     id: 0,
@@ -1450,8 +1450,8 @@ export const TEMPLATES = {
               },
               {
                 marketType: CATEGORICAL,
-                question: `Women's Soccer (O/U): [0] vs. [1]: Total goals scored; Over/Under [2].5?`,
-                example: `Women's Soccer (O/U): Real Madrid vs. Manchester United: Total goals scored Over/Under 4.5?\nEstimated schedule start time: Sept 19, 2019 1:00 pm EST`,
+                question: `Women's Football (Soccer) (O/U): [0] vs. [1]: Total goals scored; Over/Under [2].5?`,
+                example: `Women's Football (Soccer) (O/U): Real Madrid vs. Manchester United: Total goals scored Over/Under 4.5?\nEstimated schedule start time: Sept 19, 2019 1:00 pm EST`,
                 inputs: [
                   {
                     id: 0,

--- a/packages/augur-tools/src/templates-template.ts
+++ b/packages/augur-tools/src/templates-template.ts
@@ -14,7 +14,7 @@ export const USDT = 'USDT';
 export const EUR = 'EUR';
 
 // Market Subtemplates
-export const SOCCER = 'Soccer';
+export const SOCCER = 'Football (Soccer)';
 export const AMERICAN_FOOTBALL = 'American Football';
 export const BASEBALL = 'Baseball';
 export const GOLF = 'Golf';

--- a/packages/augur-ui/src/modules/create-market/set-categories.ts
+++ b/packages/augur-ui/src/modules/create-market/set-categories.ts
@@ -8,8 +8,8 @@ export const setCategories: SortedGroup[] = [
     label: 'Sports',
     subGroup: [
       {
-        value: 'Soccer',
-        label: 'Soccer',
+        value: 'Football (Soccer)',
+        label: 'Football (Soccer)',
         subGroup: [
           { value: 'Copa America', label: 'Copa America' },
           { value: 'Africa Cup of Nations', label: 'Africa Cup of Nations' },


### PR DESCRIPTION
## Description

Removes references of `Soccer` in the templates to `Football (Soccer)`.

## Issue
#5257 