### PR TITLE
Migrate REP button to new styling in side-nav and top-nav

### DIFF
--- a/packages/augur-ui/src/modules/app/components/side-nav/side-nav.styles.less
+++ b/packages/augur-ui/src/modules/app/components/side-nav/side-nav.styles.less
@@ -49,6 +49,34 @@
   }
 }
 
+.SideNavMigrateRep {
+  button {
+    .mono-10-bold;
+    text-transform: uppercase;
+  }
+}
+
+.SideNavMigrateTooltipHint {
+  display: inline;
+  position: relative;
+  top: 0.2rem;
+  left: 0.3rem;
+
+  > svg {
+    max-height: @size-16;
+    max-width: @size-16;
+
+    > circle {
+      fill: @color-secondary-action;
+      stroke: @color-secondary-action-outline;
+    }
+
+    > path {
+      fill: @color-primary-text;
+    }
+  }
+}
+
 .SideNav__container {
   background: @color-module-background;
   position: absolute;

--- a/packages/augur-ui/src/modules/app/components/side-nav/side-nav.tsx
+++ b/packages/augur-ui/src/modules/app/components/side-nav/side-nav.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactTooltip from 'react-tooltip';
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 
@@ -9,8 +10,9 @@ import { LogoutIcon } from 'modules/common/icons';
 import { NavMenuItem } from 'modules/types';
 import Styles from 'modules/app/components/side-nav/side-nav.styles.less';
 import HelpResources from 'modules/app/containers/help-resources';
-import { SecondaryButton, PrimaryButton } from 'modules/common/buttons';
-import { Chevron } from 'modules/common/icons';
+import { SecondaryButton } from 'modules/common/buttons';
+import TooltipStyles from 'modules/common/tooltip.styles.less';
+import { helpIcon, Chevron } from 'modules/common/icons';
 
 interface SideNavProps {
   defaultMobileClick: Function;
@@ -78,10 +80,39 @@ const SideNav = ({
             ))}
 
             <div>
-              {showMigrateRepButton && <PrimaryButton
-                text='Migrate V1 to V2 REP'
-                action={() => migrateV1Rep()}
-              />}
+              {showMigrateRepButton && (
+                <span className={Styles.SideNavMigrateRep}>
+                  <SecondaryButton
+                    text='Migrate V1 to V2 REP'
+                    action={() => migrateV1Rep()}
+                  />
+                </span>
+              )}
+
+              {showMigrateRepButton && (
+                <span>
+                  <label
+                    className={classNames(Styles.SideNavMigrateTooltipHint)}
+                    data-tip
+                    data-for={'migrateRep'}
+                  >
+                    {helpIcon}
+                  </label>
+                  <ReactTooltip
+                    id={'migrateRep'}
+                    className={TooltipStyles.Tooltip}
+                    effect="solid"
+                    place="top"
+                    type="light"
+                  >
+                    <p>
+                      {
+                        'You have V1 REP in your wallet. Migrate it to V2 REP to use it in Augur V2'
+                      }
+                    </p>
+                  </ReactTooltip>
+                </span>
+              )}
             </div>
           </ul>
 

--- a/packages/augur-ui/src/modules/app/components/side-nav/side-nav.tsx
+++ b/packages/augur-ui/src/modules/app/components/side-nav/side-nav.tsx
@@ -81,13 +81,11 @@ const SideNav = ({
 
             <div>
               {showMigrateRepButton && (
-                <span>
-                  <span className={Styles.SideNavMigrateRep}>
-                    <SecondaryButton
-                      text='Migrate V1 to V2 REP'
-                      action={() => migrateV1Rep()}
-                    />
-                  </span>
+                <span className={Styles.SideNavMigrateRep}>
+                  <SecondaryButton
+                    text='Migrate V1 to V2 REP'
+                    action={() => migrateV1Rep()}
+                  />
                   <label
                     className={classNames(Styles.SideNavMigrateTooltipHint)}
                     data-tip

--- a/packages/augur-ui/src/modules/app/components/side-nav/side-nav.tsx
+++ b/packages/augur-ui/src/modules/app/components/side-nav/side-nav.tsx
@@ -81,16 +81,13 @@ const SideNav = ({
 
             <div>
               {showMigrateRepButton && (
-                <span className={Styles.SideNavMigrateRep}>
-                  <SecondaryButton
-                    text='Migrate V1 to V2 REP'
-                    action={() => migrateV1Rep()}
-                  />
-                </span>
-              )}
-
-              {showMigrateRepButton && (
                 <span>
+                  <span className={Styles.SideNavMigrateRep}>
+                    <SecondaryButton
+                      text='Migrate V1 to V2 REP'
+                      action={() => migrateV1Rep()}
+                    />
+                  </span>
                   <label
                     className={classNames(Styles.SideNavMigrateTooltipHint)}
                     data-tip

--- a/packages/augur-ui/src/modules/app/components/top-nav/top-nav.styles.less
+++ b/packages/augur-ui/src/modules/app/components/top-nav/top-nav.styles.less
@@ -68,8 +68,10 @@
     }
 
     > .MigrateRep {
-      background: @color-primary-action;
-      color: @color-dark-grey;
+      button {
+        .mono-10-bold;
+        text-transform: uppercase;
+      }
       position: absolute;
       right: calc(96px + @size-48);
     }

--- a/packages/augur-ui/src/modules/app/components/top-nav/top-nav.tsx
+++ b/packages/augur-ui/src/modules/app/components/top-nav/top-nav.tsx
@@ -5,7 +5,7 @@ import TooltipStyles from 'modules/common/tooltip.styles.less';
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import makePath from 'modules/routes/helpers/make-path';
-import { SecondaryButton, PrimaryButton, ExternalLinkText } from 'modules/common/buttons';
+import { SecondaryButton, ExternalLinkText } from 'modules/common/buttons';
 import { GlobalChat } from 'modules/global-chat/components/global-chat';
 
 import Styles from 'modules/app/components/top-nav/top-nav.styles.less';
@@ -74,7 +74,7 @@ const TopNav = ({
         })}
         {showMigrateRepButton && (
           <div className={Styles.MigrateRep}>
-            <PrimaryButton
+            <SecondaryButton
               text="Migrate V1 to V2 REP"
               action={() => migrateV1Rep()}
             />


### PR DESCRIPTION
## Description

Adds new button styling to the Migrate REP button.

## Issue

AugurProject/augur#5234

## Testing

- Make sure if you're trying this out to change the `showMigrateRepButton` to truthy in the files. I'm not sure how else to set up the state where you need to migrate in a local dev mode.

## Screenshots

### Top-Nav
Note here the condition where you need to add REP and migrate it shouldn't ever be reached. I just tried to get a screengrab of it working so you could technically ignore the "Add Funds" button and spacing at the moment.
![Screenshot from 2020-01-06 20-26-47](https://user-images.githubusercontent.com/1673206/71863920-5e31b900-30cc-11ea-8ab8-edf3f5ccf7b1.png)

### Side-Nav
![Screenshot from 2020-01-06 21-30-53](https://user-images.githubusercontent.com/1673206/71863938-6d186b80-30cc-11ea-8714-7cf450daae65.png)
