### PR TITLE
Adds .editorconfig for augur-core.

### DIFF
--- a/packages/augur-core/.editorconfig
+++ b/packages/augur-core/.editorconfig
@@ -1,0 +1,2 @@
+[*.ts]
+indent_size = 4


### PR DESCRIPTION
This will supercede the repo-wide .editorconfig that sets `indent_size` for `.ts` files to `2`.

The alternative solution would be to reformat all TS files in core, which seems like the wrong solution for me to undertake.