### PR TITLE
Fixes incorrect indentation in `GnosisSafe`.

### DIFF
--- a/packages/augur-core/source/contracts/GnosisSafe.sol
+++ b/packages/augur-core/source/contracts/GnosisSafe.sol
@@ -368,12 +368,12 @@ contract OwnerManager is SelfAuthorized {
 
 
 contract MasterCopy is SelfAuthorized {
-  // masterCopy always needs to be first declared variable, to ensure that it is at the same location as in the Proxy contract.
-  // It should also always be ensured that the address is stored alone (uses a full word)
+    // masterCopy always needs to be first declared variable, to ensure that it is at the same location as in the Proxy contract.
+    // It should also always be ensured that the address is stored alone (uses a full word)
     address public masterCopy;
 
-  /// @dev Allows to upgrade the contract. This can only be done via a Safe transaction.
-  /// @param _masterCopy New contract address.
+    /// @dev Allows to upgrade the contract. This can only be done via a Safe transaction.
+    /// @param _masterCopy New contract address.
     function changeMasterCopy(address _masterCopy)
         public
         authorized


### PR DESCRIPTION
This is a quality of life change since my editor chokes when trying to code fold indentation that is not consistent.

I believe I submitted an upstream PR for this as well.