### PR TITLE
Adds NodeJS 12 to supported engines.

### DIFF
--- a/packages/augur-ui/package.json
+++ b/packages/augur-ui/package.json
@@ -5,7 +5,7 @@
   "author": "The Augur Developers <team@augur.net>",
   "license": "AAL",
   "engines": {
-    "node": "8 || 9 || 10"
+    "node": "8 || 9 || 10 || 12"
   },
   "main": "src/index.js",
   "repository": {


### PR DESCRIPTION
I'm not sure if this is intentionally left out, but the fact that node 8 (ancient) and node 9 (non-stable) is still in the list suggests this was just an oversight.