### PR TITLE
Fixed the user rep box overlapping container

### DIFF
--- a/packages/augur-ui/src/modules/reporting/common.styles.less
+++ b/packages/augur-ui/src/modules/reporting/common.styles.less
@@ -195,13 +195,13 @@ div.ReportingSubheaders {
         height: @size-12;
         margin-left: @size-4;
         width: @size-12;
-  
+
         > circle {
           fill: @color-secondary-action;
           stroke: @color-secondary-action-outline;
           stroke-width: 1.5;
         }
-  
+
         > path {
           fill: @color-inactive-text;
         }
@@ -283,14 +283,17 @@ div.ReportingSubheaders {
     bottom: 0;
     color: @color-primary-text;
     left: 0;
-    margin: @size-4;
+    margin: 0;
     position: absolute;
-    padding: 4rem;
+    padding: 0 4rem;
     right: 0;
     text-align: center;
     text-transform: capitalize;
     top: 0;
     z-index: @default-z-index;
+    display: flex;
+    align-items: center;
+    height: 100%;
 
     @media @breakpoint-mobile {
       .text-16;


### PR DESCRIPTION
This fixes the user rep box when the user is not logged in. Currently it's overlapping the container.

Current
![Captura de Tela 2020-01-07 às 12 00 00](https://user-images.githubusercontent.com/10351013/71904644-434f5b00-3145-11ea-83b2-5a384f6061dd.png)

Fixed
![Captura de Tela 2020-01-07 às 11 59 54](https://user-images.githubusercontent.com/10351013/71904643-434f5b00-3145-11ea-852c-b3b0bb4cce04.png)



