### PR TITLE
reverting order processing when trading

### DIFF
--- a/packages/augur-tools/src/flash/data/canned-markets.ts
+++ b/packages/augur-tools/src/flash/data/canned-markets.ts
@@ -20,17 +20,25 @@ export interface OrderBook {
   [outcome: string]: BuySell;
 }
 
-const singleOutcomeAsks: AskBid[] = [
+export const singleOutcomeAsks: AskBid[] = [
   { shares: "100.00", price: "0.31" },
   { shares: "200.00", price: "0.35" },
   { shares: "300.00", price: "0.40" },
 ];
-const singleOutcomeBids: AskBid[] = [
+export const singleOutcomeBids: AskBid[] = [
   { shares: "100.00", price: "0.30" },
   { shares: "200.00", price: "0.25" },
   { shares: "300.00", price: "0.19" },
 ];
 const yesNoOrderBook: OrderBook = {
+  0: {
+    buy: singleOutcomeBids,
+    sell: singleOutcomeAsks,
+  },
+  1: {
+    buy: singleOutcomeBids,
+    sell: singleOutcomeAsks,
+  },
   2: {
     buy: singleOutcomeBids,
     sell: singleOutcomeAsks,

--- a/packages/augur-ui/src/modules/alerts/actions/set-alert-text.ts
+++ b/packages/augur-ui/src/modules/alerts/actions/set-alert-text.ts
@@ -189,9 +189,7 @@ export default function setAlertText(alert: any, callback: Function) {
           alert.description = alert.params.marketInfo.description;
           alert.details = `${
             toCapitalizeCase(alert.params.orderType)
-          } ${formatShares(alert.params.amount).formatted} of ${
-            formatShares(alert.params.amount).formatted
-          } of ${alert.params.outcome} @ ${
+          } ${formatShares(alert.params.amount).formatted} of ${alert.params.outcome} @ ${
             formatDai(alert.params.price).formatted
           }`;
         } else {
@@ -238,10 +236,8 @@ export default function setAlertText(alert: any, callback: Function) {
                 alert.status,
                 marketInfo
               );
-              alert.details = `${orderType}  ${
+              alert.details = `${orderType} ${
                 formatShares(amount).formatted
-              } of ${
-                formatShares(originalQuantity).formatted
               } of ${outcomeDescription} @ ${formatDai(price).formatted}`;
             })
           );
@@ -250,10 +246,7 @@ export default function setAlertText(alert: any, callback: Function) {
               const marketInfo = selectMarket(marketId);
               if (marketInfo === null) return;
               const { loginAccount, userOpenOrders } = getState() as AppState;
-              let originalQuantity = convertOnChainAmountToDisplayAmount(
-                createBigNumber(alert.params.amountFilled),
-                createBigNumber(marketInfo.tickSize)
-              );
+              let originalQuantity = null;
               let updatedOrderType = alert.params.orderType;
               if (
                 alert.params.orderCreator.toUpperCase() ===
@@ -290,8 +283,7 @@ export default function setAlertText(alert: any, callback: Function) {
               );
               alert.details = `${orderType}  ${
                 formatShares(amount).formatted
-              } of ${
-                formatShares(originalQuantity).formatted
+              } ${ originalQuantity ? ` of ${formatShares(originalQuantity).formatted}` : ''
               } of ${outcomeDescription} @ ${formatDai(price).formatted}`;
             })
           );

--- a/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
+++ b/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
@@ -37,7 +37,6 @@ import {
 } from 'modules/orders/actions/pending-orders-management';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
-import { AppState } from 'store';
 import { Events, Getters, TXEventName } from '@augurproject/sdk';
 import {
   addPendingData,

--- a/packages/augur-ui/src/modules/trades/actions/update-trade-cost-shares.ts
+++ b/packages/augur-ui/src/modules/trades/actions/update-trade-cost-shares.ts
@@ -167,7 +167,21 @@ async function runSimulateTrade(
   const kycToken = undefined; // TODO: figure out how kyc tokens are going to be handled
   const doNotCreateOrders = false; // TODO: this needs to be passed from order form
 
-  const userShares = new BigNumber(marketOutcomeShares[outcomeId] || 0);
+  let userShares = createBigNumber(marketOutcomeShares[outcomeId] || 0);
+
+  if (orderType === 0) {
+    // ignore trading outcome shares and find min across all other outcome shares.
+    const userSharesBalancesRemoveOutcome = Object.keys(
+      marketOutcomeShares
+    ).reduce(
+      (p, o) =>
+        String(outcomeId) === o ? p : [...p, new BigNumber(marketOutcomeShares[o])],
+      []
+    );
+    userShares = userSharesBalancesRemoveOutcome.length > 0 ? BigNumber.min(
+      ...userSharesBalancesRemoveOutcome
+    ) : ZERO;
+  }
 
   const simulateTradeValue: SimulateTradeData = await simulateTrade(
     orderType,

--- a/packages/augur-ui/src/modules/trades/actions/update-trade-cost-shares.ts
+++ b/packages/augur-ui/src/modules/trades/actions/update-trade-cost-shares.ts
@@ -6,7 +6,7 @@ import { AppState } from 'store';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
 import { BigNumber } from "bignumber.js";
-import { NodeStyleCallback, AccountPositionAction, AccountPosition } from 'modules/types';
+import { NodeStyleCallback, AccountPosition } from 'modules/types';
 import {
   simulateTrade,
   simulateTradeGasLimit,
@@ -166,25 +166,8 @@ async function runSimulateTrade(
   const fingerprint = undefined; // TODO: get this from state
   const kycToken = undefined; // TODO: figure out how kyc tokens are going to be handled
   const doNotCreateOrders = false; // TODO: this needs to be passed from order form
-  const userShares;
 
-  if (orderType === 0) {
-    const outcomes = Object.keys(marketOutcomeShares);
-    var minShares = null;
-    for (const outcome in outcomes) {
-      if (outcome != outcomeId) {
-        if (minShares === null) {
-          minShares = createBigNumber(marketOutcomeShares[outcome]);
-        }
-        minShares = BigNumber.min(minShares, createBigNumber(marketOutcomeShares[outcome]));
-      }
-    }
-    userShares = minShares || createBigNumber(0);
-  }
-  else {
-    userShares = createBigNumber(marketOutcomeShares[outcomeId] || 0);
-  }
-
+  const userShares = new BigNumber(marketOutcomeShares[outcomeId] || 0);
 
   const simulateTradeValue: SimulateTradeData = await simulateTrade(
     orderType,

--- a/packages/augur-ui/src/modules/trading/components/form.tsx
+++ b/packages/augur-ui/src/modules/trading/components/form.tsx
@@ -276,7 +276,7 @@ class Form extends Component<FromProps, FormState> {
         `Precision must be ${UPPER_FIXED_PRECISION_BOUND} decimals or less`
       );
     }
-    
+
     let tradeInterval = DEFAULT_TRADE_INTERVAL;
     if (marketType == MarketType.Scalar) {
       tradeInterval = TRADE_INTERVAL_VALUE.dividedBy(market.numTicks);
@@ -580,9 +580,9 @@ class Form extends Component<FromProps, FormState> {
               property === this.INPUT_TYPES.EST_DAI)
           ) {
             updateTradeNumShares(order);
-          } 
+          }
           if (order[this.INPUT_TYPES.QUANTITY] &&
-            order[this.INPUT_TYPES.PRICE] && order[this.INPUT_TYPES.EST_DAI] && 
+            order[this.INPUT_TYPES.PRICE] && order[this.INPUT_TYPES.EST_DAI] &&
             order[this.INPUT_TYPES.EST_DAI] != 0 && order[this.INPUT_TYPES.QUANTITY] != 0 &&
             property === this.INPUT_TYPES.EXPIRATION_DATE
             ) {
@@ -895,9 +895,9 @@ class Form extends Component<FromProps, FormState> {
             >
               {ExclamationCircle}
               <span>
-                {`Max cost of ${
+                {`Max cost of $${
                   orderEscrowdDai === '' ? '-' : orderEscrowdDai
-                } $ will be escrowed`}
+                } will be escrowed`}
               </span>
             </label>
           </li>
@@ -982,7 +982,7 @@ class Form extends Component<FromProps, FormState> {
                   />
                   {s.expirationDateOption === EXPIRATION_DATE_OPTIONS.DAYS && (
                     <span>
-                      {  
+                      {
                         convertUnixToFormattedDate(
                           moment(s[this.INPUT_TYPES.EXPIRATION_DATE]) &&
                             moment(s[this.INPUT_TYPES.EXPIRATION_DATE]).unix()


### PR DESCRIPTION
clean up, we realized that extra processing of user shares doesn't satisfy all order creation situations. reverting code. 

add change to order form
![image](https://user-images.githubusercontent.com/3970376/71936266-88d44e00-316e-11ea-841e-0fe03852a362.png)


fixed fill text
![image](https://user-images.githubusercontent.com/3970376/71937384-d0100e00-3171-11ea-9ad4-e43207532c7c.png)
