### PR TITLE
0x gas estimation buffer for gnosis

### DIFF
--- a/packages/augur-sdk/src/api/ZeroX.ts
+++ b/packages/augur-sdk/src/api/ZeroX.ts
@@ -193,27 +193,20 @@ export class ZeroX {
       ignoreOrders
     );
 
-    const account = await this.augur.getAccount();
-
-    console.log(JSON.stringify(orders) + "Logged orders");
+    console.log(JSON.stringify(orders) + 'Logged orders');
 
     const numOrders = _.size(orders);
 
-    if (numOrders < 1 && !params.doNotCreateOrders) {
+    // No orders available to take. Maybe make some new ones
+    if (numOrders === 0 && !params.doNotCreateOrders) {
       await this.placeOnChainOrder(params);
       return;
     }
 
-    // Update list of used order ids
-    ignoreOrders = orderIds.concat(ignoreOrders || []);
-
-    let result: Event[] = [];
-
     const gasPrice = await this.augur.getGasPrice();
-
     const protocolFee = gasPrice.multipliedBy(150000 * numOrders);
 
-    result = await this.augur.contracts.ZeroXTrade.trade(
+    const result: Event[] = await this.augur.contracts.ZeroXTrade.trade(
       params.amount,
       params.fingerprint,
       params.tradeGroupId,
@@ -222,12 +215,13 @@ export class ZeroX {
       { attachedEth: protocolFee }
     );
 
+    const account = await this.augur.getAccount();
     const amountRemaining = this.getTradeAmountRemaining(account, params.amount, result);
     console.log(amountRemaining.toString());
     if (amountRemaining.gt(0)) {
       params.amount = amountRemaining;
       // On successive iterations we specify previously taken signed orders since its possible we do another loop before the mesh has updated our view on the orderbook
-      return this.placeOnChainTrade(params, orderIds);
+      return this.placeOnChainTrade(params, orderIds.concat(ignoreOrders || []));
     }
   }
 
@@ -418,7 +412,7 @@ export class ZeroX {
     params: ZeroXPlaceTradeParams,
     ignoreOrders?: string[]
   ): Promise<MatchingOrders> {
-    const orderType = params.direction == 0 ? '1' : '0';
+    const orderType = params.direction === 0 ? '1' : '0';
     const outcome = params.outcome.toString();
     const zeroXOrders = await this.augur.getZeroXOrders({
       marketId: params.market,
@@ -440,7 +434,7 @@ export class ZeroX {
     const { loopLimit, gasLimit } = this.getTradeTransactionLimits(params);
 
     const ordersData =
-      params.direction == 0
+      params.direction === 0
         ? _.take(sortedOrders, loopLimit.toNumber())
         : _.takeRight(sortedOrders, loopLimit.toNumber());
 
@@ -478,7 +472,7 @@ export class ZeroX {
     params: ZeroXPlaceTradeParams
   ): Promise<string | null> {
     if (params.outcome >= params.numOutcomes) {
-      return "Invalid outcome given for trade: ${params.outcome.toString()}. Must be between 0 and ${params.numOutcomes.toString()}";
+      return 'Invalid outcome given for trade: ${params.outcome.toString()}. Must be between 0 and ${params.numOutcomes.toString()}';
     }
     if (params.price.lte(0) || params.price.gte(params.numTicks)) {
       return `Invalid price given for trade: ${params.price.toString()}. Must be between 0 and ${params.numTicks.toString()}`;
@@ -487,7 +481,7 @@ export class ZeroX {
     const amountNotCoveredByShares = params.amount.minus(params.shares);
 
     const cost =
-      params.direction == 0
+      params.direction === 0
         ? params.price.multipliedBy(amountNotCoveredByShares)
         : params.numTicks
             .minus(params.price)

--- a/packages/contract-dependencies-ethers/src/ContractDependenciesEthers.ts
+++ b/packages/contract-dependencies-ethers/src/ContractDependenciesEthers.ts
@@ -1,10 +1,10 @@
 import { Dependencies, AbiFunction, AbiParameter, Transaction, TransactionReceipt } from 'contract-dependencies';
 import { ethers } from 'ethers'
 import { BigNumber } from 'bignumber.js';
-import { TransactionRequest, TransactionResponse } from "ethers/providers";
-import { isInstanceOfBigNumber, isInstanceOfEthersBigNumber, isInstanceOfArray, isObject } from "./utils";
-import { getAddress } from "ethers/utils/address";
-import * as _ from "lodash";
+import { TransactionRequest, TransactionResponse } from 'ethers/providers';
+import { isInstanceOfBigNumber, isInstanceOfEthersBigNumber, isInstanceOfArray, isObject } from './utils';
+import { getAddress } from 'ethers/utils/address';
+import * as _ from 'lodash';
 
 export interface EthersSigner {
   sendTransaction(transaction: ethers.providers.TransactionRequest): Promise<ethers.providers.TransactionResponse>;
@@ -46,42 +46,42 @@ export class ContractDependenciesEthers implements Dependencies<BigNumber> {
   protected transactionDataMetaData: { [data: string]: TransactionMetadata } = {};
   protected transactionStatusCallbacks: { [key: string]: TransactionStatusCallback } = {};
 
-  public constructor(
-    public readonly provider: EthersProvider,
+  constructor(
+    readonly provider: EthersProvider,
     public signer?: EthersSigner,
-    public readonly address?: string) {
+    readonly address?: string) {
   }
 
-  public setSigner(signer: EthersSigner) {
+  setSigner(signer: EthersSigner) {
     this.signer = signer;
   }
 
-  public transactionToEthersTransaction(transaction: Transaction<BigNumber>): Transaction<ethers.utils.BigNumber> {
+  transactionToEthersTransaction(transaction: Transaction<BigNumber>): Transaction<ethers.utils.BigNumber> {
     const transactionObj: Transaction<ethers.utils.BigNumber> = {
       to: transaction.to,
       data: transaction.data,
       value: transaction.value ? new ethers.utils.BigNumber(transaction.value.toString()) : new ethers.utils.BigNumber(0)
-    }
+    };
     if (transaction.from) {
       transactionObj.from = transaction.from;
     }
     return transactionObj;
   }
 
-  public ethersTransactionToTransaction(transaction: Transaction<ethers.utils.BigNumber>): Transaction<BigNumber> {
+  ethersTransactionToTransaction(transaction: Transaction<ethers.utils.BigNumber>): Transaction<BigNumber> {
     return {
       to: transaction.to,
       from: transaction.from,
       data: transaction.data,
-      value: transaction.value ? new BigNumber(transaction.value.toString()) : new BigNumber(0)
+      value: transaction.value ? new BigNumber(transaction.value.toString()) : new BigNumber(0),
     }
   }
 
-  public keccak256(utf8String: string): string {
+  keccak256(utf8String: string): string {
     return ethers.utils.keccak256(ethers.utils.toUtf8Bytes(utf8String));
   }
 
-  public encodeParams(abiFunction: AbiFunction, parameters: Array<any>) {
+  encodeParams(abiFunction: AbiFunction, parameters: any[]) {
     const ethersParams = _.map(parameters, (param) => {
       return this.encodeParam(param);
     });
@@ -101,7 +101,7 @@ export class ContractDependenciesEthers implements Dependencies<BigNumber> {
     return param;
   }
 
-  public storeTxMetadata(abiFunction: AbiFunction, parameters: Array<any>, txData: string): void {
+  storeTxMetadata(abiFunction: AbiFunction, parameters: any[], txData: string): void {
     const txParams = _.reduce(abiFunction.inputs, (result, input, index) => {
       result[input.name] = parameters[index];
       return result;
@@ -112,7 +112,7 @@ export class ContractDependenciesEthers implements Dependencies<BigNumber> {
     };
   }
 
-  public decodeParams(abiParameters: Array<AbiParameter>, encoded: string) {
+  decodeParams(abiParameters: AbiParameter[], encoded: string) {
     const results = this.abiCoder.decode(abiParameters, encoded);
     return _.map(results, (result) => {
       if (isInstanceOfEthersBigNumber(result)) {
@@ -124,11 +124,11 @@ export class ContractDependenciesEthers implements Dependencies<BigNumber> {
     });
   }
 
-  public async call(transaction: Transaction<BigNumber>): Promise<string> {
-    return await this.provider.call(this.transactionToEthersTransaction(transaction));
+  async call(transaction: Transaction<BigNumber>): Promise<string> {
+    return this.provider.call(this.transactionToEthersTransaction(transaction));
   }
 
-  public async getDefaultAddress(): Promise<string | undefined> {
+  async getDefaultAddress(): Promise<string | undefined> {
     if (this.signer) {
       return getAddress(await this.signer.getAddress());
     }
@@ -138,26 +138,26 @@ export class ContractDependenciesEthers implements Dependencies<BigNumber> {
     return undefined;
   }
 
-  public registerTransactionStatusCallback(key: string, callback: TransactionStatusCallback): void {
+  registerTransactionStatusCallback(key: string, callback: TransactionStatusCallback): void {
     this.transactionStatusCallbacks[key] = callback;
   }
 
-  public deRegisterTransactionStatusCallback(key: string): void {
+  deRegisterTransactionStatusCallback(key: string): void {
     delete this.transactionStatusCallbacks[key];
   }
 
-  public deRegisterAllTransactionStatusCallbacks(): void {
+  deRegisterAllTransactionStatusCallbacks(): void {
     Object.keys(this.transactionStatusCallbacks).map((key) => this.deRegisterTransactionStatusCallback(key));
   }
 
-  public onTransactionStatusChanged(txMetadata: TransactionMetadata, status: TransactionStatus, hash?: string): void {
-    for (let callback of Object.values(this.transactionStatusCallbacks)) {
+  onTransactionStatusChanged(txMetadata: TransactionMetadata, status: TransactionStatus, hash?: string): void {
+    for (const callback of Object.values(this.transactionStatusCallbacks)) {
       callback(txMetadata, status, hash);
     }
   }
 
-  public async submitTransaction(transaction: Transaction<BigNumber>): Promise<TransactionReceipt> {
-    if (!this.signer) throw new Error("Attempting to sign a transaction while not providing a signer");
+  async submitTransaction(transaction: Transaction<BigNumber>): Promise<TransactionReceipt> {
+    if (!this.signer) throw new Error('Attempting to sign a transaction while not providing a signer');
     // @TODO: figure out a way to propagate a warning up to the user in this scenario, we don't currently have a mechanism for error propagation, so will require infrastructure work
     const tx = this.transactionToEthersTransaction(transaction);
     const txMetadataKey = `0x${transaction.data.substring(10)}`;
@@ -167,10 +167,10 @@ export class ContractDependenciesEthers implements Dependencies<BigNumber> {
     try {
       const receipt = await this.sendTransaction(tx, txMetadata);
       hash = receipt.transactionHash;
-      const status = receipt.status == 1 ? TransactionStatus.SUCCESS : TransactionStatus.FAILURE;
+      const status = receipt.status === 1 ? TransactionStatus.SUCCESS : TransactionStatus.FAILURE;
       this.onTransactionStatusChanged(txMetadata, status, hash);
       // ethers has `status` on the receipt as optional, even though it isn't and never will be undefined if using a modern network (which this is designed for)
-      return <TransactionReceipt>receipt;
+      return receipt as TransactionReceipt;
     } catch (e) {
       this.onTransactionStatusChanged(txMetadata, TransactionStatus.FAILURE, hash);
       throw e;
@@ -179,7 +179,7 @@ export class ContractDependenciesEthers implements Dependencies<BigNumber> {
     }
   }
 
-  public async sendTransaction(tx: Transaction<ethers.utils.BigNumber>, txMetadata: TransactionMetadata): Promise<ethers.providers.TransactionReceipt> {
+  async sendTransaction(tx: Transaction<ethers.utils.BigNumber>, txMetadata: TransactionMetadata): Promise<ethers.providers.TransactionReceipt> {
     const gasLimit = await this.provider.estimateGas(tx);
 
     // @BODY https://github.com/ethers-io/ethers.js/issues/321
@@ -192,11 +192,11 @@ export class ContractDependenciesEthers implements Dependencies<BigNumber> {
     });
     const hash = response.hash;
     this.onTransactionStatusChanged(txMetadata, TransactionStatus.PENDING, hash);
-    return await response.wait();
+    return response.wait();
   }
 
-  public async estimateGas(transaction: Transaction<BigNumber>): Promise<BigNumber> {
-    const gasEstimate = await this.provider.estimateGas(this.transactionToEthersTransaction(transaction));
-    return new BigNumber(gasEstimate.toString());
+  async estimateGas(transaction: Transaction<BigNumber>): Promise<BigNumber> {
+    const estimate = await this.provider.estimateGas(this.transactionToEthersTransaction(transaction));
+    return new BigNumber(estimate.toString());
   }
 }

--- a/packages/contract-dependencies-gnosis/src/ContractDependenciesGnosis.ts
+++ b/packages/contract-dependencies-gnosis/src/ContractDependenciesGnosis.ts
@@ -191,8 +191,7 @@ export class ContractDependenciesGnosis extends ContractDependenciesEthers {
   async estimateGas(transaction: Transaction<BigNumber>): Promise<BigNumber> {
     if (this.useSafe && this.safeAddress && this.useRelay) {
       transaction.from = this.safeAddress;
-      const response = await this.relayerEstimateGas(transaction);
-      return response;
+      return this.relayerEstimateGas(transaction);
     } else {
       return super.estimateGas(transaction);
     }
@@ -219,8 +218,7 @@ export class ContractDependenciesGnosis extends ContractDependenciesEthers {
     );
     const safeTxGas = new BigNumber(gasEstimates.safeTxGas);
     const baseGas = new BigNumber(gasEstimates.baseGas);
-
-    return safeTxGas.plus(baseGas);
+    return baseGas.plus(safeTxGas);
   }
 
   async estimateTransactionViaRelay(

--- a/packages/ethersjs-provider/src/EthersProvider.ts
+++ b/packages/ethersjs-provider/src/EthersProvider.ts
@@ -23,10 +23,7 @@ interface PerformQueueTask {
 export class EthersProvider extends ethers.providers.BaseProvider
   implements EProvider {
   gasLimit: ethers.utils.BigNumber | null = new ethers.utils.BigNumber(7500000);
-  gasEstimateIncreasePercentage: ethers.utils.BigNumber | null = new ethers.utils.BigNumber(
-    10
-  );
-
+  gasEstimateIncreasePercentage: ethers.utils.BigNumber | null = new ethers.utils.BigNumber(34);
   private contractMapping: ContractMapping = {};
   private performQueue: AsyncQueue<PerformQueueTask>;
   readonly provider: ethers.providers.JsonRpcProvider;

--- a/packages/ethersjs-provider/src/EthersProvider.ts
+++ b/packages/ethersjs-provider/src/EthersProvider.ts
@@ -89,7 +89,8 @@ export class EthersProvider extends ethers.providers.BaseProvider
   async call(
     transaction: Transaction<ethers.utils.BigNumber>
   ): Promise<string> {
-    return super.call(transaction);
+    const txRequest: ethers.providers.TransactionRequest = transaction;
+    return super.call(txRequest);
   }
 
   async getNetworkId(): Promise<NetworkId> {
@@ -113,7 +114,8 @@ export class EthersProvider extends ethers.providers.BaseProvider
     let gasEstimate = await super.estimateGas(transaction);
     if (this.gasEstimateIncreasePercentage) {
       gasEstimate = gasEstimate.add(
-        gasEstimate.div(this.gasEstimateIncreasePercentage)
+        gasEstimate.div(
+          new ethers.utils.BigNumber(100).div(this.gasEstimateIncreasePercentage))
       );
     }
 

--- a/packages/gnosis-relay-api/src/GnosisRelayAPI.ts
+++ b/packages/gnosis-relay-api/src/GnosisRelayAPI.ts
@@ -116,6 +116,7 @@ export interface IGnosisRelayAPI {
 
 export class GnosisRelayAPI implements IGnosisRelayAPI {
   readonly relayURL: string;
+  gasEstimateIncreasePercentage: BigNumber = new BigNumber(10);
 
   constructor(relayURL: string) {
     this.relayURL = relayURL;
@@ -183,7 +184,16 @@ export class GnosisRelayAPI implements IGnosisRelayAPI {
 
     try {
       const result = await axios.post(url, relayTxEstimateData);
-      return result.data;
+      const relayTxEstimate: RelayTxEstimateResponse = result.data;
+
+      if (this.gasEstimateIncreasePercentage) {
+        relayTxEstimate.safeTxGas = relayTxEstimate.safeTxGas.plus(
+          relayTxEstimate.safeTxGas.div(
+            new BigNumber(100).div(this.gasEstimateIncreasePercentage))
+        );
+      }
+
+      return relayTxEstimate;
     } catch (error) {
       throw new Error(JSON.stringify(error.response.data));
     }

--- a/packages/gnosis-relay-api/src/GnosisRelayAPI.ts
+++ b/packages/gnosis-relay-api/src/GnosisRelayAPI.ts
@@ -116,7 +116,7 @@ export interface IGnosisRelayAPI {
 
 export class GnosisRelayAPI implements IGnosisRelayAPI {
   readonly relayURL: string;
-  gasEstimateIncreasePercentage: BigNumber = new BigNumber(10);
+  gasEstimateIncreasePercentage: BigNumber | null = new BigNumber(34);
 
   constructor(relayURL: string) {
     this.relayURL = relayURL;


### PR DESCRIPTION
Properly ignoring already-matched orders.
Cleanup.
Adding 10% buffer to gnosis txs instead of adding gas buffer to Transaction.
Correctly calculating percentage.