### PR TITLE
fix updating total order size and percentage buttons

### DIFF
--- a/packages/augur-ui/src/modules/trades/actions/update-trade-cost-shares.ts
+++ b/packages/augur-ui/src/modules/trades/actions/update-trade-cost-shares.ts
@@ -112,9 +112,12 @@ export function updateTradeShares({
     if (side === BUY) {
       newShares = createBigNumber(maxCost).dividedBy(scaledPrice);
     }
+
     newTradeDetails.numShares = newShares
       .abs()
-      .toNumber()
+      .dividedBy(10)
+      .integerValue()
+      .multipliedBy(10)
       .toString();
 
     return runSimulateTrade(

--- a/packages/augur-ui/src/modules/trading/components/form.tsx
+++ b/packages/augur-ui/src/modules/trading/components/form.tsx
@@ -444,7 +444,7 @@ class Form extends Component<FromProps, FormState> {
     errorCount += priceErrorCount;
     errors = { ...errors, ...priceErrors };
 
-    let quantityValid = false;
+    let quantityValid = true;
 
     if (changedProperty !== this.INPUT_TYPES.EST_DAI) {
       const {
@@ -647,9 +647,10 @@ class Form extends Component<FromProps, FormState> {
   updateTotalValue(percent: Number) {
     const { availableDai } = this.props;
 
-    const value = availableDai.times(createBigNumber(percent));
-
-    this.validateForm(this.INPUT_TYPES.EST_DAI, value.toString());
+    const value = availableDai.times(createBigNumber(percent)).integerValue(BigNumber.ROUND_DOWN);
+    this.setState({ [this.INPUT_TYPES.EST_DAI]: value.toString() }, () =>
+      this.validateForm(this.INPUT_TYPES.EST_DAI, value.toString())
+    );
   }
 
   render() {

--- a/packages/augur-ui/src/modules/trading/components/wrapper.tsx
+++ b/packages/augur-ui/src/modules/trading/components/wrapper.tsx
@@ -371,6 +371,7 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
           {
             orderQuantity: String(numShares),
             orderEscrowdDai: newOrder.costInDai.formatted,
+            orderDaiEstimate: order.orderDaiEstimate,
             trade: newOrder,
             gasCostEst: formattedGasCost,
           },


### PR DESCRIPTION
fix updating total order size and percentage buttons. 

to test: 
verify 100% rounds down so user doesn't get insufficient funds
verify that all percentage buttons update num shares and total order cost
verify manually changing total order size updates num shares. 
verify num shares is multiple of 10. 