### PR TITLE
Fix mobile/desktop handling of Help Tooltip Toggle icon in Top Nav

### DIFF
--- a/packages/augur-ui/src/modules/app/components/help-resources.styles.less
+++ b/packages/augur-ui/src/modules/app/components/help-resources.styles.less
@@ -5,12 +5,8 @@
   position: relative;
   display: flex;
   flex: 1;
-  max-width: 57px;
+  max-width: 56px;
   z-index: @above-all-content-above;
-
-  @media @breakpoint-mobile {
-    display: none;
-  }
 
   > span {
     padding: @size-18;

--- a/packages/augur-ui/src/modules/app/components/top-bar.styles.less
+++ b/packages/augur-ui/src/modules/app/components/top-bar.styles.less
@@ -21,19 +21,6 @@
       padding: @size-8 0;
     }
 
-
-    > div:last-of-type {
-      @media @breakpoint-mobile {
-        display: none;
-      }
-    }
-
-    > div > div:last-of-type {
-      @media @breakpoint-mobile {
-        display: none;
-      }
-    }
-
     > button {
       margin-right: @size-12;
     }

--- a/packages/augur-ui/src/modules/app/components/top-bar.tsx
+++ b/packages/augur-ui/src/modules/app/components/top-bar.tsx
@@ -19,6 +19,7 @@ import HelpResources from 'modules/app/containers/help-resources';
 interface TopBarProps {
   alertsVisible: boolean;
   isLogged: boolean;
+  isMobile: boolean;
   restoredAccount: boolean;
   stats: CoreStats;
   unseenCount: number;
@@ -30,6 +31,7 @@ interface TopBarProps {
 const TopBar: React.FC<TopBarProps> = ({
   alertsVisible,
   isLogged,
+  isMobile,
   restoredAccount,
   stats,
   unseenCount,
@@ -62,6 +64,7 @@ const TopBar: React.FC<TopBarProps> = ({
         </div>
       )}
       <div>
+        {(!isLogged) && <HelpResources />}
         {!isLogged && !restoredAccount && (
           <SecondaryButton action={() => loginModal()} text={'Login'} />
         )}
@@ -69,8 +72,8 @@ const TopBar: React.FC<TopBarProps> = ({
           <PrimaryButton action={() => signupModal()} text={'Signup'} />
         )}
 
-        {(isLogged || restoredAccount) && <HelpResources />}
-        <ConnectAccount />
+        {!isMobile && (isLogged || restoredAccount) && <HelpResources />}
+        { !isMobile && (<ConnectAccount />)}
 
         {(isLogged || restoredAccount) && (
           <button

--- a/packages/augur-ui/src/modules/app/containers/top-bar.ts
+++ b/packages/augur-ui/src/modules/app/containers/top-bar.ts
@@ -11,11 +11,12 @@ import { MODAL_LOGIN, MODAL_SIGNUP } from 'modules/common/constants';
 import { Action } from 'redux';
 
 const mapStateToProps = (state: AppState) => {
-  const { sidebarStatus, authStatus } = state;
+  const { sidebarStatus, authStatus, appStatus } = state;
   const { unseenCount } = selectInfoAlertsAndSeenCount(state);
   return {
     stats: selectCoreStats(state),
     unseenCount,
+    isMobile: appStatus.isMobile,
     isLogged: authStatus.isLogged,
     restoredAccount: authStatus.restoredAccount,
     alertsVisible: authStatus.isLogged && sidebarStatus.isAlertsVisible,


### PR DESCRIPTION
## Description

Adds appropriate cases for top nav Help Tooltip Toggle visibility.

To facilitate the change, I have removed some ambiguous Less rules and moved visibility control to purely JS using the `isMobile` state in the `appState` variables. It is currently a mix of JS and CSS, and I figured it would be best to move all visibility control to JS since you have to test at the JS level `loggedIn` anyway.

## Screenshots
- Desktop - Logged In:     SHOW

    ![Screenshot from 2020-01-08 14-28-03](https://user-images.githubusercontent.com/1673206/72012359-cf3ab300-3229-11ea-8a29-1f4db45bd4e4.png)


- Desktop - Logged Out:  SHOW
    
    ![Screenshot from 2020-01-08 14-27-48](https://user-images.githubusercontent.com/1673206/72012290-b16d4e00-3229-11ea-900c-e8f044461618.png)

- Mobile - Logged In:       HIDE

    ![Screenshot from 2020-01-08 14-27-21](https://user-images.githubusercontent.com/1673206/72012201-8682fa00-3229-11ea-8d06-38d551cc2da0.png)

- Mobile - Logged Out:    SHOW
    ![Screenshot from 2020-01-08 14-27-33](https://user-images.githubusercontent.com/1673206/72012243-9995ca00-3229-11ea-9474-a3963bca59bd.png)


## Issues

#5207 
#5206 
#5202 
#5201 

## Note

- This clears up some requirements in the above issues and does not close them out fully.
- This does not fix help icon styling. Punting that to a separate PR.