### PR TITLE
Inverting Help Icon color to match spec.

### DIFF
--- a/packages/augur-ui/src/modules/app/components/help-resources.styles.less
+++ b/packages/augur-ui/src/modules/app/components/help-resources.styles.less
@@ -24,12 +24,11 @@
       height: @size-20;
 
       > circle {
-        stroke: @color-primary-text;
-        fill: none;
+        fill: @color-primary-text;
       }
 
       > path {
-        fill: @color-primary-text;
+        fill: black;
       }
     }
 

--- a/packages/augur-ui/src/modules/app/components/help-resources.styles.less
+++ b/packages/augur-ui/src/modules/app/components/help-resources.styles.less
@@ -28,7 +28,7 @@
       }
 
       > path {
-        fill: black;
+        fill: @color-dark-grey;
       }
     }
 


### PR DESCRIPTION
## Description

A number of issues mentioned to fix the help icon to match the design color. This PR updates the Help Icon to an inverted color to match spec. 

## Screenshots

### Destop
![Screenshot from 2020-01-10 23-18-20](https://user-images.githubusercontent.com/1673206/72198744-9bb18180-33ff-11ea-97f7-911777ac6e8d.png)


### Mobile
![Screenshot from 2020-01-10 23-18-12](https://user-images.githubusercontent.com/1673206/72198740-95bba080-33ff-11ea-9c17-fce8efa593ed.png)



## Issues

#5207
#5206
#5202
#5210 
#5203 
#5201