### PR TITLE
Split Help Menu components and add to side-nav.

### DIFF
--- a/packages/augur-ui/src/modules/app/components/app.tsx
+++ b/packages/augur-ui/src/modules/app/components/app.tsx
@@ -341,6 +341,9 @@ export default class AppView extends Component<AppProps> {
       migrateV1Rep,
       showMigrateRepButton,
       updateModal,
+      isHelpMenuOpen,
+      updateConnectionTray,
+      updateHelpMenuState,
     } = this.props;
 
     const currentPath = parsePath(location.pathname)[0];
@@ -412,6 +415,9 @@ export default class AppView extends Component<AppProps> {
                 menuData={this.sideNavMenuData}
                 currentBasePath={sidebarStatus.currentBasePath}
                 isConnectionTrayOpen={isConnectionTrayOpen}
+                isHelpMenuOpen={isHelpMenuOpen}
+                updateConnectionTray={updateConnectionTray}
+                updateHelpMenuState={updateHelpMenuState}
                 logout={() => this.props.logout()}
                 showGlobalChat={() => this.props.showGlobalChat()}
                 migrateV1Rep={migrateV1Rep}

--- a/packages/augur-ui/src/modules/app/components/help-resources.styles.less
+++ b/packages/augur-ui/src/modules/app/components/help-resources.styles.less
@@ -116,7 +116,6 @@
 
 .HelpMenu {
   position: absolute;
-  top: 0;
   background: @color-module-background;
   border: 1px solid @color-secondary-action-outline;
   border-radius: @border-radius-default;

--- a/packages/augur-ui/src/modules/app/components/help-resources.styles.less
+++ b/packages/augur-ui/src/modules/app/components/help-resources.styles.less
@@ -1,13 +1,7 @@
 @import (reference) '~assets/styles/shared';
 
-.HelpResources {
-  color: @color-primary-text;
-  position: relative;
-  display: flex;
-  flex: 1;
-  max-width: 56px;
+.HelpIcon {
   z-index: @above-all-content-above;
-
   > span {
     padding: @size-18;
     display: flex;
@@ -46,78 +40,148 @@
     }
   }
 
-  > div {
-    position: absolute;
-    top: 0;
-    background: @color-module-background;
-    border: 1px solid @color-secondary-action-outline;
-    border-radius: @border-radius-default;
-    width: 210px;
-    top: 100%;
-    right: -1px;
-    margin-top: -1px;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    display: flex;
-    flex-direction: column;
-
-    > span:first-of-type {
-      .mono-11-bold;
-
-      text-transform: uppercase;
-      padding: @size-22 @size-16;
-      color: @color-primary-text;
-      background: @color-module-background;
-    }
-
-    > span:not(:first-of-type) {
-      padding: @size-13 @size-16;
-      background: @color-table-header;
-      border-top: 1px solid @color-dark-grey;
-
-      &.hideOnTablet {
-        @media @breakpoint-smallish-desktop {
-          display: none;
-        }
-      }
-    }
-
-    > span:last-of-type {
-      border-bottom-left-radius: @border-radius-default;
-      border-bottom-right-radius: @border-radius-default;
-    }
-
-    @media @breakpoint-mobile {
-      bottom: unset;
-      margin-bottom: -1px;
-      border-bottom-right-radius: 0;
-      border-bottom-left-radius: 0;
-      position: absolute;
-      right: 0px;
-      top: 65px;
-
-      > span:not(:first-of-type) {
-        border-bottom: 1px solid @color-dark-grey;
-      }
-
-      > span:last-of-type {
-        border-top-left-radius: @border-radius-default;
-        border-top-right-radius: @border-radius-default;
-      }
-    }
-  }
-
   &.Open {
     > span {
-      border: 1px solid @color-secondary-action-outline;
       border-bottom: 0;
       background: @color-module-background;
       z-index: @above-all-content;
 
       @media @breakpoint-mobile {
-        border: 1px solid @color-secondary-action-outline;
         border-top: 0;
       }
     }
   }
+}
+
+.HelpMenuList {
+  display: contents;
+  position: absolute;
+  top: 0;
+  background: @color-module-background;
+  border: 1px solid @color-secondary-action-outline;
+  border-radius: @border-radius-default;
+  width: 210px;
+  top: 100%;
+  right: -1px;
+  margin-top: -1px;
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+  display: flex;
+  flex-direction: column;
+
+  > li:first-of-type {
+    .mono-11-bold;
+
+    text-transform: uppercase;
+    padding: @size-22 @size-16;
+    color: @color-primary-text;
+    background: @color-module-background;
+  }
+
+  > li:not(:first-of-type) {
+    padding: @size-13 @size-16;
+    background: @color-table-header;
+    border-top: 1px solid @color-dark-grey;
+
+    &.hideOnTablet {
+      @media @breakpoint-smallish-desktop {
+        display: none;
+      }
+    }
+  }
+
+  > li:last-of-type {
+    border-bottom-left-radius: @border-radius-default;
+    border-bottom-right-radius: @border-radius-default;
+  }
+
+  @media @breakpoint-mobile {
+    bottom: unset;
+    margin-bottom: -1px;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+    position: absolute;
+    right: 0px;
+    top: 65px;
+    display: contents;
+
+    > li:not(:first-of-type) {
+      border-bottom: 1px solid @color-dark-grey;
+    }
+
+    > li:last-of-type {
+      border-top-left-radius: @border-radius-default;
+      border-top-right-radius: @border-radius-default;
+    }
+  }
+}
+
+.HelpMenu {
+  position: absolute;
+  top: 0;
+  background: @color-module-background;
+  border: 1px solid @color-secondary-action-outline;
+  border-radius: @border-radius-default;
+  width: 210px;
+  top: 100%;
+  right: -1px;
+  margin-top: -1px;
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+  display: flex;
+  flex-direction: column;
+
+  > span:first-of-type {
+    .mono-11-bold;
+
+    text-transform: uppercase;
+    padding: @size-22 @size-16;
+    color: @color-primary-text;
+    background: @color-module-background;
+  }
+
+  > span:not(:first-of-type) {
+    padding: @size-13 @size-16;
+    background: @color-table-header;
+    border-top: 1px solid @color-dark-grey;
+
+    &.hideOnTablet {
+      @media @breakpoint-smallish-desktop {
+        display: none;
+      }
+    }
+  }
+
+  > span:last-of-type {
+    border-bottom-left-radius: @border-radius-default;
+    border-bottom-right-radius: @border-radius-default;
+  }
+
+  @media @breakpoint-mobile {
+    bottom: unset;
+    margin-bottom: -1px;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+    position: absolute;
+    right: 0px;
+    top: 65px;
+
+    > span:not(:first-of-type) {
+      border-bottom: 1px solid @color-dark-grey;
+    }
+
+    > span:last-of-type {
+      border-top-left-radius: @border-radius-default;
+      border-top-right-radius: @border-radius-default;
+    }
+  }
+}
+
+.HelpResources {
+  color: @color-primary-text;
+  position: relative;
+  display: flex;
+  flex: 1;
+  max-width: 56px;
+  z-index: @above-all-content-above;
 }

--- a/packages/augur-ui/src/modules/app/components/help-resources.styles.less
+++ b/packages/augur-ui/src/modules/app/components/help-resources.styles.less
@@ -54,9 +54,7 @@
 }
 
 .HelpMenuList {
-  display: contents;
   position: absolute;
-  top: 0;
   background: @color-module-background;
   border: 1px solid @color-secondary-action-outline;
   border-radius: @border-radius-default;

--- a/packages/augur-ui/src/modules/app/components/help-resources.tsx
+++ b/packages/augur-ui/src/modules/app/components/help-resources.tsx
@@ -45,6 +45,66 @@ const HELP_LINKS = [
   },
 ];
 
+export const HelpMenuList = () => {
+  return (
+    <span className={classNames(Styles.HelpMenuList)}>
+      <li>popular help resources</li>
+      {HELP_LINKS.map((helpLink, index) => (
+        <li key={'helpLink_' + index} className={helpLink.className}>
+          <ExternalLinkButton
+            light
+            URL={helpLink.link}
+            label={helpLink.label}
+            customLink={helpLink.customLink}
+          />
+        </li>
+      ))}
+    </span>
+  );
+};
+
+export const HelpMenu = () => {
+  return (
+    <div className={classNames(Styles.HelpMenu)}>
+      <span>popular help resources</span>
+      {HELP_LINKS.map((helpLink, index) => (
+        <span key={'helpLink_' + index} className={helpLink.className}>
+          <ExternalLinkButton
+            light
+            URL={helpLink.link}
+            label={helpLink.label}
+            customLink={helpLink.customLink}
+          />
+        </span>
+      ))}
+    </div>
+  );
+};
+
+
+interface HelpIconProps {
+  isHelpMenuOpen: boolean;
+  updateHelpMenuState: Function;
+}
+
+export const HelpIcon = ({
+  updateHelpMenuState,
+  isHelpMenuOpen
+}: HelpIconProps) => {
+  return (
+    <div
+      className={classNames(Styles.HelpIcon, {
+        [Styles.Open]: isHelpMenuOpen,
+      })}
+      onClick={event => event.stopPropagation()}
+    >
+      <span onClick={() => updateHelpMenuState(!isHelpMenuOpen)}>
+        {QuestionIcon}
+      </span>
+    </div>
+  );
+};
+
 export const HelpResources = ({
   isHelpMenuOpen,
   updateHelpMenuState,
@@ -63,24 +123,8 @@ export const HelpResources = ({
       })}
       onClick={event => event.stopPropagation()}
     >
-      <span onClick={() => updateHelpMenuState(!isHelpMenuOpen)}>
-        {QuestionIcon}
-      </span>
-      {isHelpMenuOpen && (
-        <div>
-          <span>popular help resources</span>
-          {HELP_LINKS.map((helpLink, index) => (
-            <span key={'helpLink_' + index} className={helpLink.className}>
-              <ExternalLinkButton
-                light
-                URL={helpLink.link}
-                label={helpLink.label}
-                customLink={helpLink.customLink}
-              />
-            </span>
-          ))}
-        </div>
-      )}
+      <HelpIcon updateHelpMenuState={updateHelpMenuState} isHelpMenuOpen={isHelpMenuOpen} />
+      {isHelpMenuOpen && (<HelpMenu />)}
     </div>
   );
 };

--- a/packages/augur-ui/src/modules/app/components/side-nav/side-nav.styles.less
+++ b/packages/augur-ui/src/modules/app/components/side-nav/side-nav.styles.less
@@ -98,7 +98,6 @@
     height: calc(100vh - @top-bar-height-mobile);
     margin-top: @top-bar-height-mobile;
     padding-bottom: @top-bar-height-mobile;
-    padding-top: 1.6875rem;
 
     &.accountDetailsOpen {
       margin-top: 0;

--- a/packages/augur-ui/src/modules/app/components/side-nav/side-nav.tsx
+++ b/packages/augur-ui/src/modules/app/components/side-nav/side-nav.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import ReactTooltip from 'react-tooltip';
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
@@ -9,7 +9,7 @@ import ConnectAccount from 'modules/auth/containers/connect-account';
 import { LogoutIcon } from 'modules/common/icons';
 import { NavMenuItem } from 'modules/types';
 import Styles from 'modules/app/components/side-nav/side-nav.styles.less';
-import HelpResources from 'modules/app/containers/help-resources';
+import { HelpIcon, HelpMenuList } from 'modules/app/components/help-resources';
 import { SecondaryButton } from 'modules/common/buttons';
 import TooltipStyles from 'modules/common/tooltip.styles.less';
 import { helpIcon, Chevron } from 'modules/common/icons';
@@ -25,6 +25,9 @@ interface SideNavProps {
   showGlobalChat: Function;
   migrateV1Rep: Function;
   showMigrateRepButton: boolean;
+  isHelpMenuOpen: boolean;
+  updateHelpMenuState: Function;
+  updateConnectionTray: Function;
 }
 
 const SideNav = ({
@@ -38,7 +41,16 @@ const SideNav = ({
   showGlobalChat,
   migrateV1Rep,
   showMigrateRepButton,
+  isHelpMenuOpen,
+  updateHelpMenuState,
+  updateConnectionTray,
 }: SideNavProps) => {
+  useEffect(() => {
+    if (isHelpMenuOpen) {
+      updateConnectionTray(false);
+    }
+  }, [isHelpMenuOpen]);
+
   const accessFilteredMenu = menuData.filter(
     item => !(item.requireLogin && !isLogged)
   );
@@ -50,10 +62,9 @@ const SideNav = ({
       })}
     >
       <div>
-        {isLogged && <HelpResources />}
+        {isLogged && (<HelpIcon isHelpMenuOpen={isHelpMenuOpen} updateHelpMenuState={updateHelpMenuState} />)}
         <ConnectAccount />
       </div>
-
       <div className={Styles.SideNav__container}>
         <div>
           {isConnectionTrayOpen && <ConnectDropdown />}
@@ -62,6 +73,7 @@ const SideNav = ({
               [Styles.accountDetailsOpen]: isConnectionTrayOpen,
             })}
           >
+            {isHelpMenuOpen && <HelpMenuList />}
             {accessFilteredMenu.map((item, idx) => (
               <li
                 key={idx}

--- a/packages/augur-ui/src/modules/app/containers/app.ts
+++ b/packages/augur-ui/src/modules/app/containers/app.ts
@@ -44,6 +44,7 @@ const mapStateToProps = state => {
     restoredAccount: state.authStatus.restoredAccount,
     isMobile: state.appStatus.isMobile,
     isMobileSmall: state.appStatus.isMobileSmall,
+    isHelpMenuOpen: state.appStatus.isHelpMenuOpen,
     loginAccount: state.loginAccount,
     modal: state.modal,
     toasts: alerts.filter(alert => alert.toast && !alert.seen),
@@ -60,8 +61,8 @@ const mapDispatchToProps = dispatch => ({
   initAugur: (history, overrides, cb) =>
     dispatch(initAugur(history, overrides, cb)),
   updateIsMobile: isMobile => dispatch(updateAppStatus(IS_MOBILE, isMobile)),
-  updateIsMobileSmall: isMobileSmall =>
-    dispatch(updateAppStatus(IS_MOBILE_SMALL, isMobileSmall)),
+  updateHelpMenuState: isHelpMenuOpen => dispatch(updateAppStatus(IS_HELP_MENU_OPEN, isHelpMenuOpen)),
+  updateIsMobileSmall: isMobileSmall => dispatch(updateAppStatus(IS_MOBILE_SMALL, isMobileSmall)),
   updateModal: modal => dispatch(updateModal(modal)),
   finalizeMarket: marketId => dispatch(sendFinalizeMarket(marketId)),
   logout: () => dispatch(logout()),


### PR DESCRIPTION
## Description

In the Figma designs for #5210, the help menu in the side nav has a button toggle that doesn't hover over the existing navigation, and instead is inside the menu container, pushing down existing content. This was not possible since the Redux dispatch on the application state, the icon, and the menu list are all wrapped in the same component.

This PR
- Refactors the Help Menu icon and Menu List to be separate components, allowing them to be exported. (Previous Help Menu is untouched).
- Adds appropriate Help Menu redux state and effects into the side nav component, pushing down necessary state to the props.
- Uses the exposed Help Menu icon and Help Menu list in the side nav in the appropriate positions

## Screenshots

![Screenshot from 2020-01-13 01-04-45](https://user-images.githubusercontent.com/1673206/72235618-2e3d5680-35a1-11ea-97d3-9828b7a1106b.png)

![Screenshot from 2020-01-13 01-21-39](https://user-images.githubusercontent.com/1673206/72236009-1b2b8600-35a3-11ea-918f-d080071fb7c4.png)



## Issue
#5210 