### PR TITLE
don't center align markets titles on portfolio page

### DIFF
--- a/packages/augur-ui/src/modules/portfolio/components/common/market-row.styles.less
+++ b/packages/augur-ui/src/modules/portfolio/components/common/market-row.styles.less
@@ -48,7 +48,6 @@
     > span {
       .text-12-medium;
 
-      align-items: center;
       color: @color-primary-text;
       display: flex;
       flex: 1;


### PR DESCRIPTION
short titles are centered and shouldn't be

![image](https://user-images.githubusercontent.com/3970376/72281714-9e2ef980-3600-11ea-87d2-cb6b38eaa753.png)



![image](https://user-images.githubusercontent.com/3970376/72281682-94a59180-3600-11ea-862f-cba68f8099f1.png)



![image](https://user-images.githubusercontent.com/3970376/72281775-c880b700-3600-11ea-85f7-f9a42961a507.png)
