### PR TITLE
Reorganize mobile and desktop help menu items to match V2 spec

### DIFF
--- a/packages/augur-ui/src/modules/app/components/help-resources.styles.less
+++ b/packages/augur-ui/src/modules/app/components/help-resources.styles.less
@@ -66,6 +66,15 @@
   display: flex;
   flex-direction: column;
 
+  > li {
+      > button {
+      width: 100%;
+      justify-content: left;
+      background: none;
+      border: none;
+    }
+  }
+
   > li:first-of-type {
     .mono-11-bold;
 
@@ -126,6 +135,15 @@
   border-top-left-radius: 0;
   display: flex;
   flex-direction: column;
+
+  > span {
+      > button {
+      width: 100%;
+      justify-content: left;
+      background: none;
+      border: none;
+    }
+  }
 
   > span:first-of-type {
     .mono-11-bold;

--- a/packages/augur-ui/src/modules/app/components/help-resources.tsx
+++ b/packages/augur-ui/src/modules/app/components/help-resources.tsx
@@ -18,6 +18,16 @@ interface HelpResourcesProps {
 
 const HELP_LINKS = [
   {
+    label: 'trading tutorial',
+    showNonLink: true,
+    customLink: {
+      pathname: MARKET,
+      search: makeQuery({
+        [MARKET_ID_PARAM_NAME]: TRADING_TUTORIAL,
+      }),
+    },
+  },
+  {
     label: 'help center',
     link: 'https://docs.augur.net',
   },
@@ -33,16 +43,6 @@ const HELP_LINKS = [
     label: 'how to dispute',
     link: 'https://docs.augur.net',
   },
-  {
-    label: 'MAKE A TEST TRADE',
-    className: Styles.hideOnTablet,
-    customLink: {
-      pathname: MARKET,
-      search: makeQuery({
-        [MARKET_ID_PARAM_NAME]: TRADING_TUTORIAL,
-      }),
-    },
-  },
 ];
 
 export const HelpMenuList = () => {
@@ -56,6 +56,7 @@ export const HelpMenuList = () => {
             URL={helpLink.link}
             label={helpLink.label}
             customLink={helpLink.customLink}
+            showNonLink={helpLink.showNonLink}
           />
         </li>
       ))}
@@ -74,6 +75,7 @@ export const HelpMenu = () => {
             URL={helpLink.link}
             label={helpLink.label}
             customLink={helpLink.customLink}
+            showNonLink={helpLink.showNonLink}
           />
         </span>
       ))}


### PR DESCRIPTION
## Description

Removes buttons from Help Menu and adds correct ordering and text for menu options. See Issues below for exact links.

## Screenshots

### Mobile
![Screenshot from 2020-01-13 18-43-27](https://user-images.githubusercontent.com/1673206/72301653-7a39db00-3635-11ea-9b57-73480830a811.png)

### Desktop
![Screenshot from 2020-01-13 18-46-12](https://user-images.githubusercontent.com/1673206/72301664-845bd980-3635-11ea-853b-0a4d01d55306.png)


## Issues

#5203 
#5210 