### PR TITLE
fix bulk cancel or orders

### DIFF
--- a/packages/augur-sdk/src/Augur.ts
+++ b/packages/augur-sdk/src/Augur.ts
@@ -465,9 +465,11 @@ export class Augur<TProvider extends Provider = Provider> {
   }
 
   async batchCancelOrders(orderHashes: string[]): Promise<void> {
-    const orders = orderHashes.map(async (orderHash) => {
-      return this.getOrder({ orderHash })
-    });
+    const orders = [];
+    for (let index = 0; index < orderHashes.length; index++) {
+      const order = await this.getOrder({ orderHash: orderHashes[index] });
+      orders.push(order);
+    }
     await this.zeroX.batchCancelOrders(orders);
   }
 

--- a/packages/augur-ui/src/modules/auth/actions/load-account-history.ts
+++ b/packages/augur-ui/src/modules/auth/actions/load-account-history.ts
@@ -1,5 +1,5 @@
 import { userPositionProcessing } from 'modules/positions/actions/load-account-positions';
-import { updateUserFilledOrders, bulkMarketTradingHistory, updateUserOpenOrders } from 'modules/markets/actions/market-trading-history-management';
+import { updateUserFilledOrders, bulkMarketTradingHistory, refreshUserOpenOrders } from 'modules/markets/actions/market-trading-history-management';
 import { clearTransactions } from 'modules/transactions/actions/update-transactions-data';
 import { ThunkDispatch, ThunkAction } from 'redux-thunk';
 import { Action } from 'redux';
@@ -37,7 +37,7 @@ async function loadTransactions(
   }), {});
 
   dispatch(updateMarketsData(marketsDataById));
-  if (userData.userOpenOrders) dispatch(updateUserOpenOrders(userData.userOpenOrders.orders));
+  if (userData.userOpenOrders) dispatch(refreshUserOpenOrders(userData.userOpenOrders.orders));
   dispatch(updateLoginAccount({ reporting: userData.userStakedRep }));
   if (userData.userPositions) userPositionProcessing(userData.userPositions, dispatch);
   if (userData.userPositionTotals) dispatch(updateLoginAccount(userData.userPositionTotals));

--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -285,7 +285,7 @@ export const handleOrderCreatedLog = (log: Logs.ParsedOrderEventLog) => (
   if (isUserDataUpdate) {
     handleAlert(log, PUBLICTRADE, false, dispatch, getState);
 
-    dispatch(loadAccountOpenOrders({ marketId }));
+    dispatch(loadAccountOpenOrders());
     dispatch(loadAccountPositionsTotals());
   }
 };
@@ -312,7 +312,7 @@ export const handleOrderCanceledLog = (log: Logs.ParsedOrderEventLog) => (
         params: { ...log },
       })
     );
-    dispatch(loadAccountOpenOrders({ marketId }));
+    dispatch(loadAccountOpenOrders());
     dispatch(loadAccountPositionsTotals());
   }
 };
@@ -329,7 +329,7 @@ export const handleOrderFilledLog = (log: Logs.ParsedOrderEventLog) => (
   if (isUserDataUpdate) {
     handleAlert(log, PUBLICFILLORDER, true, dispatch, getState);
     dispatch(loadUserFilledOrders({ marketId }));
-    dispatch(loadAccountOpenOrders({ marketId }));
+    dispatch(loadAccountOpenOrders());
     dispatch(orderFilled(marketId, log, isSameAddress(log.orderCreator, address)));
   }
   dispatch(loadMarketTradingHistory(marketId));

--- a/packages/augur-ui/src/modules/markets/actions/market-trading-history-management.ts
+++ b/packages/augur-ui/src/modules/markets/actions/market-trading-history-management.ts
@@ -10,9 +10,8 @@ import { FILLED, REPORTING_STATE } from 'modules/common/constants';
 import { Getters } from "@augurproject/sdk";
 
 export const UPDATE_USER_FILLED_ORDERS = 'UPDATE_USER_FILLED_ORDERS';
-export const UPDATE_USER_OPEN_ORDERS = 'UPDATE_USER_OPEN_ORDERS';
+export const REFRESH_USER_OPEN_ORDERS = 'REFRESH_USER_OPEN_ORDERS';
 export const BULK_MARKET_TRADING_HISTORY = 'BULK_MARKET_TRADING_HISTORY';
-export const UPDATE_USER_OPEN_ORDERS_MARKET = 'UPDATE_USER_OPEN_ORDERS_MARKET';
 
 export function bulkMarketTradingHistory(
   keyedMarketTradingHistory: Getters.Markets.MarketTradingHistory
@@ -38,24 +37,11 @@ export function updateUserFilledOrders(
   };
 }
 
-export function updateUserOpenOrdersInMarket(
-  marketId: string,
+export function refreshUserOpenOrders(
   openOrders: Getters.Markets.Orders
 ) {
   return {
-    type: UPDATE_USER_OPEN_ORDERS_MARKET,
-    data: {
-      marketId,
-      openOrders,
-    },
-  };
-}
-
-export function updateUserOpenOrders(
-  openOrders: Getters.Markets.Orders
-) {
-  return {
-    type: UPDATE_USER_OPEN_ORDERS,
+    type: REFRESH_USER_OPEN_ORDERS,
     data: {
       openOrders,
     },

--- a/packages/augur-ui/src/modules/orders/actions/load-account-open-orders.ts
+++ b/packages/augur-ui/src/modules/orders/actions/load-account-open-orders.ts
@@ -2,25 +2,24 @@ import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
 import { augurSdk } from 'services/augursdk';
 import { AppState } from 'store';
-import { updateUserOpenOrders, updateUserOpenOrdersInMarket } from 'modules/markets/actions/market-trading-history-management';
+import { refreshUserOpenOrders } from 'modules/markets/actions/market-trading-history-management';
 import { updateLoginAccount } from 'modules/account/actions/login-account';
 
-export const loadAccountOpenOrders = (
-  options: any = {},
-  marketIdAggregator: Function
-) => async (dispatch: ThunkDispatch<void, any, Action>, getState: () => AppState) => {
+export const loadAccountOpenOrders = () => async (
+  dispatch: ThunkDispatch<void, any, Action>,
+  getState: () => AppState
+) => {
   const { universe, loginAccount } = getState();
   const Augur = augurSdk.get();
   const userOpenOrders = await Augur.getUserOpenOrders({
     universe: universe.id,
     account: loginAccount.mixedCaseAddress,
   });
-  if (marketIdAggregator) marketIdAggregator(Object.keys(userOpenOrders.orders));
-  dispatch(updateUserOpenOrders(userOpenOrders.orders));
-  if (options.marketId) {
-    // update orders in market, they could have been cancelled
-    dispatch(updateUserOpenOrdersInMarket(options.marketId, userOpenOrders.orders));
-  }
-  if (userOpenOrders.totalOpenOrdersFrozenFunds) dispatch(updateLoginAccount({totalOpenOrdersFrozenFunds: userOpenOrders.totalOpenOrdersFrozenFunds}));
+  dispatch(refreshUserOpenOrders(userOpenOrders.orders));
+  if (userOpenOrders.totalOpenOrdersFrozenFunds)
+    dispatch(
+      updateLoginAccount({
+        totalOpenOrdersFrozenFunds: userOpenOrders.totalOpenOrdersFrozenFunds,
+      })
+    );
 };
-

--- a/packages/augur-ui/src/modules/orders/reducers/open-orders.ts
+++ b/packages/augur-ui/src/modules/orders/reducers/open-orders.ts
@@ -1,4 +1,4 @@
-import { UPDATE_USER_OPEN_ORDERS, UPDATE_USER_OPEN_ORDERS_MARKET } from 'modules/markets/actions/market-trading-history-management';
+import { REFRESH_USER_OPEN_ORDERS } from 'modules/markets/actions/market-trading-history-management';
 import { BaseAction, OpenOrders } from 'modules/types';
 import { CLEAR_LOGIN_ACCOUNT } from 'modules/account/actions/login-account';
 import { RESET_STATE } from 'modules/app/actions/reset-state';
@@ -10,22 +10,10 @@ export default function(
   { type, data }: BaseAction
 ): OpenOrders {
   switch (type) {
-    case UPDATE_USER_OPEN_ORDERS: {
+    case REFRESH_USER_OPEN_ORDERS: {
       const { openOrders } = data;
 
       return {
-        ...userOpenOrders,
-        ...openOrders,
-      };
-    }
-    case UPDATE_USER_OPEN_ORDERS_MARKET: {
-      const { marketId, openOrders } = data;
-      const ordersNotInMarket = Object.keys(userOpenOrders).reduce(
-        (p, m) => (m !== marketId ? { ...p, [m]: userOpenOrders[m] } : p),
-        {}
-      );
-      return {
-        ...ordersNotInMarket,
         ...openOrders,
       };
     }


### PR DESCRIPTION
noticed an issue with bulk cancellation of orders. `batchCancelOrders` used map which doesn't wait for the promise to resolve so the promise was passed to contract call. Changed map to for loop so getOrders gets resolved before calling zeroX.batchCancelOrders