### PR TITLE
adjust price based on numTicks of market

### DIFF
--- a/packages/augur-ui/src/modules/market/containers/market-outcome.ts
+++ b/packages/augur-ui/src/modules/market/containers/market-outcome.ts
@@ -1,31 +1,29 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { AppState } from 'store';
-import getValue from 'utils/get-value';
 import { COLUMN_TYPES, INVALID_OUTCOME_ID } from 'modules/common/constants';
 import { selectMarketOutcomeBestBidAsk, selectBestBidAlert } from 'modules/markets/selectors/select-market-outcome-best-bid-ask';
 import Row from 'modules/common/row';
-import { ThunkDispatch } from 'redux-thunk';
-import { Action } from 'redux';
 
 const mapStateToProps = (state: AppState, ownProps) => {
   const { marketInfos } = state;
   const market = marketInfos[ownProps.marketId];
-  const { minPrice, maxPrice } = market;
+  const { minPrice, maxPrice, tickSize } = market;
   return {
     orderBook: state.orderBooks ? state.orderBooks[ownProps.marketId] : null,
     minPrice,
     maxPrice,
+    tickSize
   };
 };
 
-const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({});
+const mapDispatchToProps = () => ({});
 
 const mergeProps = (sP: any, dP: any, oP: any) => {
   const outcome = oP.outcome;
   const outcomeName = outcome.description;
   const orderBook = sP.orderBook && sP.orderBook[outcome.id];
-  const { topAsk, topBid } = selectMarketOutcomeBestBidAsk(orderBook);
+  const { topAsk, topBid } = selectMarketOutcomeBestBidAsk(orderBook, sP.tickSize);
   const bestBidAlert = selectBestBidAlert(outcome.id, topBid.price.value, sP.minPrice, sP.maxPrice)
   const topBidShares = topBid.shares;
   const topAskShares = topAsk.shares;
@@ -56,6 +54,7 @@ const mergeProps = (sP: any, dP: any, oP: any) => {
       useFull: true,
       showEmptyDash: true,
       alert: bestBidAlert,
+
     },
     {
       key: "topAskPrice",

--- a/packages/augur-ui/src/modules/markets/selectors/select-market-outcome-best-bid-ask.ts
+++ b/packages/augur-ui/src/modules/markets/selectors/select-market-outcome-best-bid-ask.ts
@@ -1,15 +1,15 @@
-import { formatNone, formatShares, formatDai } from 'utils/format-number';
+import { formatNone, formatShares, formatBestPrice } from 'utils/format-number';
 import { INVALID_OUTCOME_ID, INVALID_BEST_BID_ALERT_VALUE } from 'modules/common/constants';
 import { createBigNumber } from 'utils/create-big-number';
 
-export const selectMarketOutcomeBestBidAsk = orderBook => {
+export const selectMarketOutcomeBestBidAsk = (orderBook, tickSize = 0) => {
   const none = { price: formatNone(), shares: formatNone() };
   let topAsk = none;
   let topBid = none;
 
   const formatData = item => {
     return {
-      price: formatDai(item.price),
+      price: formatBestPrice(item.price, tickSize),
       shares: formatShares(item.shares, {decimals: 2, decimalsRounded: 2}),
     };
   };

--- a/packages/augur-ui/src/modules/markets/selectors/select-market-outcome-best-bid-ask.ts
+++ b/packages/augur-ui/src/modules/markets/selectors/select-market-outcome-best-bid-ask.ts
@@ -1,45 +1,51 @@
 import { formatNone, formatShares, formatBestPrice } from 'utils/format-number';
-import { INVALID_OUTCOME_ID, INVALID_BEST_BID_ALERT_VALUE } from 'modules/common/constants';
+import {
+  INVALID_OUTCOME_ID,
+  INVALID_BEST_BID_ALERT_VALUE,
+} from 'modules/common/constants';
 import { createBigNumber } from 'utils/create-big-number';
+import memoize from 'memoizee';
 
-export const selectMarketOutcomeBestBidAsk = (orderBook, tickSize = 0) => {
-  const none = { price: formatNone(), shares: formatNone() };
-  let topAsk = none;
-  let topBid = none;
+export const selectMarketOutcomeBestBidAsk = memoize(
+  (orderBook, tickSize = 0) => {
+    const none = { price: formatNone(), shares: formatNone() };
+    let topAsk = none;
+    let topBid = none;
 
-  const formatData = item => {
-    return {
-      price: formatBestPrice(item.price, tickSize),
-      shares: formatShares(item.shares, {decimals: 2, decimalsRounded: 2}),
+    const formatData = item => {
+      return {
+        price: formatBestPrice(item.price, tickSize),
+        shares: formatShares(item.shares, { decimals: 2, decimalsRounded: 2 }),
+      };
     };
-  };
 
-  if (orderBook) {
-    topAsk =
-      orderBook.asks && orderBook.asks.length > 0
-        ? orderBook.asks
-            // Ascending order for asks
-            .sort((a, b) => Number(a.price) - Number(b.price))
-            .map(item => formatData(item))
-            .shift()
-        : topAsk;
+    if (orderBook) {
+      topAsk =
+        orderBook.asks && orderBook.asks.length > 0
+          ? orderBook.asks
+              // Ascending order for asks
+              .sort((a, b) => Number(a.price) - Number(b.price))
+              .map(item => formatData(item))
+              .shift()
+          : topAsk;
 
-    topBid =
-      orderBook.bids && orderBook.bids.length > 0
-        ? orderBook.bids
-            // Decreasing order for bids
-            .sort((a, b) => Number(b.price) - Number(a.price))
-            .map(item => formatData(item))
-            .shift()
-        : topBid;
-  }
+      topBid =
+        orderBook.bids && orderBook.bids.length > 0
+          ? orderBook.bids
+              // Decreasing order for bids
+              .sort((a, b) => Number(b.price) - Number(a.price))
+              .map(item => formatData(item))
+              .shift()
+          : topBid;
+    }
 
-  return {
-    topAsk,
-    topBid,
-  };
-};
-
+    return {
+      topAsk,
+      topBid,
+    };
+  },
+  { max: 1 }
+);
 
 export const selectBestBidAlert = (
   outcomeId: number,
@@ -49,6 +55,8 @@ export const selectBestBidAlert = (
 ) => {
   if (outcomeId !== INVALID_OUTCOME_ID) return false;
   const range = createBigNumber(maxPrice).minus(createBigNumber(minPrice));
-  const percentage = (createBigNumber(bestBidPrice).minus(createBigNumber(minPrice))).dividedBy(range);
+  const percentage = createBigNumber(bestBidPrice)
+    .minus(createBigNumber(minPrice))
+    .dividedBy(range);
   return percentage.gte(INVALID_BEST_BID_ALERT_VALUE);
 };

--- a/packages/augur-ui/src/utils/format-number.ts
+++ b/packages/augur-ui/src/utils/format-number.ts
@@ -159,7 +159,7 @@ export function formatBestPrice(
     decimals = String(tickSize).split(".")[1].length;
   }
   return formatNumber(num, {
-    decimals: decimals,
+    decimals,
     decimalsRounded: decimals,
     denomination: v => {
       const isNegative = Number(v) < 0;

--- a/packages/augur-ui/src/utils/format-number.ts
+++ b/packages/augur-ui/src/utils/format-number.ts
@@ -100,7 +100,7 @@ export function formatDaiEstimate(
   return formatNumber(num, {
     decimals: 2,
     decimalsRounded: 2,
-    
+
     denomination: v => {
       const isNegative = Number(v) < 0;
       const val = isNegative ? createBigNumber(v).abs().toFixed(2) : v;
@@ -147,6 +147,35 @@ export function formatShares(
   });
 
   return formattedShares;
+}
+
+export function formatBestPrice(
+  num: NumStrBigNumber,
+  tickSize: number,
+  opts: FormattedNumberOptions = {}
+): FormattedNumber {
+  let decimals = 0;
+  if(String(tickSize).indexOf('.') >= 0) {
+    decimals = String(tickSize).split(".")[1].length;
+  }
+  return formatNumber(num, {
+    decimals: decimals,
+    decimalsRounded: decimals,
+    denomination: v => {
+      const isNegative = Number(v) < 0;
+      const val = isNegative
+        ? createBigNumber(v)
+            .abs()
+            .toFixed(2)
+        : v;
+      return `${isNegative ? '-' : ''}${val}`;
+    },
+    positiveSign: false,
+    zeroStyled: false,
+    blankZero: false,
+    bigUnitPostfix: false,
+    ...opts,
+  });
 }
 
 export function formatDai(


### PR DESCRIPTION
remove `$` in market trading page outcome best prices. 
adjust price based on market tickSize.


![image](https://user-images.githubusercontent.com/3970376/72469419-f868bf80-37a4-11ea-8740-97e8d6f61a95.png)


scalar price needs to use tickSize for decimals
![image](https://user-images.githubusercontent.com/3970376/72469725-a2e0e280-37a5-11ea-9fa5-586c95f0a7a5.png)
