### PR TITLE
Update font-weight to semi-bold in dropdowns

### DIFF
--- a/packages/augur-ui/src/modules/common/selection.styles.less
+++ b/packages/augur-ui/src/modules/common/selection.styles.less
@@ -108,7 +108,7 @@
   }
 
   > button {
-    .text-12;
+    .text-12-medium;
 
     @media @breakpoint-mobile {
       .text-12-bold;
@@ -144,7 +144,7 @@
   }
 
   > div > button {
-    .text-12;
+    .text-12-medium;
 
     padding: 0 @size-12;
     height: @size-32;
@@ -174,7 +174,7 @@
   }
 
   > button {
-    .text-10;
+    .text-10-semi-bold;
 
     @media @breakpoint-mobile {
       .text-10-bold;
@@ -220,7 +220,7 @@
   }
 
   > div > button {
-    .text-10;
+    .text-10-semi-bold;
 
     padding: 0 @size-8;
     height: @size-24;

--- a/packages/augur-ui/src/modules/trading/components/form.styles.less
+++ b/packages/augur-ui/src/modules/trading/components/form.styles.less
@@ -317,7 +317,7 @@
   padding: @size-12 @size-12 0;
 
   > div > button {
-    .text-12;
+    .text-12-medium;
   }
 }
 


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/5016

Update font-weight based on feedback on
https://github.com/AugurProject/augur/issues/5016#issuecomment-575127738 
> Only thing is that it's showing up as regular rather than semi-bold. Could you please update to Semi-bold as regular looks too weak. thanks

Build
![Screen Shot 2020-01-17 at 1 02 41 AM](https://user-images.githubusercontent.com/58647954/72598656-13caec00-38c5-11ea-856c-2da5f3c6faae.png)
