### PR TITLE
Ui add swap component

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ NOTE: Run `yarn` at the base of the repository to install dependencies before ru
 |  `yarn build:watch`   |  Build everything but the UI continuously. |
 |  `yarn build:clean`   |  Remove JUST typescript build artifacts |
 |  `yarn clean`         |  Remove everything that isn't currently being tracked by git (node_modules, build aretifacts, etc.) |
+|  `yarn docker:all`    |  Run all the needed dockers to run the UI in dev mode
 
 ## UI development
 

--- a/packages/augur-ui/src/modules/app/actions/init-augur.ts
+++ b/packages/augur-ui/src/modules/app/actions/init-augur.ts
@@ -26,6 +26,7 @@ import {
   MODAL_BUY_DAI,
   MODAL_TEST_BET,
   MODAL_TUTORIAL_INTRO,
+  SIGNIN_LOADING_TEXT,
 } from 'modules/common/constants';
 import { windowRef } from 'utils/window-ref';
 import { AppState } from 'store';
@@ -89,7 +90,7 @@ function pollForAccount(
                 setTimeout(() => {
                   dispatch(closeModal());
                 }),
-              message: `Connecting to our partners at ${accountType} to create your secure account.`,
+              message: accountType === ACCOUNT_TYPES.WEB3WALLET ? SIGNIN_LOADING_TEXT : `Connecting to our partners at ${accountType} to create your secure account.`,
               showLearnMore: true,
               showCloseAfterDelay: true,
             })

--- a/packages/augur-ui/src/modules/app/reducers/gas-price-info.ts
+++ b/packages/augur-ui/src/modules/app/reducers/gas-price-info.ts
@@ -6,7 +6,7 @@ import { BaseAction, GasPriceInfo } from 'modules/types';
 import { GWEI_CONVERSION } from 'modules/common/constants';
 
 const gasPriceSafeLow = 1000000000; // default value safeLow
-const gasPriceAverage = 2000000000; // default value average
+const gasPriceAverage = 4000000000; // default value average
 const gasPriceFast = 20000000000; // default value fast
 
 const inGwei = (gasPrice) => {

--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -113,11 +113,11 @@ export const WALLET_TYPE = {
 
 export const SIGNIN_LOADING_TEXT = 'Sit tight - loading your account.';
 export const SIGNIN_LOADING_TEXT_PORTIS =
-  'Follow instructions in the Portis window.';
+  'Connecting to our partners at Portis to create your secure account.';
 export const SIGNIN_LOADING_TEXT_FORTMATIC =
-  'Follow instructions in the Fortmatic window.';
+  'Connecting to our partners at Fortmatic to create your secure account.';
 export const SIGNIN_LOADING_TEXT_TORUS =
-  'Follow instructions in the Tor.us window.';
+  'Connecting to our partners at Tor.us to create your secure account.';
 export const SIGNIN_SIGN_WALLET =
   'Your wallet will ask you to digitally sign in to link it with Augur';
 

--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -93,6 +93,12 @@ export const SIXTY_DAYS = 60 * SECONDS_PER_DAY;
 
 export const EDGE_WALLET_TYPE = 'wallet:ethereum';
 
+// Add Funds types
+export const ADD_FUNDS_SWAP = '0';
+export const ADD_FUNDS_CREDIT_CARD = '1';
+export const ADD_FUNDS_COINBASE = '2';
+export const ADD_FUNDS_TRANSFER = '3';
+
 // # Connect Constants
 export const ACCOUNT_TYPES = {
   EDGE: 'Edge',

--- a/packages/augur-ui/src/modules/common/icons.tsx
+++ b/packages/augur-ui/src/modules/common/icons.tsx
@@ -2385,3 +2385,14 @@ export const ScalarMarketIcon = (
     />
   </svg>
 );
+
+export const SwapArrow = (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+    <path d="M8 0.75V15.25" strokeMiterlimit="10" />
+    <path
+      d="M12.5 10.75L8 15.25L3.5 10.75"
+      strokeMiterlimit="10"
+      strokeLinecap="square"
+    />
+  </svg>
+);

--- a/packages/augur-ui/src/modules/markets-list/components/landing-hero.styles.less
+++ b/packages/augur-ui/src/modules/markets-list/components/landing-hero.styles.less
@@ -66,12 +66,13 @@
     }
   }
 
-  @media @breakpoint-mobile {
+  @media all and (max-width: @step-2-2) {
     height: 100%;
     padding: @size-24 @size-16;
 
     > img {
       height: 100%;
+      width: fit-content;
     }
 
     > div:first-of-type {

--- a/packages/augur-ui/src/modules/modal/add-funds.tsx
+++ b/packages/augur-ui/src/modules/modal/add-funds.tsx
@@ -26,6 +26,8 @@ interface AddFundsProps {
   autoSelect?: boolean;
   fundType: string;
   loginAccount: LoginAccount;
+  ETH_RATE: number;
+  REP_Rate: number;
 }
 
 export const generateDaiTooltip = (
@@ -58,6 +60,8 @@ export const AddFunds = ({
   autoSelect = false,
   fundType = DAI,
   loginAccount,
+  ETH_RATE,
+  REP_RATE,
 }: AddFundsProps) => {
   const address = loginAccount.address
   const accountMeta =loginAccount.meta;
@@ -167,7 +171,10 @@ export const AddFunds = ({
               <Swap
                 balances={loginAccount.balances}
                 toToken={REP}
-                fromToken={DAI} />
+                fromToken={DAI}
+                ETH_RATE={ETH_RATE}
+                REP_RATE={REP_RATE}
+              />
             </>
           )}
 

--- a/packages/augur-ui/src/modules/modal/add-funds.tsx
+++ b/packages/augur-ui/src/modules/modal/add-funds.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-
 import {
   ExternalLinkButton,
   PrimaryButton,
@@ -20,14 +19,13 @@ import TooltipStyles from 'modules/common/tooltip.styles.less';
 import Styles from 'modules/modal/modal.styles.less';
 import { helpIcon } from 'modules/common/icons';
 import noop from 'utils/noop';
+import { Swap } from 'modules/swap/components';
 
 interface AddFundsProps {
   closeAction: Function;
-  address: string;
-  accountMeta: LoginAccount['meta'];
-  Gnosis_ENABLED: boolean;
   autoSelect?: boolean;
   fundType: string;
+  loginAccount: LoginAccount;
 }
 
 export const generateDaiTooltip = (
@@ -57,17 +55,26 @@ export const generateDaiTooltip = (
 
 export const AddFunds = ({
   closeAction,
-  accountMeta,
-  address,
-  Gnosis_ENABLED = false,
   autoSelect = false,
   fundType = DAI,
+  loginAccount,
 }: AddFundsProps) => {
+  const address = loginAccount.address
+  const accountMeta =loginAccount.meta;
   let autoSelection = '2'; // default Coinbase
 
   if (autoSelect) {
-    if ([ACCOUNT_TYPES.TORUS, ACCOUNT_TYPES.PORTIS].includes(accountMeta.accountType) && fundType !== REP) {
+    if (
+      [ACCOUNT_TYPES.TORUS, ACCOUNT_TYPES.PORTIS].includes(
+        accountMeta.accountType
+      ) &&
+      fundType !== REP
+    ) {
       autoSelection = '1'; // default Credit/Debit Card
+    } else if (
+      fundType === REP
+    ) {
+      autoSelection = '0'; // default Uniswap
     }
   }
 
@@ -75,9 +82,9 @@ export const AddFunds = ({
   const fundTypeLabel = fundType === DAI ? 'Dai ($)' : 'REP';
 
   const FUND_OTPIONS = [
-    // TODO build uniswap component
-    { header: 'Swap',
-      description: 'Swap funds in your account for REP',
+    {
+      header: 'Swap',
+      description: `Swap funds in your account for ${fundTypeLabel}`,
       value: '0',
     },
     {
@@ -99,8 +106,18 @@ export const AddFunds = ({
 
   const addFundsOptions = [FUND_OTPIONS[2], FUND_OTPIONS[3]];
 
-  if (fundType !== REP && (accountMeta.accountType === ACCOUNT_TYPES.TORUS || accountMeta.accountType === ACCOUNT_TYPES.PORTIS)) {
+  if (
+    fundType !== REP &&
+    (accountMeta.accountType === ACCOUNT_TYPES.TORUS ||
+      accountMeta.accountType === ACCOUNT_TYPES.PORTIS)
+  ) {
     addFundsOptions.unshift(FUND_OTPIONS[1]);
+  }
+
+  if (
+    fundType === REP
+  ) {
+    addFundsOptions.unshift(FUND_OTPIONS[0]);
   }
 
   return (
@@ -135,7 +152,25 @@ export const AddFunds = ({
           <BackButton action={() => setSelectedOption(() => null)} />
           <CloseButton action={() => closeAction()} />
         </div>
-        <div className={selectedOption === '3' ? Styles.AddFundsTransfer : Styles.AddFundsCreditDebitCoinbase}>
+        <div
+          className={
+            selectedOption === '3'
+              ? Styles.AddFundsTransfer
+              : Styles.AddFundsCreditDebitCoinbase
+          }
+        >
+          {selectedOption === '0' && (
+            <>
+              <h1>Swap</h1>
+              <h2>Swap a currency for {fundTypeLabel}</h2>
+
+              <Swap
+                balances={loginAccount.balances}
+                toToken={REP}
+                fromToken={DAI} />
+            </>
+          )}
+
           {selectedOption === '1' && (
             <>
               <h1>Credit/debit card</h1>

--- a/packages/augur-ui/src/modules/modal/add-funds.tsx
+++ b/packages/augur-ui/src/modules/modal/add-funds.tsx
@@ -13,7 +13,15 @@ import { RadioTwoLineBarGroup, TextInput } from 'modules/common/form';
 import classNames from 'classnames';
 import ReactTooltip from 'react-tooltip';
 import { toChecksumAddress } from 'ethereumjs-util';
-import { ACCOUNT_TYPES, DAI, REP } from 'modules/common/constants';
+import {
+  ACCOUNT_TYPES,
+  DAI,
+  REP,
+  ADD_FUNDS_SWAP,
+  ADD_FUNDS_COINBASE,
+  ADD_FUNDS_CREDIT_CARD,
+  ADD_FUNDS_TRANSFER,
+} from 'modules/common/constants';
 import { LoginAccount } from 'modules/types';
 import TooltipStyles from 'modules/common/tooltip.styles.less';
 import Styles from 'modules/modal/modal.styles.less';
@@ -27,7 +35,7 @@ interface AddFundsProps {
   fundType: string;
   loginAccount: LoginAccount;
   ETH_RATE: number;
-  REP_Rate: number;
+  REP_RATE: number;
 }
 
 export const generateDaiTooltip = (
@@ -64,8 +72,8 @@ export const AddFunds = ({
   REP_RATE,
 }: AddFundsProps) => {
   const address = loginAccount.address
-  const accountMeta =loginAccount.meta;
-  let autoSelection = '2'; // default Coinbase
+  const accountMeta = loginAccount.meta;
+  let autoSelection = ADD_FUNDS_COINBASE;
 
   if (autoSelect) {
     if (
@@ -74,11 +82,11 @@ export const AddFunds = ({
       ) &&
       fundType !== REP
     ) {
-      autoSelection = '1'; // default Credit/Debit Card
+      autoSelection = ADD_FUNDS_CREDIT_CARD;
     } else if (
       fundType === REP
     ) {
-      autoSelection = '0'; // default Uniswap
+      autoSelection = ADD_FUNDS_SWAP;
     }
   }
 
@@ -89,22 +97,22 @@ export const AddFunds = ({
     {
       header: 'Swap',
       description: `Swap funds in your account for ${fundTypeLabel}`,
-      value: '0',
+      value: ADD_FUNDS_SWAP,
     },
     {
       header: 'Credit/debit card',
       description: 'Add Funds instantly using a credit/debit card',
-      value: '1',
+      value: ADD_FUNDS_CREDIT_CARD,
     },
     {
       header: 'Coinbase',
       description: 'Send funds from a Coinbase account',
-      value: '2',
+      value: ADD_FUNDS_COINBASE,
     },
     {
       header: 'Transfer',
       description: 'Send funds to your Augur account address',
-      value: '3',
+      value: ADD_FUNDS_TRANSFER,
     },
   ];
 
@@ -158,12 +166,12 @@ export const AddFunds = ({
         </div>
         <div
           className={
-            selectedOption === '3'
+            selectedOption === ADD_FUNDS_TRANSFER
               ? Styles.AddFundsTransfer
               : Styles.AddFundsCreditDebitCoinbase
           }
         >
-          {selectedOption === '0' && (
+          {selectedOption === ADD_FUNDS_SWAP && (
             <>
               <h1>Swap</h1>
               <h2>Swap a currency for {fundTypeLabel}</h2>
@@ -178,7 +186,7 @@ export const AddFunds = ({
             </>
           )}
 
-          {selectedOption === '1' && (
+          {selectedOption === ADD_FUNDS_CREDIT_CARD && (
             <>
               <h1>Credit/debit card</h1>
               {accountMeta.accountType === ACCOUNT_TYPES.PORTIS && (
@@ -216,7 +224,7 @@ export const AddFunds = ({
               </h4>
             </>
           )}
-          {selectedOption === '2' && (
+          {selectedOption === ADD_FUNDS_COINBASE && (
             <>
               <h1>Coinbase</h1>
               <h2>
@@ -238,7 +246,7 @@ export const AddFunds = ({
               <ExternalLinkButton URL='https://docs.augur.net/' label={'Learn about your address'} />
             </>
           )}
-          {selectedOption === '3' && (
+          {selectedOption === ADD_FUNDS_TRANSFER && (
             <>
               <h1>Transfer</h1>
               <h2>

--- a/packages/augur-ui/src/modules/modal/containers/modal-add-funds.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-add-funds.ts
@@ -8,10 +8,18 @@ import { Action } from 'redux';
 import getValue from 'utils/get-value';
 import { ADD_FUNDS, track } from 'services/analytics/helpers';
 
-const mapStateToProps = (state: AppState) => ({
-  modal: state.modal,
-  loginAccount: state.loginAccount,
-});
+const mapStateToProps = (state: AppState) => {
+  // TODO placeholder rates until price feed is hooked up
+  const ETH_RATE = 160.63;
+  const REP_RATE = 15.87;
+
+  return {
+    modal: state.modal,
+    loginAccount: state.loginAccount,
+    ETH_RATE,
+    REP_RATE
+  }
+};
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({
   closeModal: () => dispatch(closeModal()),

--- a/packages/augur-ui/src/modules/modal/containers/modal-add-funds.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-add-funds.ts
@@ -10,9 +10,7 @@ import { ADD_FUNDS, track } from 'services/analytics/helpers';
 
 const mapStateToProps = (state: AppState) => ({
   modal: state.modal,
-  address: getValue(state, 'loginAccount.address'),
-  Gnosis_ENABLED: getValue(state, 'appStatus.gnosisEnabled'),
-  accountMeta: getValue(state, 'loginAccount.meta'),
+  loginAccount: state.loginAccount,
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({

--- a/packages/augur-ui/src/modules/swap/components/index.styles.less
+++ b/packages/augur-ui/src/modules/swap/components/index.styles.less
@@ -1,0 +1,105 @@
+@import (reference) '~assets/styles/shared';
+
+.Swap {
+  > div:nth-of-type(2) {
+    align-items: center;
+    background: @color-table-header;
+    display: flex;
+    height: @size-40;
+    justify-content: center;
+    margin: 0 @size-8;
+
+    > svg > path {
+      stroke: @color-primary-action;
+    }
+  }
+
+  > button {
+    .text-16-bold;
+
+    background: @color-primary-action;
+    border-radius: 58px;
+    height: 50px;
+    margin-top: @size-48;
+    width: 100%;
+  }
+}
+
+.SwapRow {
+  background: @color-dark-grey;
+  border-radius: @size-12;
+  display: flex;
+  flex-direction: column;
+  height: 87px;
+  justify-content: space-between;
+  padding: @size-12 @size-16;
+
+  > div {
+    display: flex;
+    justify-content: space-between;
+    user-select: none;
+    cursor: pointer;
+  }
+
+  > div:first-of-type {
+    > div {
+      .text-12;
+
+      color: @color-primary-text;
+    }
+  }
+
+  > div:last-of-type {
+    > div {
+      .text-24;
+
+      color: @color-secondary-text;
+    }
+
+    > div:last-of-type {
+      > div {
+        .text-16;
+
+        align-items: center;
+        background: @color-secondary-action;
+        border: @size-1 solid @color-secondary-action-outline;
+        border-radius: @size-16;
+        display: flex;
+        justify-content: space-evenly;
+        height: @size-32;
+        width: 98px;
+
+        svg {
+          fill: @color-outcome-seven;
+          transform: scale(1.25);
+          width: @size-16;
+        }
+      }
+    }
+  }
+}
+
+.SwapRow:first-of-type {
+  > div:last-of-type > input {
+    .text-24;
+
+    padding: 0;
+  }
+}
+
+.SwapRate {
+  align-items: center;
+  background: @color-table-header;
+  border-bottom-left-radius: @size-12;
+  border-bottom-right-radius: @size-12;
+  display: flex;
+  justify-content: space-between;
+  margin: 0 @size-8;
+  padding: @size-8;
+
+  > div {
+    .text-12;
+
+    color: @color-secondary-text;
+  }
+}

--- a/packages/augur-ui/src/modules/swap/components/index.tsx
+++ b/packages/augur-ui/src/modules/swap/components/index.tsx
@@ -1,0 +1,167 @@
+import React, { useState } from 'react';
+
+import { ETH, DAI, REP } from 'modules/common/constants';
+import { AccountBalances, FormattedNumber } from 'modules/types';
+import {
+  SwapArrow,
+  REP as REPIcon,
+  ETH as ETHIcon,
+  DaiLogoIcon,
+} from 'modules/common/icons';
+import { formatEther, formatDai } from 'utils/format-number';
+
+import Styles from 'modules/swap/components/index.styles.less';
+
+interface SwapProps {
+  balances: AccountBalances;
+  toToken: string;
+  fromToken: string;
+}
+
+export const Swap = ({ balances, fromToken, toToken }: SwapProps) => {
+  // TODO placeholder rates until price feed is hooked up
+  const ETH_RATE = 160.63;
+  const REP_RATE = 15.87;
+
+  const setFromToken = () => {
+    const nextToken = selectedToken === ETH ? DAI : ETH;
+    setSelectedFromTokenAmount('');
+    setSelectedToken(nextToken);
+  };
+
+  const setTokenAmount = (amount, displayBalance) => {
+    if (amount < 0) {
+      setSelectedFromTokenAmount('');
+    } else if (amount > displayBalance) {
+      setSelectedFromTokenAmount(displayBalance);
+    } else {
+      setSelectedFromTokenAmount(amount);
+    }
+  };
+
+  let displayBalance;
+  const [selectedToken, setSelectedToken] = useState(fromToken);
+  const [selectedFromTokenAmount, setSelectedFromTokenAmount] = useState('');
+
+  if (selectedToken === DAI) {
+    displayBalance = formatDai(Number(balances.dai) || 0);
+  } else {
+    displayBalance = formatEther(
+      Number(balances[selectedToken === REP ? 'rep' : 'eth']) || 0
+    );
+  }
+
+  let result = 0;
+  if (Number(selectedFromTokenAmount) > 0 && selectedToken === DAI) {
+    result = Number(selectedFromTokenAmount) / REP_RATE;
+  }
+
+  if (selectedToken === ETH) {
+    result = (Number(selectedFromTokenAmount) * ETH_RATE) / REP_RATE;
+  }
+
+  return (
+    <div className={Styles.Swap}>
+      <SwapRow
+        amount={selectedFromTokenAmount}
+        token={selectedToken}
+        label={'Input'}
+        balance={displayBalance}
+        logo={selectedToken === DAI ? DaiLogoIcon : ETHIcon}
+        setTokenAmount={setTokenAmount}
+        setAmount={setSelectedFromTokenAmount}
+        setFromToken={setFromToken}
+      />
+
+      <div>{SwapArrow}</div>
+
+      <SwapRow
+        amount={result}
+        token={toToken}
+        label={'Output (estimated)'}
+        balance={formatEther(balances.rep)}
+        logo={REPIcon}
+      />
+
+      <SwapRate
+        baseToken={selectedToken}
+        swapForToken={REP}
+        repRate={REP_RATE}
+        ethRate={ETH_RATE}
+      />
+
+      <button>Swap</button>
+    </div>
+  );
+};
+
+interface SwapBlockProps {
+  token: string;
+  label: string;
+  balance: FormattedNumber;
+  amount: number | string;
+  setTokenAmount?: Function;
+  setFromToken?: Function;
+  setAmount?: Function;
+  logo?: React.ReactFragment;
+}
+
+export const SwapRow = ({
+  token,
+  label,
+  balance,
+  amount = 0,
+  setAmount,
+  setTokenAmount,
+  setFromToken,
+  logo = null,
+}: SwapBlockProps) => (
+  <div className={Styles.SwapRow}>
+    <div>
+      <div>{label}</div>
+      <div onClick={setAmount ? () => setAmount(balance.formattedValue) : null}>
+        Balance: {balance.formattedValue}
+      </div>
+    </div>
+
+    <div>
+      {!setTokenAmount && <div>{Number(amount).toFixed(4)}</div>}
+      {setTokenAmount && (
+        <input
+          placeholder='0'
+          type='number'
+          value={amount}
+          onChange={e => setTokenAmount(e.target.value, balance.formattedValue)}
+        />
+      )}
+      <div>
+        <div onClick={setFromToken ? () => setFromToken() : null}>
+          {logo} {token}
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+interface SwapRateProps {
+  baseToken: string;
+  swapForToken: string;
+  repRate: number;
+  ethRate: number;
+}
+
+export const SwapRate = ({
+  baseToken,
+  swapForToken,
+  repRate,
+  ethRate,
+}: SwapRateProps) => (
+  <div className={Styles.SwapRate}>
+    <div>Exchange Rate</div>
+    <div>{`1 ${swapForToken} = ${
+      baseToken === DAI
+        ? repRate + ' DAI'
+        : (repRate / ethRate).toFixed(4) + ' ETH'
+    }`}</div>
+  </div>
+);

--- a/packages/contract-dependencies-gnosis/src/ContractDependenciesGnosis.ts
+++ b/packages/contract-dependencies-gnosis/src/ContractDependenciesGnosis.ts
@@ -20,7 +20,7 @@ import { ethers } from 'ethers';
 import { getAddress } from 'ethers/utils/address';
 import * as _ from 'lodash';
 
-const DEFAULT_GAS_PRICE = new BigNumber(10 ** 9);
+const DEFAULT_GAS_PRICE = new BigNumber(10 ** 9 * 4); // Default: GasPrice: 4
 const BASE_GAS_ESTIMATE = '75000';
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
 const GWEI_CONVERSION = 1000000000;
@@ -76,7 +76,7 @@ export class ContractDependenciesGnosis extends ContractDependenciesEthers {
         gasToken: '0x0',
         safeTxGas: '0x0',
         dataGas: new BigNumber(0),
-        gasPrice: new BigNumber(0),
+        gasPrice: DEFAULT_GAS_PRICE,
         refundReceiver: '0x0',
         nonce: nonce - 1,
         value: new BigNumber(0),
@@ -91,7 +91,7 @@ export class ContractDependenciesGnosis extends ContractDependenciesEthers {
           gasToken: '0x0',
           safeTxGas: '0x0',
           dataGas: new BigNumber(0),
-          gasPrice: new BigNumber(0),
+          gasPrice: DEFAULT_GAS_PRICE,
           refundReceiver: '0x0',
           nonce: -1,
           value: new BigNumber(0),
@@ -256,6 +256,7 @@ export class ContractDependenciesGnosis extends ContractDependenciesEthers {
       value: value ? new BigNumber(value.toString()) : new BigNumber(0),
       operation: Operation.Call,
       gasToken: this.gasToken,
+      gasPrice: new ethers.utils.BigNumber(Number(this.gasPrice).toFixed()),
     };
 
     const gasEstimates: RelayTxEstimateResponse = await this.estimateTransactionViaRelay(
@@ -346,6 +347,7 @@ export class ContractDependenciesGnosis extends ContractDependenciesEthers {
       value: new BigNumber(value.toString()),
       operation,
       gasToken: this.gasToken,
+      gasPrice: this.gasPrice,
     };
 
     let gasEstimates: RelayTxEstimateResponse;


### PR DESCRIPTION

- first pass at swap. Adding UI components and wiring up to AddFunds (REP flow). Middleware work still required for swap/price feeds.
<img width="444" src="https://user-images.githubusercontent.com/1683736/72638038-89b86d00-3930-11ea-987e-6543fe0a9d95.png">


- closes #5447 [Background image is stretching and imagery is being warped]
- closes #4893 [Loading modal fixes]
- closes #2278  [If Eth gas station is down or has not responded use reasonable gas estimate]
