### PR TITLE
Fix width in outcome selector in order ticket #5617

### DIFF
--- a/packages/augur-ui/src/modules/common/selection.styles.less
+++ b/packages/augur-ui/src/modules/common/selection.styles.less
@@ -54,6 +54,7 @@
     overflow-y: auto;
     position: absolute;
     top: 106%;
+    width: 100%;
     z-index: @mask;
 
     > div:first-of-type {


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/5617

It was
![68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3563303761663437303335383935333038393131633463352f32396234393564362d353464392d343435642d396532362d633566393266373663613761](https://user-images.githubusercontent.com/58647954/72772373-8cc58e80-3bb8-11ea-8eb8-c70e23417bd9.png)

With PR, it will be
![Screen Shot 2020-01-20 at 7 05 16 PM](https://user-images.githubusercontent.com/58647954/72772403-9d760480-3bb8-11ea-94d0-b32e8d6d5415.png)


