### PR TITLE
add confirmation time endpoint, wire up to expiry check

### DIFF
--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -55,6 +55,10 @@ export const GAS_PRICE_BACKUP_API_ENDPOINT = {
   [NETWORK_IDS.Mainnet]: 'https://api.etherscan.io/api?module=gastracker&action=gasoracle',
 }
 
+export const GAS_CONFIRM_ESTIMATE = {
+  [NETWORK_IDS.Mainnet]: 'https://api.etherscan.io/api?module=gastracker&action=gasestimate&gasprice=',
+}
+
 export const GAS_SPEED_LABELS = {
   STANDARD: 'Standard',
   FAST: 'Fast',

--- a/packages/augur-ui/src/modules/trading/containers/form.ts
+++ b/packages/augur-ui/src/modules/trading/containers/form.ts
@@ -6,11 +6,20 @@ import { formatOrderBook } from 'modules/create-market/helpers/format-order-book
 import { orderPriceEntered, orderAmountEntered } from 'services/analytics/helpers';
 import { AppState } from 'store';
 import { totalTradingBalance } from 'modules/auth/selectors/login-account';
+import { formatGasCost } from 'utils/format-number';
+import { createBigNumber } from 'utils/create-big-number';
+import { GWEI_CONVERSION } from 'modules/common/constants';
 
 
 const mapStateToProps = (state: AppState, ownProps) => {
   const { loginAccount, appStatus, blockchain } = state;
   const { zeroXEnabled: Ox_ENABLED } = appStatus;
+
+  const gasPriceInWei = formatGasCost(
+    createBigNumber(state.gasPriceInfo.userDefinedGasPrice || 0).times(
+      createBigNumber(GWEI_CONVERSION)
+    ), {}
+  ).value;
 
   const selectedOutcomeId =
     ownProps.selectedOutcome !== undefined &&
@@ -35,6 +44,7 @@ const mapStateToProps = (state: AppState, ownProps) => {
       ownProps.market.outcomesFormatted
     ),
     Ox_ENABLED,
+    gasPrice: gasPriceInWei,
   };
 };
 


### PR DESCRIPTION

- Added confirmation by gasPrice estimate endpoint
- Updated errors[this.INPUT_TYPES.EXPIRATION_DATE].push(`Order expires less than 70 seconds into the future`);} to use getGasConfirmEstimate * 1.5 seconds time
