### PR TITLE
Fix Waiting For Gnosis Safe error

### DIFF
--- a/packages/augur-ui/src/modules/account/containers/transactions.ts
+++ b/packages/augur-ui/src/modules/account/containers/transactions.ts
@@ -15,15 +15,15 @@ import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
 import { getNetworkId, getLegacyRep } from 'modules/contracts/actions/contractCalls'
 import getValue from 'utils/get-value';
-import { GnosisSafeState } from '@augurproject/gnosis-relay-api';
+import { isGnosisUnavailable } from 'modules/app/selectors/gnosis';
 
 const mapStateToProps = (state: AppState) => {
   const networkId = getNetworkId();
   const Gnosis_ENABLED = getValue(state, 'appStatus.gnosisEnabled');
-  const gnosisStatus = getValue(state, 'appStatus.gnosisStatus');
+  const GnosisUnavailable = isGnosisUnavailable(state);
 
   const showFaucets = Gnosis_ENABLED
-    ? networkId !== NETWORK_IDS.Mainnet && gnosisStatus === GnosisSafeState.AVAILABLE
+    ? networkId !== NETWORK_IDS.Mainnet && !GnosisUnavailable
     : networkId !== NETWORK_IDS.Mainnet;
 
   return {

--- a/packages/augur-ui/src/modules/app/selectors/gnosis.tsx
+++ b/packages/augur-ui/src/modules/app/selectors/gnosis.tsx
@@ -1,0 +1,25 @@
+import { createSelector } from 'reselect';
+import { AppState } from 'store';
+import { GnosisSafeState } from '@augurproject/gnosis-relay-api/src/GnosisRelayAPI';
+
+export const selectAuthState = (state: AppState) => state.authStatus;
+export const selectAppState = (state: AppState) => state.appStatus;
+
+export const isGnosisUnavailable = createSelector(
+  selectAuthState,
+  selectAppState,
+  (authStatus, appStatus) => {
+    const { gnosisEnabled, gnosisStatus } = appStatus;
+    const { isLogged } = authStatus;
+    const gnosisUnavailable =
+      gnosisEnabled &&
+      isLogged &&
+      [
+        GnosisSafeState.WAITING_FOR_FUNDS,
+        GnosisSafeState.CREATED,
+        GnosisSafeState.UNAVAILABLE,
+      ].includes(gnosisStatus);
+
+    return gnosisUnavailable;
+  }
+);

--- a/packages/augur-ui/src/modules/trading/components/wrapper.tsx
+++ b/packages/augur-ui/src/modules/trading/components/wrapper.tsx
@@ -33,7 +33,6 @@ export interface SelectedOrderProperties {
 }
 
 interface WrapperProps {
-  gnosisStatus: GnosisSafeState;
   market: MarketData;
   selectedOutcome: OutcomeFormatted;
   selectedOrderProperties: SelectedOrderProperties;
@@ -60,6 +59,7 @@ interface WrapperProps {
   tradingTutorial?: boolean;
   currentTimestamp: number;
   availableDai: number;
+  GnosisUnavailable: boolean;
 }
 
 interface WrapperState {
@@ -398,9 +398,9 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
       isLogged,
       loginModal,
       addFundsModal,
-      gnosisStatus,
       hasHistory,
-      availableDai
+      availableDai,
+      GnosisUnavailable,
     } = this.props;
     let {
       marketType,
@@ -430,11 +430,6 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
       trade &&
       trade.totalCost &&
       createBigNumber(trade.totalCost.value).gte(createBigNumber(availableDai));
-    const GnosisUnavailable =
-      Gnosis_ENABLED &&
-      isLogged &&
-      hasFunds &&
-      gnosisStatus !== GnosisSafeState.AVAILABLE;
     let actionButton: any = (
       <OrderButton
         type={selectedNav}

--- a/packages/augur-ui/src/modules/trading/containers/wrapper.ts
+++ b/packages/augur-ui/src/modules/trading/containers/wrapper.ts
@@ -23,6 +23,7 @@ import { addPendingOrder } from 'modules/orders/actions/pending-orders-managemen
 import { orderSubmitted } from 'services/analytics/helpers';
 import { AppState } from 'store';
 import { totalTradingBalance } from 'modules/auth/selectors/login-account';
+import { isGnosisUnavailable } from 'modules/app/selectors/gnosis';
 
 const getMarketPath = id => {
   return {
@@ -39,7 +40,6 @@ const mapStateToProps = (state: AppState, ownProps) => {
   const hasHistory = !!accountPositions[marketId] || !!userOpenOrders[marketId];
   const {
     gnosisEnabled: Gnosis_ENABLED,
-    gnosisStatus,
   } = appStatus;
   const hasFunds = Gnosis_ENABLED
     ? !!loginAccount.balances.dai
@@ -51,9 +51,9 @@ const mapStateToProps = (state: AppState, ownProps) => {
     hasFunds,
     isLogged: authStatus.isLogged,
     Gnosis_ENABLED,
-    gnosisStatus,
     currentTimestamp: blockchain.currentAugurTimestamp,
     availableDai: totalTradingBalance(loginAccount),
+    GnosisUnavailable: isGnosisUnavailable(state),
   };
 };
 


### PR DESCRIPTION
### Fixes the below bugs 




Bug 1: "Waiting For Gnosis Safe"

1) Don't be logged in
2) Add/Click an order from the Order Book
3) [You should see a Insufficient ETH error]
4) Login with your Gnosis account
5) [Insufficient ETH error should turn into a Waiting For Gnosis Safe error]

<img width="218" src="https://user-images.githubusercontent.com/1683736/73186248-6be7c680-40ed-11ea-8385-76f2298207d5.png">


Bug 2/3: 
On Relayer down error, you are unable to trade with Gnosis ("Waiting For Gnosis Safe") 
AND 
You are unable to use the faucets

