### PR TITLE
fixed issue where winning outcome didn't stay shown on resolved marke…

### DIFF
--- a/packages/augur-ui/src/modules/market-cards/common.tsx
+++ b/packages/augur-ui/src/modules/market-cards/common.tsx
@@ -8,12 +8,13 @@ import {
   SCALAR_UP_ID,
   YES_NO,
   ZERO,
+  INVALID_OUTCOME_NAME,
 } from 'modules/common/constants';
 import { BigNumber, createBigNumber } from 'utils/create-big-number';
 import ReactTooltip from 'react-tooltip';
 import TooltipStyles from 'modules/common/tooltip.styles.less';
 import { CheckCircleIcon } from 'modules/common/icons';
-import { FormattedNumber, MarketData, OutcomeFormatted } from 'modules/types';
+import { FormattedNumber, MarketData, OutcomeFormatted, ConsensusFormatted } from 'modules/types';
 import { formatAttoRep, formatDai, formatNumber } from 'utils/format-number';
 import { Getters } from '@augurproject/sdk';
 import InvalidLabel from 'modules/common/containers/labels';
@@ -381,19 +382,18 @@ export const HoverIcon = (props: HoverIconProps) => (
 );
 
 export interface ResolvedOutcomesProps {
-  outcomes: Array<OutcomeFormatted>;
+  consensusFormatted: ConsensusFormatted;
+  outcomes: OutcomeFormatted[];
   expanded?: Boolean;
 }
 
 export const ResolvedOutcomes = (props: ResolvedOutcomesProps) => {
-  const winnerIndex = props.outcomes.findIndex(outcome => outcome.winner);
-  const outcomes = props.outcomes;
-  const winner = outcomes.splice(winnerIndex, 1)[0];
+  const outcomes = props.outcomes.filter(outcome => String(outcome.id) !== props.consensusFormatted.outcome);
 
   return (
     <div className={Styles.ResolvedOutcomes}>
       <span>Winning Outcome {CheckCircleIcon} </span>
-      <span>{winner && winner.description}</span>
+      <span>{props.consensusFormatted.invalid ? INVALID_OUTCOME_NAME : props.consensusFormatted.outcomeName}</span>
       {props.expanded && (
         <div>
           <span>other outcomes</span>

--- a/packages/augur-ui/src/modules/market-cards/market-card.tsx
+++ b/packages/augur-ui/src/modules/market-cards/market-card.tsx
@@ -126,6 +126,7 @@ export default class MarketCard extends React.Component<
       endTimeFormatted,
       designatedReporter,
       isTemplate,
+      consensusFormatted
     } = market;
 
     if (loading) {
@@ -356,6 +357,7 @@ export default class MarketCard extends React.Component<
           <MigrateMarketNotice marketId={id} />
           {marketResolved && (
             <ResolvedOutcomes
+              consensusFormatted={consensusFormatted}
               outcomes={outcomesFormatted}
               expanded={expandedView}
             />

--- a/packages/augur-ui/src/modules/market/components/market-header/market-header-reporting.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-header/market-header-reporting.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import Styles from 'modules/market/components/market-header/market-header-reporting.styles.less';
-import { REPORTING_STATE, SCALAR } from 'modules/common/constants';
+import { REPORTING_STATE, SCALAR, INVALID_OUTCOME_NAME } from 'modules/common/constants';
 import { PrimaryButton } from 'modules/common/buttons';
 import { getOutcomeNameWithOutcome } from 'utils/get-outcome';
 import { MarketData } from 'modules/types';
@@ -26,20 +26,20 @@ export const MarketHeaderReporting = ({
   canClaimProceeds,
   showReportingModal
 }: MarketHeaderReportingProps) => {
-  const { reportingState, id, consensusFormatted: consensus } = market;
+  const { reportingState, id, consensusFormatted } = market;
   let content = null;
   const slowDisputing =
     market.disputeInfo && market.disputeInfo.disputePacingOn;
 
-  if (consensus && (consensus.winningOutcome || consensus.isInvalid)) {
+  if (consensusFormatted && (consensusFormatted.winningOutcome || consensusFormatted.invalid)) {
     content = (
       <div className={classNames(Styles.Content, Styles.Set)}>
         <div>
           <span>Winning Outcome</span>
           <span>
-            {consensus.isInvalid
-              ? 'Invalid'
-              : consensus.outcomeName || consensus.winningOutcome}
+            {consensusFormatted.invalid
+              ? INVALID_OUTCOME_NAME
+              : consensusFormatted.outcomeName}
           </span>
         </div>
         {canClaimProceeds && (

--- a/packages/augur-ui/src/modules/types.ts
+++ b/packages/augur-ui/src/modules/types.ts
@@ -93,7 +93,7 @@ export interface MarketInfos {
 export interface Outcomes extends Getters.Markets.MarketInfoOutcome {
   name?: string;
 }
-export interface Consensus extends PayoutNumeratorValue {
+export interface ConsensusFormatted extends PayoutNumeratorValue {
   winningOutcome: string | null;
   outcomeName: string | null;
 }
@@ -126,7 +126,7 @@ export interface MarketData extends Getters.Markets.MarketInfo {
   finalizationTimeFormatted: DateFormattedObject | null;
   // TODO: add this to getter Getters.Markets.MarketInfo
   // disputeInfo: object; this needs to get filled in on getter
-  consensusFormatted: Consensus | null;
+  consensusFormatted: ConsensusFormatted | null;
   outcomesFormatted: OutcomeFormatted[];
   isTemplate: boolean;
 }


### PR DESCRIPTION
…t card.

to test, use `docker:all false true` to get fake time. 
add orders to a market using flash
`yarn flash create-yesno-zerox-orders -m 0x8DC19d10cA776992Fa6732B6a9d3B49c00Ea441A`
then push time to get the market in reporting.
report and push time again. `yarn flash push-timestamp -c 1d`


issue:

![2020-01-26 19 37 05](https://user-images.githubusercontent.com/3970376/73193504-4ad4a500-40f0-11ea-928f-1fb960d3e63d.gif)




fixed
![image](https://user-images.githubusercontent.com/3970376/73193448-342e4e00-40f0-11ea-8050-d58f8150148b.png)
