### PR TITLE
ZeroX orders will be sycned from RPC before bulk sync.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,6 +122,7 @@ jobs:
           targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
           vstsFeed: npmPackages
       - script: |
+          yarn clean
           yarn install --frozen-lockfile
         displayName: Install Dependencies
       - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
@@ -483,7 +484,6 @@ jobs:
           targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
           vstsFeed: npmPackages
       - script: |
-          rm -rf node_modules
           yarn install --frozen-lockfile
           yarn build
         displayName: Install Dependencies

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -483,6 +483,7 @@ jobs:
           targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
           vstsFeed: npmPackages
       - script: |
+          yarn clean
           yarn install --frozen-lockfile
           yarn build
         displayName: Install Dependencies

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -483,7 +483,7 @@ jobs:
           targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
           vstsFeed: npmPackages
       - script: |
-          yarn clean
+          rm -rf node_modules
           yarn install --frozen-lockfile
           yarn build
         displayName: Install Dependencies

--- a/packages/augur-sdk/src/Augur.ts
+++ b/packages/augur-sdk/src/Augur.ts
@@ -86,6 +86,9 @@ export class Augur<TProvider extends Provider = Provider> {
     this.events = new Subscriptions(augurEmitter);
     this.events.on(SubscriptionEventName.GnosisSafeStatus, this.updateGnosisSafe.bind(this));
 
+    this.connector.client = this;
+    if(this.zeroX) this.zeroX.client = this;
+
     // API
     this.addresses = addresses;
     this.contracts = new Contracts(this.addresses, this.dependencies);
@@ -126,8 +129,6 @@ export class Augur<TProvider extends Provider = Provider> {
       zeroX,
       enableFlexSearch
     );
-    connector.client = client;
-    if(zeroX) zeroX.client = client;
     await client.contracts.setReputationToken(networkId);
     return client;
   }

--- a/packages/augur-sdk/src/state/db/DB.ts
+++ b/packages/augur-sdk/src/state/db/DB.ts
@@ -177,9 +177,7 @@ export class DB {
 
     if (enableZeroX) {
       this.zeroXOrders = await ZeroXOrders.create(this, networkId, this.augur);
-      this.augur.events.on('ZeroX:Ready', () => {
-        this.zeroXOrders.sync();
-      });
+      await this.zeroXOrders.sync();
     }
 
     // Always start syncing from 10 blocks behind the lowest

--- a/packages/augur-sdk/src/state/db/ZeroXOrders.ts
+++ b/packages/augur-sdk/src/state/db/ZeroXOrders.ts
@@ -173,8 +173,8 @@ export class ZeroXOrders extends AbstractTable {
   }
 
   async sync(): Promise<void> {
-    var orders: OrderInfo[];
-    orders = await this.augur.zeroX.getOrders();
+    console.log("Syncing ZeroX Orders");
+    const orders: OrderInfo[] = await this.augur.zeroX.getOrders();
     let documents;
     if (orders && orders.length > 0) {
       documents = _.filter(orders, this.validateOrder.bind(this));
@@ -189,6 +189,7 @@ export class ZeroXOrders extends AbstractTable {
         this.augur.events.emit('OrderEvent', {eventType: OrderEventType.Create, ...d});
       }
     }
+    console.log(`Synced ${orders.length } ZeroX Orders`);
   }
 
   validateOrder(order: OrderInfo): boolean {

--- a/packages/augur-test/src/libs/MakeDbMock.ts
+++ b/packages/augur-test/src/libs/MakeDbMock.ts
@@ -55,7 +55,7 @@ export function makeDbMock(prefix:string = uuid.v4()) {
         constants.defaultStartSyncBlockNumber,
         augur,
         makeBlockAndLogStreamerListener(),
-        true,
+        !!augur.zeroX,
       );
       mockState.db = db;
 

--- a/packages/augur-tools/src/flash/flash.ts
+++ b/packages/augur-tools/src/flash/flash.ts
@@ -196,10 +196,6 @@ export class FlashSession {
         SubscriptionEventName.NewBlock,
         this.sdkNewBlock
       );
-
-      if (config.zeroX && config.zeroX.rpc.enabled) {
-        this.user.augur.events.emit('ZeroX:Ready');
-      }
     }
 
     return this.user;

--- a/packages/augur-tools/src/libs/contract-api.ts
+++ b/packages/augur-tools/src/libs/contract-api.ts
@@ -55,7 +55,7 @@ export class ContractAPI {
       zeroX.rpc = meshClient;
     }
     const augur = await Augur.create(provider, dependencies, addresses, connector, zeroX, true);
-    if (meshBrowser) {
+    if (zeroX && meshBrowser) {
       zeroX.mesh = meshBrowser;
     }
     return new ContractAPI(augur, provider, dependencies, account);

--- a/packages/augur-ui/src/services/augursdk.ts
+++ b/packages/augur-ui/src/services/augursdk.ts
@@ -74,10 +74,6 @@ export class SDK {
     this.client = await createClient(config, connector, account, signer, ethersProvider, enableFlexSearch, createBrowserMesh);
     await connector.connect(config, account)
 
-    if (config.zeroX && (config.zeroX.rpc && config.zeroX.rpc.enabled || config.zeroX.mesh && config.zeroX.mesh.enabled)) {
-      this.client.events.emit('ZeroX:Ready');
-    }
-
     if (!isEmpty(account)) {
       await this.getOrCreateGnosisSafe(account);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,7 @@
 # yarn lockfile v1
 
 
+
 "@0x/abi-gen-wrappers@^5.3.2":
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/@0x/abi-gen-wrappers/-/abi-gen-wrappers-5.3.2.tgz#bf7d1942f56916b7d13fae627f6455f309c5c8b5"


### PR DESCRIPTION
This still doesn't fix the case where the mesh allows order-getting,
since in that case we'll need to do the `sync()` call after the mesh
is initialized, but that can just be done on the DB directly.