### PR TITLE
auto login clears hot loading market loading modal and order book get…

### DIFF
--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -30,6 +30,7 @@ import {
   TUTORIAL_QUANTITY,
   TUTORIAL_PRICE,
   TRADING_TUTORIAL_OUTCOMES,
+  MODAL_MARKET_LOADING,
 } from 'modules/common/constants';
 import ModuleTabs from 'modules/market/components/common/module-tabs/module-tabs';
 import ModulePane from 'modules/market/components/common/module-tabs/module-pane';
@@ -80,7 +81,7 @@ interface MarketViewProps {
   addAlert: Function;
   hotloadMarket: Function;
   canHotload: boolean;
-  modalShowing?: boolean;
+  modalShowing?: string;
   removeAlert: Function;
   outcomeId?: number;
   account: string;
@@ -215,7 +216,9 @@ export default class MarketView extends Component<
 
   startOrderBookTimer = () => {
     const { timer } = this.state;
+    console.log('does time exist', !!timer);
     if (!timer) {
+      console.log('calling to get order book')
       this.getOrderBook();
       const timer = setInterval(
         () => this.getOrderBook(),
@@ -267,10 +270,11 @@ export default class MarketView extends Component<
       this.props.loadMarketTradingHistory(marketId);
     }
 
-    if (isMarketLoading !== this.props.isMarketLoading && !this.props.modalShowing && this.props.canHotload === undefined) {
+    if (isMarketLoading !== this.props.isMarketLoading && this.props.modalShowing === MODAL_MARKET_LOADING) {
       closeMarketLoadingModal();
       this.startOrderBookTimer();
     }
+
     if (
       !tradingTutorial &&
       !this.props.scalarModalSeen &&
@@ -700,7 +704,7 @@ export default class MarketView extends Component<
                             marketId={marketId}
                             market={preview && market}
                             selectedOutcomeId={outcomeId}
-                            isMarketLoading={isMarketLoading || modalShowing}
+                            isMarketLoading={isMarketLoading || !!modalShowing}
                             canHotload={canHotload}
                           />
                         )}
@@ -986,7 +990,7 @@ export default class MarketView extends Component<
                               market={preview && market}
                               preview={preview}
                               orderBook={outcomeOrderBook}
-                              isMarketLoading={isMarketLoading || modalShowing}
+                              isMarketLoading={isMarketLoading || !!modalShowing}
                               canHotload={canHotload}
                             />
                           </div>

--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -216,9 +216,7 @@ export default class MarketView extends Component<
 
   startOrderBookTimer = () => {
     const { timer } = this.state;
-    console.log('does time exist', !!timer);
     if (!timer) {
-      console.log('calling to get order book')
       this.getOrderBook();
       const timer = setInterval(
         () => this.getOrderBook(),

--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -30,7 +30,6 @@ import {
   TUTORIAL_QUANTITY,
   TUTORIAL_PRICE,
   TRADING_TUTORIAL_OUTCOMES,
-  MODAL_MARKET_LOADING,
 } from 'modules/common/constants';
 import ModuleTabs from 'modules/market/components/common/module-tabs/module-tabs';
 import ModulePane from 'modules/market/components/common/module-tabs/module-pane';
@@ -268,8 +267,8 @@ export default class MarketView extends Component<
       this.props.loadMarketTradingHistory(marketId);
     }
 
-    if (isMarketLoading !== this.props.isMarketLoading && this.props.modalShowing === MODAL_MARKET_LOADING) {
-      closeMarketLoadingModal();
+    if (isMarketLoading !== this.props.isMarketLoading) {
+      closeMarketLoadingModal(this.props.modalShowing);
       this.startOrderBookTimer();
     }
 

--- a/packages/augur-ui/src/modules/market/containers/market-view.ts
+++ b/packages/augur-ui/src/modules/market/containers/market-view.ts
@@ -146,7 +146,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         type: MODAL_MARKET_LOADING,
       })
     ),
-  closeMarketLoadingModal: () => dispatch(closeModal()),
+  closeMarketLoadingModal: (type: string) => type === MODAL_MARKET_LOADING && dispatch(closeModal()),
   addAlert: alert => dispatch(addAlert(alert)),
   removeAlert: (id: string, name: string) => dispatch(removeAlert(id, name)),
 });

--- a/packages/augur-ui/src/modules/market/containers/market-view.ts
+++ b/packages/augur-ui/src/modules/market/containers/market-view.ts
@@ -100,9 +100,9 @@ const mapStateToProps = (state: AppState, ownProps) => {
       market.creationTime,
       selectCurrentTimestampInSeconds(state)
     );
-  
+
   return {
-    modalShowing: !!modal.type,
+    modalShowing: modal.type,
     daysPassed,
     isMarketLoading: false,
     preview: tradingTutorial || ownProps.preview,


### PR DESCRIPTION
…ter isn't called.

to repro:

login to UI with MM, 
nav to market with orders on the orderbook.
hard refresh page. to kick off hot loading.
notice that `Market Loading` modal appears. Then auto login modal appears and `Market Loading` modal disappears and the order book isn't populated. 

