### PR TITLE
remove redundant logic in order form.

### DIFF
--- a/packages/augur-ui/src/modules/trading/components/form.tsx
+++ b/packages/augur-ui/src/modules/trading/components/form.tsx
@@ -635,22 +635,6 @@ class Form extends Component<FromProps, FormState> {
             updateTradeTotalCost(order);
           }
         }
-        if (
-          property === this.INPUT_TYPES.PRICE &&
-          validationResults.errors[this.INPUT_TYPES.PRICE].length === 0
-        ) {
-          if (
-            this.state.lastInputModified === this.INPUT_TYPES.QUANTITY &&
-            validationResults.errors[this.INPUT_TYPES.QUANTITY].length === 0
-          ) {
-            updateTradeTotalCost(order);
-          } else if (
-            this.state.lastInputModified === this.INPUT_TYPES.EST_DAI &&
-            validationResults.errors[this.INPUT_TYPES.EST_DAI].length === 0
-          ) {
-            updateTradeNumShares(order);
-          }
-        }
         if (property !== this.INPUT_TYPES.PRICE) {
           this.setState({
             lastInputModified: property,


### PR DESCRIPTION
sim trade was called multiple times when price, quantity and/or total cost didn't change. 
removed extra processing logic in form

created open order
able to take trade
market creation pre-liquidity form works. 