### PR TITLE
revert back to using state for orderbook

### DIFF
--- a/packages/augur-sdk/src/state/getter/Markets.ts
+++ b/packages/augur-sdk/src/state/getter/Markets.ts
@@ -160,7 +160,6 @@ export interface MarketInfo {
   template: ExtraInfoTemplate;
   isTemplate: boolean;
   mostLikelyInvalid: boolean;
-  orderBookDirtyCounter?: number;
 }
 
 export interface DisputeInfo {

--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -1144,7 +1144,7 @@ export const EVENT_EXPIRATION_TOOLTIP = {
   header: 'Event expiration',
   content: 'This date time indicates when the settlement process begins.',
 };
-
+export const TUTORIAL_OUTCOME = 1;
 export const TUTORIAL_QUANTITY = 100;
 export const TUTORIAL_PRICE = 0.4;
 export const TRADING_TUTORIAL_OUTCOMES = [

--- a/packages/augur-ui/src/modules/create-market/helpers/format-order-book.ts
+++ b/packages/augur-ui/src/modules/create-market/helpers/format-order-book.ts
@@ -4,9 +4,8 @@ import {
   ASKS,
   BIDS
 } from "modules/common/constants";
-import { LiquidityOrder, UIOrder, OutcomeOrderBook } from 'modules/types';
+import { LiquidityOrder, TestTradingOrder, IndividualOutcomeOrderBook } from 'modules/types';
 import { createBigNumber } from 'utils/create-big-number';
-import { Getters } from "@augurproject/sdk";
 
 function calcSpread(asks, bids) {
   if (asks.length === 0 || bids.length === 0) {
@@ -17,12 +16,15 @@ function calcSpread(asks, bids) {
     .minus(createBigNumber(bids[0].price, 10));
 }
 
-export function formatOrderBook(outcomesOrderBook: LiquidityOrder[]): OutcomeOrderBook {
-	const bids = (outcomesOrderBook || []).filter((order: UIOrder) => order.type === BUY);
-  const asks = (outcomesOrderBook || []).filter((order: UIOrder) => order.type === SELL);
-  const orderBook: OutcomeOrderBook = {}
-  orderBook[ASKS] = asks.sort((a, b) => createBigNumber(a.price).minus(createBigNumber(b.price)));
-  orderBook[BIDS] = bids.sort((a, b) => createBigNumber(b.price).minus(createBigNumber(a.price)));
-  orderBook.spread = calcSpread(orderBook[ASKS], orderBook[BIDS]);
-  return orderBook;
+export function formatOrderBook(outcomesOrderBook: LiquidityOrder[] | TestTradingOrder[]): IndividualOutcomeOrderBook {
+	const bids = (outcomesOrderBook || []).filter((order) => order.type === BUY);
+  const asks = (outcomesOrderBook || []).filter((order) => order.type === SELL);
+  const newAsks = asks.sort((a, b) => createBigNumber(a.price).minus(createBigNumber(b.price)));
+  const newBids = bids.sort((a, b) => createBigNumber(b.price).minus(createBigNumber(a.price)));
+  const spread = calcSpread(newAsks, newBids);
+  return {
+    [ASKS]: newAsks,
+    [BIDS]: newBids,
+    spread
+  } as IndividualOutcomeOrderBook;
 }

--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -73,14 +73,14 @@ const handleAlert = (
   }
 };
 const ORDER_BOOK_REFRESH_MS = 1000;
-const loadOrderBook = _.debounce((dispatch, marketId) => setTimeout(() => dispatch(loadMarketOrderBook(marketId)), ORDER_BOOK_REFRESH_MS), ORDER_BOOK_REFRESH_MS, { leading: true, maxWait: ORDER_BOOK_REFRESH_MS });
-const asyncActionDebounced = (marketId) => dispatch => loadOrderBook(dispatch, marketId);
+const loadOrderBook = _.throttle((dispatch, marketId) => dispatch(loadMarketOrderBook(marketId)), ORDER_BOOK_REFRESH_MS, { leading: true });
+const asyncActionThrottle = (marketId) => dispatch => loadOrderBook(dispatch, marketId);
 
 const updateMarketOrderBook = (marketId: string) => (
   dispatch: ThunkDispatch<void, any, Action>
 ) => {
   if (isCurrentMarket(marketId)) {
-    dispatch(asyncActionDebounced(marketId));
+    dispatch(asyncActionThrottle(marketId));
   }
 }
 const loadUserPositionsAndBalances = (marketId: string) => (

--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -72,8 +72,8 @@ const handleAlert = (
     console.error('alert could not be created', e);
   }
 };
-
-const loadOrderBook = _.debounce((dispatch, marketId) => setTimeout(() => dispatch(loadMarketOrderBook(marketId)), 1000), 1000);
+const ORDER_BOOK_REFRESH_MS = 1000;
+const loadOrderBook = _.debounce((dispatch, marketId) => setTimeout(() => dispatch(loadMarketOrderBook(marketId)), ORDER_BOOK_REFRESH_MS), ORDER_BOOK_REFRESH_MS, { leading: true });
 const asyncActionDebounced = (marketId) => dispatch => loadOrderBook(dispatch, marketId);
 
 const updateMarketOrderBook = (marketId: string) => (

--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -73,11 +73,14 @@ const handleAlert = (
   }
 };
 
+const loadOrderBook = _.debounce((dispatch, marketId) => setTimeout(() => dispatch(loadMarketOrderBook(marketId)), 1000), 1000);
+const asyncActionDebounced = (marketId) => dispatch => loadOrderBook(dispatch, marketId);
+
 const updateMarketOrderBook = (marketId: string) => (
   dispatch: ThunkDispatch<void, any, Action>
 ) => {
   if (isCurrentMarket(marketId)) {
-    _.debounce(() => dispatch(loadMarketOrderBook(marketId)), 1000);
+    dispatch(asyncActionDebounced(marketId));
   }
 }
 const loadUserPositionsAndBalances = (marketId: string) => (

--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -73,7 +73,7 @@ const handleAlert = (
   }
 };
 const ORDER_BOOK_REFRESH_MS = 1000;
-const loadOrderBook = _.debounce((dispatch, marketId) => setTimeout(() => dispatch(loadMarketOrderBook(marketId)), ORDER_BOOK_REFRESH_MS), ORDER_BOOK_REFRESH_MS, { leading: true });
+const loadOrderBook = _.debounce((dispatch, marketId) => setTimeout(() => dispatch(loadMarketOrderBook(marketId)), ORDER_BOOK_REFRESH_MS), ORDER_BOOK_REFRESH_MS, { leading: true, maxWait: ORDER_BOOK_REFRESH_MS });
 const asyncActionDebounced = (marketId) => dispatch => loadOrderBook(dispatch, marketId);
 
 const updateMarketOrderBook = (marketId: string) => (

--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -49,7 +49,6 @@ import { updateModal } from 'modules/modal/actions/update-modal';
 import * as _ from 'lodash';
 import { loadMarketOrderBook } from 'modules/orders/actions/load-market-orderbook';
 import { isCurrentMarket } from 'modules/trades/helpers/is-current-market';
-import debounce from 'utils/debounce';
 
 const handleAlert = (
   log: any,

--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -60,7 +60,7 @@ import { Getters } from '@augurproject/sdk';
 
 interface MarketViewProps {
   isMarketLoading: boolean;
-  closeMarketLoadingModal: Function;
+  closeMarketLoadingModalOnly: Function;
   market: MarketData;
   marketId: string;
   marketReviewSeen: boolean;
@@ -217,7 +217,7 @@ export default class MarketView extends Component<
       isMarketLoading,
       tradingTutorial,
       updateModal,
-      closeMarketLoadingModal,
+      closeMarketLoadingModalOnly,
       modalShowing
     } = prevProps;
     if (
@@ -254,8 +254,8 @@ export default class MarketView extends Component<
       this.props.loadMarketTradingHistory(marketId);
     }
 
-    if (isMarketLoading !== this.props.isMarketLoading) {
-      closeMarketLoadingModal(modalShowing);
+    if (!isMarketLoading) {
+      closeMarketLoadingModalOnly(modalShowing);
     }
 
     if (

--- a/packages/augur-ui/src/modules/market/containers/market-view.ts
+++ b/packages/augur-ui/src/modules/market/containers/market-view.ts
@@ -157,7 +157,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         type: MODAL_MARKET_LOADING,
       })
     ),
-  closeMarketLoadingModal: (type: string) => type === MODAL_MARKET_LOADING && dispatch(closeModal()),
+  closeMarketLoadingModalOnly: (type: string) => type === MODAL_MARKET_LOADING && dispatch(closeModal()),
   addAlert: alert => dispatch(addAlert(alert)),
   removeAlert: (id: string, name: string) => dispatch(removeAlert(id, name)),
 });

--- a/packages/augur-ui/src/modules/market/containers/market-view.ts
+++ b/packages/augur-ui/src/modules/market/containers/market-view.ts
@@ -39,9 +39,10 @@ import {
   convertUnixToFormattedDate,
 } from 'utils/format-date';
 import { AppState } from 'store';
+import { loadMarketOrderBook } from 'modules/orders/actions/load-market-orderbook';
 
 const mapStateToProps = (state: AppState, ownProps) => {
-  const { connection, universe, modal, loginAccount } = state;
+  const { connection, universe, modal, loginAccount, orderBooks } = state;
   const marketId = parseQuery(ownProps.location.search)[MARKET_ID_PARAM_NAME];
   const queryOutcomeId = parseQuery(ownProps.location.search)[
     OUTCOME_ID_PARAM_NAME
@@ -65,7 +66,6 @@ const mapStateToProps = (state: AppState, ownProps) => {
       outcomesFormatted: TRADING_TUTORIAL_OUTCOMES,
       groupedTradeHistory: TUTORIAL_TRADING_HISTORY,
       orderBook: TUTORIAL_ORDER_BOOK,
-      orderBookDirtyCounter: 0,
     };
   } else {
     market = ownProps.market || selectMarket(marketId);
@@ -91,8 +91,16 @@ const mapStateToProps = (state: AppState, ownProps) => {
       canHotload: connection.canHotload,
       marketId,
       marketReviewSeen,
-      orderBookDirtyCounter: 0,
     };
+  }
+
+  let orderBook = null;
+  if (market && !tradingTutorial && !ownProps.preview) {
+    orderBook = orderBooks[marketId]
+  }
+
+  if (market && (tradingTutorial || ownProps.preview)) {
+    orderBook = market.orderBook;
   }
 
   const daysPassed =
@@ -105,6 +113,7 @@ const mapStateToProps = (state: AppState, ownProps) => {
 
   return {
     modalShowing: modal.type,
+    orderBook,
     daysPassed,
     isMarketLoading: false,
     preview: tradingTutorial || ownProps.preview,
@@ -125,14 +134,13 @@ const mapStateToProps = (state: AppState, ownProps) => {
       market.outcomesFormatted
     ),
     account: loginAccount.address,
-    orderBook: tradingTutorial && TUTORIAL_ORDER_BOOK || ownProps.orderBook,
-    orderBookDirtyCounter: market.orderBookDirtyCounter
   };
 };
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
   hotloadMarket: marketId => hotloadMarket(marketId),
   loadMarketsInfo: marketId => dispatch(loadMarketsInfo([marketId])),
+  loadMarketOrderBook: marketId => dispatch(loadMarketOrderBook(marketId)),
   updateModal: modal => dispatch(updateModal(modal)),
   loadMarketTradingHistory: marketId =>
     dispatch(loadMarketTradingHistory(marketId)),

--- a/packages/augur-ui/src/modules/markets/reducers/market-infos.ts
+++ b/packages/augur-ui/src/modules/markets/reducers/market-infos.ts
@@ -66,18 +66,6 @@ export default function(marketInfos: MarketInfos = DEFAULT_STATE, { type, data }
         }
       };
     }
-    case SET_MARKET_ORDERBOOK_DIRTY: {
-      const { marketId } = data;
-      if (!marketId) return marketInfos;
-      if (!marketInfos[marketId]) return marketInfos;
-      return {
-        ...marketInfos,
-        [marketId]: {
-          ...marketInfos[marketId],
-          orderBookDirtyCounter: (marketInfos[marketId].orderBookDirtyCounter || 0) + 1,
-        }
-      };
-    }
     case REMOVE_MARKET:
       return immutableDelete(marketInfos, data.marketId);
     case SWITCH_UNIVERSE:

--- a/packages/augur-ui/src/modules/orders/actions/load-market-orderbook.ts
+++ b/packages/augur-ui/src/modules/orders/actions/load-market-orderbook.ts
@@ -1,0 +1,40 @@
+import logError from 'utils/log-error';
+import { NodeStyleCallback } from 'modules/types';
+import { ThunkDispatch } from 'redux-thunk';
+import { Action } from 'redux';
+import { augurSdk } from 'services/augursdk';
+import { AppState } from 'store';
+import { Getters } from '@augurproject/sdk';
+
+export const UPDATE_ORDER_BOOK = 'UPDATE_ORDER_BOOK';
+
+export const updateOrderBook = (
+  marketId: string,
+  orderBook: Getters.Markets.OutcomeOrderBook
+) => ({
+  type: UPDATE_ORDER_BOOK,
+  data: {
+    marketId,
+    orderBook,
+  },
+});
+
+export const loadMarketOrderBook = (
+  marketId: string,
+  callback: NodeStyleCallback = logError
+) => async (
+  dispatch: ThunkDispatch<void, any, Action>,
+  getState: () => AppState
+) => {
+  if (marketId == null) {
+    return callback('must specify market ID');
+  }
+  const { loginAccount } = getState();
+  let params = loginAccount.address
+    ? { marketId, account: loginAccount.address }
+    : { marketId };
+  const Augur = augurSdk.get();
+  const marketOrderBook = await Augur.getMarketOrderBook(params);
+  dispatch(updateOrderBook(marketId, marketOrderBook.orderBook));
+  callback(null, marketOrderBook);
+};

--- a/packages/augur-ui/src/modules/orders/reducers/order-books.ts
+++ b/packages/augur-ui/src/modules/orders/reducers/order-books.ts
@@ -1,0 +1,24 @@
+
+import { RESET_STATE } from "modules/app/actions/reset-state";
+import { BaseAction, OrderBooks } from "modules/types";
+import { UPDATE_ORDER_BOOK } from "modules/orders/actions/load-market-orderbook";
+
+const DEFAULT_STATE: OrderBooks = {};
+/**
+ * @param {Object} orderBooks
+ * @param {Object} action
+ */
+export default function(orderBooks = DEFAULT_STATE, { type, data }: BaseAction): OrderBooks {
+  switch (type) {
+    case UPDATE_ORDER_BOOK: {
+      const { marketId, orderBook } = data;
+      return {
+        [marketId]: orderBook,
+      };
+    }
+    case RESET_STATE:
+      return DEFAULT_STATE;
+    default:
+      return orderBooks;
+  }
+}

--- a/packages/augur-ui/src/modules/types.ts
+++ b/packages/augur-ui/src/modules/types.ts
@@ -129,7 +129,6 @@ export interface MarketData extends Getters.Markets.MarketInfo {
   consensusFormatted: ConsensusFormatted | null;
   outcomesFormatted: OutcomeFormatted[];
   isTemplate: boolean;
-  orderBookDirtyCounter: number;
 }
 
 export interface ForkingInfo {
@@ -217,6 +216,29 @@ export interface QuantityOutcomeOrderBook {
   asks: QuantityOrderBookOrder[];
 }
 
+export interface OutcomeTestTradingOrder {
+  [outcomeId: number]: TestTradingOrder[];
+}
+export interface TestTradingOrder {
+  disappear: boolean;
+  avgPrice: FormattedNumber;
+  cumulativeShares: string;
+  id: string;
+  mySize: string;
+  orderEstimate: BigNumber;
+  outcomeId: string;
+  outcomeName: string;
+  price: string;
+  quantity: string;
+  shares: string;
+  sharesEscrowed: FormattedNumber;
+  tokensEscrowed: FormattedNumber;
+  type: string;
+  unmatchedShares: FormattedNumber;
+}
+export interface OrderBooks {
+  [marketId: string]: Getters.Markets.OutcomeOrderBook;
+}
 export interface IndividualOutcomeOrderBook {
   spread: string | BigNumber | null;
   bids: Getters.Markets.MarketOrderBookOrder[];

--- a/packages/augur-ui/src/reducers/index.ts
+++ b/packages/augur-ui/src/reducers/index.ts
@@ -27,6 +27,7 @@ import userOpenOrders from "modules/orders/reducers/open-orders";
 import drafts from "modules/create-market/reducers/drafts";
 import marketsList from "modules/markets-list/reducers/markets-list";
 import reportingListState from "modules/reporting/reducers/reporting-list-state";
+import orderBooks from "modules/orders/reducers/order-books"
 import {
   LoginAccount,
   AccountPosition,
@@ -52,7 +53,8 @@ import {
   Drafts,
   MarketsList,
   ReportingListState,
-  Analytics
+  Analytics,
+  OrderBooks
 } from "modules/types";
 import { Getters } from "@augurproject/sdk";
 
@@ -86,7 +88,8 @@ export function createReducer() {
     drafts,
     marketsList,
     reportingListState,
-    analytics
+    analytics,
+    orderBooks
   };
 }
 
@@ -122,4 +125,5 @@ export interface AppStateInterface {
   marketsList: MarketsList;
   reportingListState: ReportingListState;
   analytics: Analytics;
+  orderBooks: OrderBooks;
 }

--- a/packages/augur-ui/src/utils/convert-marketInfo-marketData.ts
+++ b/packages/augur-ui/src/utils/convert-marketInfo-marketData.ts
@@ -72,7 +72,6 @@ export function convertMarketInfoToMarketData(
       marketInfo.disputeInfo,
       marketInfo.outcomes
     ),
-    orderBookDirtyCounter: marketInfo.orderBookDirtyCounter,
   };
 
   return marketData;


### PR DESCRIPTION
move getting order book logic from market view component to log-handlers and revert back to using state for orderbook

working:
lodash debounce function isn't working properly in log-handlers.ts