### PR TITLE
fix issue where user can create market if they have pre liquid orders…

### DIFF
--- a/packages/augur-ui/src/modules/create-market/components/review.tsx
+++ b/packages/augur-ui/src/modules/create-market/components/review.tsx
@@ -142,7 +142,7 @@ export default class Review extends React.Component<
   }
 
 
-  getInsufficientFundsAmounts(testWithLiquidity = false): InsufficientFunds {
+  getInsufficientFundsAmounts(): InsufficientFunds {
     const { availableEthFormatted, availableRepFormatted, availableDaiFormatted, Gnosis_ENABLED } = this.props;
     const s = this.state;
     let insufficientFunds: InsufficientFunds = null;
@@ -171,7 +171,6 @@ export default class Review extends React.Component<
         createBigNumber(availableDaiFormatted.value || '0'),
         formattedInitialLiquidityGas || '0',
         formattedInitialLiquidityDai || '0',
-        testWithLiquidity,
         Gnosis_ENABLED
       );
     }
@@ -225,7 +224,7 @@ export default class Review extends React.Component<
                 gasCost,
               },
               () => {
-                this.updateFunds(this.getInsufficientFundsAmounts(true));
+                this.updateFunds(this.getInsufficientFundsAmounts());
               }
             );
           }

--- a/packages/augur-ui/src/modules/markets/helpers/insufficient-funds.ts
+++ b/packages/augur-ui/src/modules/markets/helpers/insufficient-funds.ts
@@ -18,7 +18,6 @@ export default function findInsufficientFunds(
   availableDai,
   formattedInitialLiquidityGas,
   formattedInitialLiquidityDai,
-  testWithLiquidity = false,
   Gnosis_ENABLED = false
 ): InsufficientFunds {
   const BNGasCost = createBigNumber(gasCost);
@@ -27,9 +26,7 @@ export default function findInsufficientFunds(
   );
   const BNLiqGas = createBigNumber(formattedInitialLiquidityGas);
   const BNLiqDai = createBigNumber(formattedInitialLiquidityDai);
-  const BNtotalEthCost = testWithLiquidity
-    ? BNLiqGas.plus(BNGasCost)
-    : BNGasCost
+  const BNtotalEthCost = BNLiqGas.plus(BNGasCost);
 
   const insufficientEth = Gnosis_ENABLED ? false : createBigNumber(availableEth || 0).lt(BNtotalEthCost);
 
@@ -40,7 +37,7 @@ export default function findInsufficientFunds(
     BNdesignatedReportNoShowReputationBond
   );
 
-  const BNtotalDaiCost = testWithLiquidity ? BNLiqDai.plus(BNvalidityBond) : BNvalidityBond;
+  const BNtotalDaiCost = BNLiqDai.plus(BNvalidityBond);
   const insufficientDai = createBigNumber(availableDai).lt(
     BNtotalDaiCost
   );


### PR DESCRIPTION
… that are greater than dai balance

Need to tell user they don't have enough DAI for pre-liquidity. 
![image](https://user-images.githubusercontent.com/3970376/73804881-b7077680-478a-11ea-9cd4-92b6a2111237.png)
