### PR TITLE
maxPrice and minPrice were getting reverted for scalar market type, u…

### DIFF
--- a/packages/augur-ui/src/modules/create-market/components/template-picker.tsx
+++ b/packages/augur-ui/src/modules/create-market/components/template-picker.tsx
@@ -112,6 +112,14 @@ export const TemplatePicker = ({ newMarket, updateNewMarket }) => {
                 newMarket.marketType === SCALAR && template.maxPrice
                   ? template.maxPrice
                   : newMarket.maxPrice,
+              minPriceBigNumber:
+                  newMarket.marketType === SCALAR && template.minPrice
+                    ? template.minPrice
+                    : newMarket.minPrice,
+              maxPriceBigNumber:
+                  newMarket.marketType === SCALAR && template.maxPrice
+                    ? template.maxPrice
+                    : newMarket.maxPrice,
               marketType: newMarket.marketType,
               categories: [
                 newMarket.categories[0],


### PR DESCRIPTION
…ser could not add orders for pre-liq.

to test:
use scalar template and try to add pre-liquidity. price will have to be between 0 and 1. 
issue is that maxPrice and minPrice got overridden by maxPriceBigNumber and minPriceBigNumber

fixes <https://github.com/AugurProject/augur/issues/5863>