### PR TITLE
disable order form when user doesn't have enough dai for pre-liq.

### DIFF
--- a/packages/augur-ui/src/modules/trading/components/confirm.tsx
+++ b/packages/augur-ui/src/modules/trading/components/confirm.tsx
@@ -11,6 +11,7 @@ import {
   WARNING,
   ERROR,
   UPPER_FIXED_PRECISION_BOUND,
+  ZERO,
 } from 'modules/common/constants';
 import ReactTooltip from 'react-tooltip';
 import TooltipStyles from 'modules/common/tooltip.styles.less';
@@ -44,6 +45,7 @@ interface ConfirmProps {
   ethToDaiRate: BigNumber;
   Gnosis_ENABLED: boolean;
   GnosisUnavailable: boolean;
+  initialLiquidity: boolean;
 }
 
 interface ConfirmState {
@@ -104,11 +106,11 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
     let needsApproval = false;
     let messages: Message | null = null;
 
-    const gasCost = formatGasCostToEther(
+    const gasCost = gasLimit ? formatGasCostToEther(
       gasLimit,
       { decimalsRounded: 4 },
       gasPrice
-    );
+    ) : ZERO;
 
     let gasCostDai = null;
 
@@ -175,7 +177,7 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
 
     if (
       totalCost &&
-      createBigNumber(potentialDaiLoss.fullPrecision).gt(
+      createBigNumber(totalCost.fullPrecision).gt(
         createBigNumber(availableDai)
       ) && !tradingTutorial
     ) {
@@ -212,7 +214,8 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
       ethToDaiRate,
       gasLimit,
       gasPrice,
-      Gnosis_ENABLED
+      Gnosis_ENABLED,
+      initialLiquidity
     } = this.props;
 
     const {
@@ -279,7 +282,7 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
 
     return (
       <section className={Styles.TradingConfirm}>
-        {shareCost && shareCost.value !== 0 && (
+        {!initialLiquidity && shareCost && shareCost.value !== 0 && (
           <div className={Styles.details}>
             <div className={Styles.properties}>
               CLOSING POSITION
@@ -314,7 +317,7 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
             />
           </div>
         )}
-        {newOrderAmount !== "0" && (
+        {!initialLiquidity && newOrderAmount !== "0" && (
           <div className={Styles.details}>
              <div
               className={classNames(

--- a/packages/augur-ui/src/modules/trading/components/wrapper.tsx
+++ b/packages/augur-ui/src/modules/trading/components/wrapper.tsx
@@ -453,7 +453,7 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
             }
           }
         }}
-        disabled={!trade || !trade.limitPrice || GnosisUnavailable || (insufficientFunds && !initialLiquidity)}
+        disabled={!trade || !trade.limitPrice || GnosisUnavailable || insufficientFunds}
       />
     );
     switch (true) {
@@ -552,11 +552,11 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
             />
           )}
         </div>
-        {(!initialLiquidity || tradingTutorial) &&
-          trade &&
+        {trade &&
           ((trade.shareCost && trade.shareCost.value !== 0) ||
             (trade.totalCost && trade.totalCost.value !== 0)) && (
             <Confirm
+              initialLiquidity={initialLiquidity}
               numOutcomes={market.numOutcomes}
               marketType={marketType}
               maxPrice={maxPriceBigNumber}

--- a/packages/augur-ui/src/modules/trading/containers/confirm.ts
+++ b/packages/augur-ui/src/modules/trading/containers/confirm.ts
@@ -5,8 +5,8 @@ import { getGasPrice } from 'modules/auth/selectors/get-gas-price';
 import { AppState } from 'store';
 import { totalTradingBalance } from 'modules/auth/selectors/login-account';
 
-const mapStateToProps = (state: AppState) => {
-  const { authStatus, loginAccount, appStatus } = state;
+const mapStateToProps = (state: AppState, ownProps) => {
+  const { authStatus, loginAccount, appStatus, newMarket } = state;
   const {
     gnosisEnabled: Gnosis_ENABLED,
     ethToDaiRate,
@@ -17,10 +17,14 @@ const mapStateToProps = (state: AppState) => {
     ? !!loginAccount.balances.dai
     : !!loginAccount.balances.eth && !!loginAccount.balances.dai;
 
+  let availableDai = totalTradingBalance(loginAccount)
+  if (ownProps.initialLiquidity) {
+    availableDai = availableDai.minus(newMarket.initialLiquidityDai);
+  }
   return {
     gasPrice: getGasPrice(state),
     availableEth: createBigNumber(loginAccount.balances.eth),
-    availableDai: totalTradingBalance(loginAccount),
+    availableDai,
     hasFunds,
     isLogged: authStatus.isLogged,
     allowanceBigNumber: loginAccount.allowance,

--- a/packages/augur-ui/src/modules/trading/containers/wrapper.ts
+++ b/packages/augur-ui/src/modules/trading/containers/wrapper.ts
@@ -35,7 +35,7 @@ const getMarketPath = id => {
 };
 
 const mapStateToProps = (state: AppState, ownProps) => {
-  const { authStatus, loginAccount, appStatus, accountPositions, userOpenOrders, blockchain } = state;
+  const { authStatus, loginAccount, appStatus, accountPositions, userOpenOrders, blockchain, newMarket } = state;
   const marketId = ownProps.market.id;
   const hasHistory = !!accountPositions[marketId] || !!userOpenOrders[marketId];
   const {
@@ -45,6 +45,10 @@ const mapStateToProps = (state: AppState, ownProps) => {
     ? !!loginAccount.balances.dai
     : !!loginAccount.balances.eth && !!loginAccount.balances.dai;
 
+  let availableDai = totalTradingBalance(loginAccount)
+  if (ownProps.initialLiquidity) {
+    availableDai = availableDai.minus(newMarket.initialLiquidityDai);
+  }
   return {
     hasHistory,
     gasPrice: getGasPrice(state),
@@ -52,7 +56,7 @@ const mapStateToProps = (state: AppState, ownProps) => {
     isLogged: authStatus.isLogged,
     Gnosis_ENABLED,
     currentTimestamp: blockchain.currentAugurTimestamp,
-    availableDai: totalTradingBalance(loginAccount),
+    availableDai,
     GnosisUnavailable: isGnosisUnavailable(state),
   };
 };


### PR DESCRIPTION
show same insufficient funds error in pre-liq as regular order form. 

![image](https://user-images.githubusercontent.com/3970376/73863710-1787c980-4806-11ea-9c39-f384beb872a4.png)


![image](https://user-images.githubusercontent.com/3970376/73863727-1eaed780-4806-11ea-99aa-a9bd9236ac55.png)


