### PR TITLE
emit controller new block event for MarketDB to process markets and u…

### DIFF
--- a/packages/augur-sdk/src/constants.ts
+++ b/packages/augur-sdk/src/constants.ts
@@ -33,6 +33,7 @@ export enum SubscriptionEventName {
   MarketVolumeChanged = "MarketVolumeChanged",
   MarketOIChanged = "MarketOIChanged",
   NewBlock = "NewBlock",
+  ControllerNewBlock = "controller:new:block",
   OrderEvent = "OrderEvent",
   ParticipationTokensRedeemed = "ParticipationTokensRedeemed",
   ProfitLossChanged = "ProfitLossChanged",

--- a/packages/augur-sdk/src/state/Controller.ts
+++ b/packages/augur-sdk/src/state/Controller.ts
@@ -81,6 +81,8 @@ export class Controller {
       percentSynced,
       timestamp: timestamp.toNumber(),
     });
+
+    this.augur.events.emit(SubscriptionEventName.ControllerNewBlock, block);
   };
 
   private async getLatestBlock(): Promise<Block> {


### PR DESCRIPTION
…pdate reporting state for none tx event transitions.

only partial fix. with this fix SDK does update market reporting state when event expiration passes. 

Still need to emit MarketUpdated event for the UI to get the updated market.