### PR TITLE
Liquidity Filter Updates

### DIFF
--- a/packages/augur-sdk/src/constants.ts
+++ b/packages/augur-sdk/src/constants.ts
@@ -185,3 +185,5 @@ export enum OrderEventType {
   Fill   = LogOrderEventType.Fill,
   Expire = 3
 }
+
+export const orderTypes = ['0x00', '0x01'];

--- a/packages/augur-sdk/src/state/db/MarketDB.ts
+++ b/packages/augur-sdk/src/state/db/MarketDB.ts
@@ -195,6 +195,11 @@ export class MarketDB extends DerivedDB {
       .where('[market+outcome+orderType]')
       .anyOf(allOutcomesAllOrderTypes)
       .and((order) => order.amount > '0x00')
+      .and((order) => {
+        const expirationTimeSeconds = Number(order.signedOrder.expirationTimeSeconds);
+        const nowInSeconds = Math.round(+new Date() / 1000);
+        return expirationTimeSeconds - nowInSeconds > 70;
+      })
       .toArray();
 
     const currentOrdersByOutcome = _.groupBy(currentOrdersResponse, (order) => new BigNumber(order.outcome).toNumber());

--- a/packages/augur-sdk/src/state/db/MarketDB.ts
+++ b/packages/augur-sdk/src/state/db/MarketDB.ts
@@ -12,6 +12,7 @@ import {
   WORST_CASE_FILL,
   DEFAULT_GAS_PRICE_IN_GWEI,
   MAX_TRADE_GAS_PERCENTAGE_DIVISOR,
+  orderTypes,
   MarketReportingState,
 } from '../../constants';
 import { NewBlock } from "../../events";
@@ -158,8 +159,9 @@ export class MarketDB extends DerivedDB {
     const lastSpread10 = new BigNumber(marketData.liquidity[10]);
     const lastSpread15 = new BigNumber(marketData.liquidity[15]);
 
+    const passesSpreadCheck = (spread10.gt(0) || spread15.gt(0));
     // Keep track when a market has under a 15% spread. Used for `hasRecentlyDepletedLiquidity`
-    if ((spread10.gt(0) || spread15.gt(0))) {
+    if (passesSpreadCheck) {
       const now = Math.floor(Date.now() / 1000);
       marketOrderBookData.lastPassingLiquidityCheck = now;
     } else if (lastSpread10.gt(0) || lastSpread15.gt(0)) {
@@ -168,12 +170,26 @@ export class MarketDB extends DerivedDB {
       marketOrderBookData.lastPassingLiquidityCheck = marketData.lastPassingLiquidityCheck;
     }
 
-    marketOrderBookData.hasRecentlyDepletedLiquidity = await this.hasRecentlyDepletedLiquidity(marketData, marketOrderBookData.liquidity, marketOrderBookData.lastPassingLiquidityCheck);
+    const prevInvalidFilter = marketData.invalidFilter;
+    const prevHasRecentlyDepletedLiquidity = marketData.hasRecentlyDepletedLiquidity;
+    const currentIvalidFilter = marketOrderBookData.invalidFilter;
+
+    // Add markets that recently became invalid to Recently Depleted Liquidity
+    if (passesSpreadCheck) {
+      if (!prevInvalidFilter && currentIvalidFilter ||
+          (prevInvalidFilter && currentIvalidFilter && prevHasRecentlyDepletedLiquidity)) {
+        marketOrderBookData.hasRecentlyDepletedLiquidity = true;
+      } else {
+        marketOrderBookData.hasRecentlyDepletedLiquidity = await this.hasRecentlyDepletedLiquidity(marketData, marketOrderBookData.liquidity, marketOrderBookData.lastPassingLiquidityCheck);
+      }
+    } else {
+      marketOrderBookData.hasRecentlyDepletedLiquidity = await this.hasRecentlyDepletedLiquidity(marketData, marketOrderBookData.liquidity, marketOrderBookData.lastPassingLiquidityCheck);
+    }
+
     return marketOrderBookData;
   }
 
   async getOrderBook(marketData: MarketData, numOutcomes: number, estimatedTradeGasCostInAttoDai: BigNumber): Promise<OrderBook> {
-    const orderTypes = ['0x00', '0x01'];
     let outcomes = ['0x00', '0x01', '0x02'];
 
     if (marketData.outcomes && marketData.outcomes.length > 0) {

--- a/packages/augur-sdk/src/state/getter/Markets.ts
+++ b/packages/augur-sdk/src/state/getter/Markets.ts
@@ -567,6 +567,7 @@ export class Markets {
         }
         else if (params.maxLiquiditySpread !== MaxLiquiditySpread.OneHundredPercent) {
           if (market.liquidity[params.maxLiquiditySpread] === "000000000000000000000000000000") return false;
+          if (market.invalidFilter && market.hasRecentlyDepletedLiquidity) return false;
         }
       }
       return true;
@@ -582,6 +583,12 @@ export class Markets {
     if (params.sortBy) {
       let sortBy = params.sortBy;
       marketData = _.orderBy(marketData, (item) => sortBy === "liquidity" ? item[sortBy][params.maxLiquiditySpread] : item[sortBy], params.isSortDescending ? "desc" : "asc");
+    }
+
+    // If returning Recently Depleted Liquidity (spread===0)
+    if (params.maxLiquiditySpread === MaxLiquiditySpread.ZeroPercent) {
+      // Have invalid markets appear at the bottom
+      marketData =_.sortBy(marketData, 'invalidFilter')
     }
 
     marketData = marketData.slice(params.offset, params.offset + params.limit);

--- a/packages/augur-test/src/tests/state/Rollback.test.ts
+++ b/packages/augur-test/src/tests/state/Rollback.test.ts
@@ -153,6 +153,7 @@ test('rollback derived database', async () => {
     stringTo32ByteHex('A'),
     stringTo32ByteHex('B'),
   ]);
+  const expirationTimeInSeconds = new BigNumber(Math.round(+new Date() / 1000).valueOf()).plus(10000);
 
   await (await johnDB).sync(john.augur, mock.constants.chunkSize, 0);
 
@@ -164,7 +165,7 @@ test('rollback derived database', async () => {
     new BigNumber(2000),
     new BigNumber(0.78),
     new BigNumber(0),
-    new BigNumber(100000)
+    expirationTimeInSeconds
   );
 
   await (await johnDB).sync(john.augur, mock.constants.chunkSize, 0);
@@ -179,7 +180,7 @@ test('rollback derived database', async () => {
     new BigNumber(2000),
     new BigNumber(0.78),
     new BigNumber(0),
-    new BigNumber(100000)
+    expirationTimeInSeconds
   );
 
   await (await johnDB).sync(john.augur, mock.constants.chunkSize, 0);


### PR DESCRIPTION
- don't include orders that expire within 70s
- Add recently invalid markets to Recently Depleted Liquidity (but always show at the bottom of market lists)
- previous PR feedback updates
- ~check orders every 3mins instead of on order/cancel/fill~ In another PR
