### PR TITLE
fixes for network.json and reporting disputing notification.

### DIFF
--- a/packages/augur-ui/src/config/network.json
+++ b/packages/augur-ui/src/config/network.json
@@ -95,7 +95,7 @@
       "broadcast": false
     },
     "0x-mesh": {
-      "enabled": true,
+      "enabled": true
     },
     "0x-endpoint": "wss://v2.augur.net/0x-ws"
   },

--- a/packages/augur-ui/src/modules/notifications/selectors/notification-state.ts
+++ b/packages/augur-ui/src/modules/notifications/selectors/notification-state.ts
@@ -108,8 +108,8 @@ export const selectMarketsInDispute = createSelector(
   (markets, positions, address) => {
     const state = store.getState() as AppState;
     let marketIds = Object.keys(positions);
-    const { reporting, disputing } = state.loginAccount;
-    if (disputing && disputing.contracts) {
+    const { reporting } = state.loginAccount;
+    if (reporting.disputing && reporting.disputing.contracts) {
       marketIds = Array.from(
         new Set([
           ...marketIds,


### PR DESCRIPTION
small fixes
network.json had a trailing comma that caused webpack to fail. 
notifications was pulling disputing directly from loginAccount which is incorrect. it's on reporting property.