### PR TITLE
order form clear on submit.

### DIFF
--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -217,7 +217,6 @@ export default class MarketView extends Component<
       tradingTutorial,
       updateModal,
       closeMarketLoadingModalOnly,
-      modalShowing,
       preview
     } = prevProps;
     if (
@@ -229,7 +228,6 @@ export default class MarketView extends Component<
 
     if (tradingTutorial) {
       if (
-        !isMarketLoading &&
         !this.state.introShowing &&
         this.state.tutorialStep === TRADING_TUTORIAL_STEPS.INTRO_MODAL
       ) {
@@ -254,9 +252,8 @@ export default class MarketView extends Component<
       this.props.loadMarketsInfo(this.props.marketId);
       this.props.loadMarketTradingHistory(marketId);
     }
-
-    if (!isMarketLoading) {
-      closeMarketLoadingModalOnly && closeMarketLoadingModalOnly(modalShowing);
+    if (!this.props.isMarketLoading) {
+      closeMarketLoadingModalOnly(this.props.modalShowing);
     }
 
     if (

--- a/packages/augur-ui/src/modules/trades/actions/place-market-trade.ts
+++ b/packages/augur-ui/src/modules/trades/actions/place-market-trade.ts
@@ -3,7 +3,6 @@ import {
   BUY, INVALID_OUTCOME_ID,
 } from "modules/common/constants";
 import logError from "utils/log-error";
-import noop from "utils/noop";
 import { AppState } from "store";
 import { ThunkDispatch } from "redux-thunk";
 import { Action } from "redux";
@@ -20,7 +19,6 @@ export const placeMarketTrade = ({
   tradeInProgress,
   doNotCreateOrders,
   callback = logError,
-  onComplete = noop,
 }: any) => async (dispatch: ThunkDispatch<void, any, Action>, getState: () => AppState) => {
   if (!marketId) return null;
   const { marketInfos, loginAccount, blockchain } = getState();
@@ -81,7 +79,7 @@ export const placeMarketTrade = ({
     .catch((err) => {
       console.log(err);
       dispatch(
-        updatePendingOrderStatus(tradeGroupId, marketId, TXEventName.Failure, '0')
+        updatePendingOrderStatus(tradeGroupId, marketId, TXEventName.Failure, null)
       );
       callback(err, null)
     });

--- a/packages/augur-ui/src/modules/trading/components/wrapper.tsx
+++ b/packages/augur-ui/src/modules/trading/components/wrapper.tsx
@@ -326,21 +326,8 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
       market.id,
       selectedOutcome.id,
       trade,
-      s.doNotCreateOrders,
-      (err, result) => {
-        // onSent/onFailed CB
-        if(err) {
-          console.log(err);
-          console.log(JSON.stringify(err));
-        }
-        if (!err) {
-          this.clearOrderForm();
-        }
-      },
-      res => {
-        // onComplete CB
-      }
-    );
+      s.doNotCreateOrders)
+    this.clearOrderForm();
   }
 
   updateTradeNumShares(order) {


### PR DESCRIPTION
clear order form when submit order. order form doesn't do anything with error even if one occurs.

no has to keep track of order so use null when calling `updatePendingOrderStatus` if there is an error.  doesn't look like hash is used to find the order anyway. only for verifying it's confirmed, which causes an error anyway. good to set it to null. 

I put `work-in-progress` on this b/c UI might need to disable order form submit button if user has order awaiting signing. discussion is going now, in #dev channel in discord.