### PR TITLE
fixed to order form for inputting percentage for scalar invalid outco…

### DIFF
--- a/packages/augur-ui/src/modules/trading/components/form.tsx
+++ b/packages/augur-ui/src/modules/trading/components/form.tsx
@@ -457,8 +457,7 @@ class Form extends Component<FromProps, FormState> {
         );
       }
     }
-    if (!isScalarInvalidOutcome &&
-      value &&
+    if (value &&
       value
         .minus(minPrice)
         .mod(tickSize)
@@ -787,20 +786,26 @@ class Form extends Component<FromProps, FormState> {
   calcPercentagePrice(
     percentage: string,
     minPrice: string,
+    maxPrice: string,
     tickSize: number,
     numTicks: string
   ) {
     if (percentage === undefined || percentage === null) return Number(0);
+    const bnMinPrice = createBigNumber(minPrice);
+    const bnMaxPrice = createBigNumber(maxPrice);
     const percentNumTicks = createBigNumber(numTicks).times(
       createBigNumber(percentage).dividedBy(100)
     );
+    if (percentNumTicks.lt(tickSize)) {
+      return bnMinPrice.plus(tickSize);
+    }
     const calcPrice = percentNumTicks
       .times(tickSize)
-      .plus(createBigNumber(minPrice));
+      .plus(bnMinPrice);
+      if (calcPrice.eq(maxPrice)){
+        return bnMaxPrice.minus(tickSize);
+      }
     const correctDec = formatBestPrice(calcPrice, tickSize);
-    if (createBigNumber(correctDec.fullPrecision).lt(createBigNumber(minPrice))) {
-      return minPrice;
-    }
     return correctDec.fullPrecision;
   }
 
@@ -1008,6 +1013,7 @@ class Form extends Component<FromProps, FormState> {
                       const value = this.calcPercentagePrice(
                         percentage,
                         min,
+                        max,
                         tickSize,
                         numTicks
                       );

--- a/packages/augur-ui/src/modules/trading/components/form.tsx
+++ b/packages/augur-ui/src/modules/trading/components/form.tsx
@@ -457,7 +457,7 @@ class Form extends Component<FromProps, FormState> {
         );
       }
     }
-    if (
+    if (!isScalarInvalidOutcome &&
       value &&
       value
         .minus(minPrice)
@@ -790,7 +790,7 @@ class Form extends Component<FromProps, FormState> {
     tickSize: number,
     numTicks: string
   ) {
-    if (!percentage) return Number(minPrice);
+    if (percentage === undefined || percentage === null) return Number(0);
     const percentNumTicks = createBigNumber(numTicks).times(
       createBigNumber(percentage).dividedBy(100)
     );
@@ -798,7 +798,10 @@ class Form extends Component<FromProps, FormState> {
       .times(tickSize)
       .plus(createBigNumber(minPrice));
     const correctDec = formatBestPrice(calcPrice, tickSize);
-    return correctDec.full;
+    if (createBigNumber(correctDec.fullPrecision).lt(createBigNumber(minPrice))) {
+      return minPrice;
+    }
+    return correctDec.fullPrecision;
   }
 
   render() {


### PR DESCRIPTION
…me. still can't create an order, might not be a UI issue.


https://github.com/AugurProject/augur/issues/5554

fixes:
1. needed to use fullPrecision to calculate percentage.
2. needed to return minPrice if the percentage is too low. and not a valid price. 