### PR TITLE
Update account menu

### DIFF
--- a/packages/augur-ui/src/modules/app/components/side-nav/side-nav.styles.less
+++ b/packages/augur-ui/src/modules/app/components/side-nav/side-nav.styles.less
@@ -99,7 +99,7 @@
   }
 
   > div > ul {
-    background: @color-module-background;
+    background: @color-active-background;
     height: calc(100vh - @top-bar-height-mobile);
     margin-top: @top-bar-height-mobile;
     padding-bottom: @top-bar-height-mobile;
@@ -169,7 +169,7 @@
 
   > div > footer {
     align-items: center;
-    background: @color-module-background;
+    background: @color-active-background;
     bottom: 0px;
     display: flex;
     height: @top-bar-height-mobile;
@@ -177,6 +177,7 @@
     padding: 0 @size-16;
     position: fixed;
     width: calc(100% - @size-52);
+    border-top: @size-1 solid @color-dark-grey;
 
     > div:nth-of-type(2) {
       .mono-10-semi-bold;

--- a/packages/augur-ui/src/modules/app/components/side-nav/side-nav.styles.less
+++ b/packages/augur-ui/src/modules/app/components/side-nav/side-nav.styles.less
@@ -40,7 +40,6 @@
       > div:nth-of-type(2) {
 
         > div:first-of-type {
-          background: @color-module-background;
           display: flex;
           justify-content: flex-end;
           width: 100%;

--- a/packages/augur-ui/src/modules/auth/components/connect-account/connect-account.styles.less
+++ b/packages/augur-ui/src/modules/auth/components/connect-account/connect-account.styles.less
@@ -36,7 +36,7 @@
     }
 
     background: @color-dark-grey;
-    border: @size-1 solid @color-dark-grey;
+    border: @size-1 solid @color-module-background;
     border-bottom: 0;
     display: flex;
     padding: @size-12;
@@ -44,6 +44,7 @@
 
     @media @breakpoint-mobile {
       border: none;
+      border-left: @size-1 solid @color-module-background;
       padding: @size-24 @size-12;
       max-height: @size-72;
     }

--- a/packages/augur-ui/src/modules/auth/components/connect-account/connect-account.styles.less
+++ b/packages/augur-ui/src/modules/auth/components/connect-account/connect-account.styles.less
@@ -23,6 +23,7 @@
 
       @media @breakpoint-mobile {
         border: none;
+        background: @color-module-background;
       }
     }
   }
@@ -43,7 +44,6 @@
 
     @media @breakpoint-mobile {
       border: none;
-      background: @color-module-background;
       padding: @size-24 @size-12;
       max-height: @size-72;
     }

--- a/packages/augur-ui/src/modules/auth/components/connect-dropdown/connect-dropdown.styles.less
+++ b/packages/augur-ui/src/modules/auth/components/connect-dropdown/connect-dropdown.styles.less
@@ -110,7 +110,6 @@
 
       > svg {
         height: @size-12;
-        margin-left: @size-20;
         width: @size-12;
 
         > path {
@@ -172,7 +171,7 @@
 
         width: @size-12;
         height: @size-12;
-        margin-left: @size-20;
+        margin-left: @size-4;
       }
     }
 
@@ -204,7 +203,7 @@
     width: 100%;
 
     > button {
-      width: @size-85;
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
#5208

- When I open the hamburger menu, the account menu inactive state should have the same background color as the darker gray on the left
- When I expand the account menu the background color should be: 1B1A1E
- This is different from the background color of the rest of the hamburger menu, e.g. behind the navigation links the color should be: 222124
- The tooltips should be positioned 4px from the labels
- The add funds button should be larger in terms of width, with 16px padding on the sides


![Screen Shot 2020-02-13 at 4 12 17 PM](https://user-images.githubusercontent.com/58647954/74414219-ef3e4180-4e7b-11ea-89a0-8e83f756850d.png)
![Screen Shot 2020-02-13 at 4 12 11 PM](https://user-images.githubusercontent.com/58647954/74414220-f06f6e80-4e7b-11ea-99f9-8c115e51f365.png)
