### PR TITLE
Add more spacing between the filters header and markets sub header

### DIFF
--- a/packages/augur-ui/src/modules/app/components/inner-nav/markets-list-filters.styles.less
+++ b/packages/augur-ui/src/modules/app/components/inner-nav/markets-list-filters.styles.less
@@ -63,6 +63,7 @@
     }
   }
 
+  // Filters header
   > div:first-of-type {
     .text-12-bold;
 
@@ -81,7 +82,7 @@
     @media @breakpoint-mobile {
       .text-14-bold;
 
-      margin: @size-24 @size-24 0;
+      margin: @size-24;
     }
   }
 }


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/4917

- add more spacing between the filters header and markets sub header here. Looks too tight. Refer to design

![Screen Shot 2020-02-13 at 4 33 40 PM](https://user-images.githubusercontent.com/58647954/74415869-28c47c00-4e7f-11ea-99f8-f0818e1ca3f1.png)
