### PR TITLE
added check for enough funds to designate report

### DIFF
--- a/packages/augur-ui/src/modules/reporting/common.tsx
+++ b/packages/augur-ui/src/modules/reporting/common.tsx
@@ -819,18 +819,17 @@ export class ReportingBondsView extends Component<
             threshold={threshold}
           />
         )}
-        {showTotal && (
-          <div className={Styles.ShowTotals}>
-            <span>Totals</span>
-            <span>Sum total of Initial Reporter Stake and Pre-Filled Stake</span>
-            <LinearPropertyLabel
-              key="totalRep"
-              label="Total REP"
-              value={totalRep}
-            />
-            {insufficientRep && <span className={FormStyles.ErrorText}>{insufficientRep}</span>}
-          </div>
-        )}
+        <div className={Styles.ShowTotals}>
+          <span>Totals</span>
+          <span>Sum total of Initial Reporter Stake and Pre-Filled Stake</span>
+          <LinearPropertyLabel
+            key="totalRep"
+            label="Total REP Needed"
+            value={totalRep}
+          />
+          {insufficientRep && <span className={FormStyles.ErrorText}>{insufficientRep}</span>}
+        </div>
+
         <LinearPropertyLabel
           key="totalEstimatedGasFee"
           label={Gnosis_ENABLED ? "Transaction Fee" : "Gas Fee"}

--- a/packages/augur-ui/src/modules/reporting/common.tsx
+++ b/packages/augur-ui/src/modules/reporting/common.tsx
@@ -40,7 +40,7 @@ import {
 import { MarketProgress } from 'modules/common/progress';
 import { ExclamationCircle, InfoIcon, XIcon } from 'modules/common/icons';
 import ChevronFlip from 'modules/common/chevron-flip';
-
+import FormStyles from 'modules/common/form.styles.less';
 import TooltipStyles from 'modules/common/tooltip.styles.less';
 import ButtonStyles from 'modules/common/buttons.styles.less';
 import Styles from 'modules/reporting/common.styles.less';
@@ -600,6 +600,7 @@ export interface ReportingBondsViewProps {
   userAttoRep: BigNumber;
   owesRep: boolean;
   openReporting: boolean;
+  enoughRepBalance: boolean;
 }
 
 interface ReportingBondsViewState {
@@ -638,16 +639,14 @@ export class ReportingBondsView extends Component<
       this.setState({
         threshold: String(convertAttoValueToDisplayValue(threshold)),
       });
-
       if (this.props.Gnosis_ENABLED) {
-        const gasLimit = await this.props.reportAction(true);
+        const gasLimit = await this.props.reportAction(true).catch(e => console.error(e));
         this.setState({
           gasEstimate: formatGasCostToEther(
-            gasLimit,
+            gasLimit || INITAL_REPORT_GAS_COST,
             { decimalsRounded: 4 },
             this.props.gasPrice,
           )
-
         });
       }
     }
@@ -680,8 +679,8 @@ export class ReportingBondsView extends Component<
   };
 
   updateInputtedStake = (inputStakeValue: string) => {
-    const { updateInputtedStake, inputScalarOutcome, userAttoRep } = this.props;
-    const { isScalar, threshold } = this.state;
+    const { updateInputtedStake, userAttoRep } = this.props;
+    const { threshold } = this.state;
     let disabled = false;
     if (isNaN(Number(inputStakeValue))) {
       disabled = true;
@@ -730,7 +729,8 @@ export class ReportingBondsView extends Component<
       owesRep,
       Gnosis_ENABLED,
       ethToDaiRate,
-      openReporting
+      openReporting,
+      enoughRepBalance
     } = this.props;
 
     const {
@@ -752,8 +752,10 @@ export class ReportingBondsView extends Component<
       : 'Initial Reporter Stake';
 
     repLabel = openReporting ? 'Open Reporting winning Stake' : repLabel;
+    let showTotal = showInput;
     if (owesRep) {
       repLabel = 'REP needed';
+      showTotal = true;
     }
     const reviewLabel = migrateRep
     ? 'Review REP to migrate'
@@ -771,7 +773,11 @@ export class ReportingBondsView extends Component<
     if (isScalar && inputScalarOutcome === '') {
       buttonDisabled = true;
     }
-
+    let insufficientRep = '';
+    if (!enoughRepBalance) {
+      insufficientRep = 'Not enough REP to report',
+      buttonDisabled = true;
+    }
     return (
       <div
         className={classNames(Styles.ReportingBondsView, {
@@ -813,7 +819,7 @@ export class ReportingBondsView extends Component<
             threshold={threshold}
           />
         )}
-        {showInput && (
+        {showTotal && (
           <div className={Styles.ShowTotals}>
             <span>Totals</span>
             <span>Sum total of Initial Reporter Stake and Pre-Filled Stake</span>
@@ -822,6 +828,7 @@ export class ReportingBondsView extends Component<
               label="Total REP"
               value={totalRep}
             />
+            {insufficientRep && <span className={FormStyles.ErrorText}>{insufficientRep}</span>}
           </div>
         )}
         <LinearPropertyLabel

--- a/packages/augur-ui/src/modules/reporting/containers/reporting-bonds-view.ts
+++ b/packages/augur-ui/src/modules/reporting/containers/reporting-bonds-view.ts
@@ -18,7 +18,8 @@ const mapStateToProps = (state: AppState, ownProps) => {
     hasForked && !!universe.forkingInfo.winningChildUniverseId;
   const initialReport = !migrateMarket && !migrateRep;
   const openReporting = market.reportingState === REPORTING_STATE.OPEN_REPORTING;
-  const owesRep = migrateMarket || (!openReporting && !isSameAddress(market.designatedReporter, loginAccount.address));
+  const owesRep = migrateMarket ? migrateMarket : (!openReporting && !isSameAddress(market.author, loginAccount.address));
+  const enoughRepBalance = owesRep ? userAttoRep.gte(createBigNumber(market.noShowBondAmount)) : true;
 
   return {
     owesRep,
@@ -29,7 +30,8 @@ const mapStateToProps = (state: AppState, ownProps) => {
     Gnosis_ENABLED: state.appStatus.gnosisEnabled,
     ethToDaiRate: state.appStatus.ethToDaiRate,
     gasPrice: getGasPrice(state),
-    openReporting
+    openReporting,
+    enoughRepBalance
   };
 };
 


### PR DESCRIPTION
added check for user having enough funds to report when DR is not market creator (super edge case)

show total rep needed for DR and Open reporting so user has better idea of REP needed for transaction.

when no rep is needed to report
![image](https://user-images.githubusercontent.com/3970376/74553183-6a573480-4f1c-11ea-82cf-c18ccee9181b.png)

when they add pre-filled stake
![image](https://user-images.githubusercontent.com/3970376/74553222-7f33c800-4f1c-11ea-8800-f37ee2758e08.png)

when user doesn't enough REP

![image](https://user-images.githubusercontent.com/3970376/74553270-a2f70e00-4f1c-11ea-8000-8938cda69ebc.png)


