### PR TITLE
stub out methods so there is no exceptions

### DIFF
--- a/packages/augur-ui/src/services/analytics/analytics.ts
+++ b/packages/augur-ui/src/services/analytics/analytics.ts
@@ -19,6 +19,11 @@ const analytics = isLocalHost() ? {} : Analytics({
 });
 */
 
-const analytics = {};
+const analytics = {
+  track: (name, data) => {},
+  page: (data) => {},
+  reset: () => {},
+  identify: (name, data) => {}
+};
 
 export { analytics };


### PR DESCRIPTION
analytics is throwing since it was commented out. need to stub out method names so there is no exceptions. user's weren't able to get logged in. 


