### PR TITLE
show Portis error message

### DIFF
--- a/packages/augur-ui/src/modules/auth/actions/login-with-portis.ts
+++ b/packages/augur-ui/src/modules/auth/actions/login-with-portis.ts
@@ -69,7 +69,7 @@ import { getNetwork } from 'utils/get-network-name';
         dispatch(
           updateModal({
             type: MODAL_ERROR,
-            error: JSON.stringify(error),
+            error: JSON.stringify(error && error.message ? error.message : 'Sorry, something went wrong.'),
           })
         );
       });


### PR DESCRIPTION
closes #6354 

show error message if available.

 
<img width="555" src="https://user-images.githubusercontent.com/1683736/75065778-7e200f00-54b7-11ea-8d3f-8850442fc7fe.png">
