### PR TITLE
Clear pending order after order fill

### DIFF
--- a/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
+++ b/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
@@ -806,7 +806,6 @@ export async function placeTrade(
   marketId: string,
   numOutcomes: number,
   outcomeId: number,
-  fingerprint: string = getFingerprint(),
   doNotCreateOrders: boolean,
   numTicks: BigNumber | string,
   minPrice: BigNumber | string,
@@ -816,6 +815,7 @@ export async function placeTrade(
   displayShares: BigNumber | string,
   expirationTime?: BigNumber,
   tradeGroupId?: string,
+  fingerprint: string = getFingerprint(),
 ): Promise<void> {
   const Augur = augurSdk.get();
   const params: PlaceTradeDisplayParams = {

--- a/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
+++ b/packages/augur-ui/src/modules/events/actions/add-update-transaction.ts
@@ -4,12 +4,10 @@ import {
   removeCanceledOrder,
 } from 'modules/orders/actions/update-order-status';
 import {
-  PUBLICTRADE,
   CANCELORDER,
   CANCELORDERS,
   TX_ORDER_ID,
   TX_ORDER_IDS,
-  TX_MARKET_ID,
   CREATEMARKET,
   CREATECATEGORICALMARKET,
   CREATESCALARMARKET,
@@ -21,7 +19,6 @@ import {
   PUBLICFILLORDER,
   BUYPARTICIPATIONTOKENS,
   MODAL_ERROR,
-  DOINITIALREPORT
 } from 'modules/common/constants';
 import { CreateMarketData } from 'modules/types';
 import { ThunkDispatch } from 'redux-thunk';

--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -68,6 +68,7 @@ import * as _ from 'lodash';
 import { loadMarketOrderBook } from 'modules/orders/actions/load-market-orderbook';
 import { isCurrentMarket } from 'modules/trades/helpers/is-current-market';
 import { removePendingDataByHash, addPendingData } from 'modules/pending-queue/actions/pending-queue-management';
+import { removePendingOrder } from 'modules/orders/actions/pending-orders-management';
 
 const handleAlert = (
   log: any,
@@ -410,6 +411,7 @@ export const handleOrderFilledLog = (log: Logs.ParsedOrderEventLog) => (
     );
     dispatch(throttleLoadUserOpenOrders());
     handleAlert(log, PUBLICFILLORDER, true, dispatch, getState);
+    dispatch(removePendingOrder(log.tradeGroupId, marketId));
   }
   if (isOnTradePage()) {
     dispatch(loadMarketTradingHistory(marketId));

--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -68,7 +68,7 @@ import * as _ from 'lodash';
 import { loadMarketOrderBook } from 'modules/orders/actions/load-market-orderbook';
 import { isCurrentMarket } from 'modules/trades/helpers/is-current-market';
 import { removePendingDataByHash, addPendingData } from 'modules/pending-queue/actions/pending-queue-management';
-import { removePendingOrder } from 'modules/orders/actions/pending-orders-management';
+import { removePendingOrder, constructPendingOrderid } from 'modules/orders/actions/pending-orders-management';
 
 const handleAlert = (
   log: any,
@@ -362,6 +362,9 @@ export const handleOrderCreatedLog = (log: Logs.ParsedOrderEventLog) => (
   if (isUserDataUpdate && authStatus.isLogged) {
     handleAlert(log, PUBLICTRADE, false, dispatch, getState);
     dispatch(throttleLoadUserOpenOrders());
+    console.log('log order created', log);
+    const pendingOrderId = constructPendingOrderid(log.amount, log.price, log.outcome, log.market)
+    dispatch(removePendingOrder(pendingOrderId, log.market));
   }
   dispatch(updateMarketOrderBook(log.market));
 };

--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -362,7 +362,6 @@ export const handleOrderCreatedLog = (log: Logs.ParsedOrderEventLog) => (
   if (isUserDataUpdate && authStatus.isLogged) {
     handleAlert(log, PUBLICTRADE, false, dispatch, getState);
     dispatch(throttleLoadUserOpenOrders());
-    console.log('log order created', log);
     const pendingOrderId = constructPendingOrderid(log.amount, log.price, log.outcome, log.market)
     dispatch(removePendingOrder(pendingOrderId, log.market));
   }

--- a/packages/augur-ui/src/modules/events/actions/wrap-log-handler.ts
+++ b/packages/augur-ui/src/modules/events/actions/wrap-log-handler.ts
@@ -10,7 +10,7 @@ export const wrapLogHandler = (logHandler: Function) => (
 ) => {
   if (log) {
     const universeId: string = getState().universe.id;
-    console.log("event name", Array.isArray(log) ? log.length : log.eventName);
+    // console.log("event name", Array.isArray(log) ? log.length : log.eventName);
     const isInCurrentUniverse = true;
     // TODO: process universe when Events have universe propety, for now assume all events are good
     // const isInCurrentUniverse = Object.values(log).find(

--- a/packages/augur-ui/src/modules/events/actions/wrap-log-handler.ts
+++ b/packages/augur-ui/src/modules/events/actions/wrap-log-handler.ts
@@ -10,7 +10,7 @@ export const wrapLogHandler = (logHandler: Function) => (
 ) => {
   if (log) {
     const universeId: string = getState().universe.id;
-    // console.log("event name", Array.isArray(log) ? log.length : log.eventName);
+    console.log("event name", Array.isArray(log) ? log.length : log.eventName);
     const isInCurrentUniverse = true;
     // TODO: process universe when Events have universe propety, for now assume all events are good
     // const isInCurrentUniverse = Object.values(log).find(

--- a/packages/augur-ui/src/modules/orders/actions/liquidity-management.ts
+++ b/packages/augur-ui/src/modules/orders/actions/liquidity-management.ts
@@ -263,7 +263,6 @@ const createZeroXLiquidityOrders = async (
         market.id,
         market.numOutcomes,
         o.outcomeId,
-        fingerprint,
         false,
         market.numTicks,
         market.minPrice,

--- a/packages/augur-ui/src/modules/orders/actions/pending-orders-management.ts
+++ b/packages/augur-ui/src/modules/orders/actions/pending-orders-management.ts
@@ -5,6 +5,7 @@ import { isTransactionConfirmed } from 'modules/contracts/actions/contractCalls'
 import {
   convertDisplayAmountToOnChainAmount,
   convertDisplayPriceToOnChainPrice,
+  convertDisplayValuetoAttoValue,
 } from '@augurproject/sdk';
 import { createBigNumber } from 'utils/create-big-number';
 import { TransactionMetadataParams } from 'contract-dependencies-ethers/src';
@@ -61,8 +62,8 @@ export const constructPendingOrderid = (
   market: string
 ) => {
   const params: TransactionMetadataParams = {
-    amount: onChainAmount,
-    price: onChainPrice,
+    amount: createBigNumber(onChainAmount).toString(),
+    price: createBigNumber(onChainPrice).toString(16),
     outcome: onchainOutcome,
     market,
   };
@@ -97,7 +98,7 @@ export const generatePendingOrderId = (
 
   const params: TransactionMetadataParams = {
     amount: onChainAmount.toString(),
-    price: onChainPrice.toString(),
+    price: onChainPrice.toString(16),
     outcome: hexOutcome,
     market: marketId,
   };

--- a/packages/augur-ui/src/modules/orders/actions/pending-orders-management.ts
+++ b/packages/augur-ui/src/modules/orders/actions/pending-orders-management.ts
@@ -2,6 +2,13 @@ import { UIOrder } from 'modules/types';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
 import { isTransactionConfirmed } from 'modules/contracts/actions/contractCalls';
+import {
+  convertDisplayAmountToOnChainAmount,
+  convertDisplayPriceToOnChainPrice,
+} from '@augurproject/sdk';
+import { createBigNumber } from 'utils/create-big-number';
+import { TransactionMetadataParams } from 'contract-dependencies-ethers/src';
+import { generateTxParameterId } from 'utils/generate-tx-parameter-id';
 
 export const ADD_PENDING_ORDER = 'ADD_PENDING_ORDER';
 export const REMOVE_PENDING_ORDER = 'REMOVE_PENDING_ORDER';
@@ -45,4 +52,57 @@ export const loadPendingOrdersTransactions = (pendingOrders: UIOrder[]) => (
         : dispatch(addPendingOrder(o, marketId));
     });
   });
+};
+
+export const constructPendingOrderid = (
+  onChainAmount: string,
+  onChainPrice: string,
+  onchainOutcome: string,
+  market: string
+) => {
+  const params: TransactionMetadataParams = {
+    amount: onChainAmount,
+    price: onChainPrice,
+    outcome: onchainOutcome,
+    market,
+  };
+
+  console.log(params);
+
+  return generateTxParameterId(params);
+};
+
+export const generatePendingOrderId = (
+  amount: string,
+  price: string,
+  outcome: string,
+  marketId: string,
+  tickSize: string,
+  minPrice: string
+) => {
+  const bnTickSize = createBigNumber(tickSize);
+  const bnMinPrice = createBigNumber(minPrice);
+  const bnAmount = createBigNumber(amount);
+  const bnPrice = createBigNumber(price);
+  const onChainAmount = convertDisplayAmountToOnChainAmount(
+    bnAmount,
+    bnTickSize
+  );
+  const onChainPrice = convertDisplayPriceToOnChainPrice(
+    bnPrice,
+    bnMinPrice,
+    bnTickSize
+  );
+  const hexOutcome = `0x0${outcome}`;
+
+  const params: TransactionMetadataParams = {
+    amount: onChainAmount.toString(),
+    price: onChainPrice.toString(),
+    outcome: hexOutcome,
+    market: marketId,
+  };
+
+  console.log(params);
+
+  return generateTxParameterId(params);
 };

--- a/packages/augur-ui/src/modules/orders/actions/pending-orders-management.ts
+++ b/packages/augur-ui/src/modules/orders/actions/pending-orders-management.ts
@@ -5,7 +5,6 @@ import { isTransactionConfirmed } from 'modules/contracts/actions/contractCalls'
 import {
   convertDisplayAmountToOnChainAmount,
   convertDisplayPriceToOnChainPrice,
-  convertDisplayValuetoAttoValue,
 } from '@augurproject/sdk';
 import { createBigNumber } from 'utils/create-big-number';
 import { TransactionMetadataParams } from 'contract-dependencies-ethers/src';
@@ -68,8 +67,6 @@ export const constructPendingOrderid = (
     market,
   };
 
-  console.log(params);
-
   return generateTxParameterId(params);
 };
 
@@ -102,8 +99,6 @@ export const generatePendingOrderId = (
     outcome: hexOutcome,
     market: marketId,
   };
-
-  console.log(params);
 
   return generateTxParameterId(params);
 };

--- a/packages/augur-ui/src/modules/orders/reducers/pending-orders.ts
+++ b/packages/augur-ui/src/modules/orders/reducers/pending-orders.ts
@@ -3,8 +3,7 @@ import {
   REMOVE_PENDING_ORDER,
   UPDATE_PENDING_ORDER,
 } from 'modules/orders/actions/pending-orders-management';
-import { PendingOrders, BaseAction, UIOrder } from 'modules/types';
-import { RESET_STATE } from 'modules/app/actions/reset-state';
+import { PendingOrders, BaseAction } from 'modules/types';
 
 const DEFAULT_STATE: PendingOrders = {};
 

--- a/packages/augur-ui/src/modules/trades/actions/place-market-trade.ts
+++ b/packages/augur-ui/src/modules/trades/actions/place-market-trade.ts
@@ -7,7 +7,7 @@ import { ThunkDispatch } from "redux-thunk";
 import { Action } from "redux";
 import { placeTrade, approveToTrade } from "modules/contracts/actions/contractCalls";
 import { Getters, TXEventName } from "@augurproject/sdk";
-import { addPendingOrder, removePendingOrder, updatePendingOrderStatus } from "modules/orders/actions/pending-orders-management";
+import { addPendingOrder, removePendingOrder, updatePendingOrderStatus, generatePendingOrderId } from "modules/orders/actions/pending-orders-management";
 import { convertUnixToFormattedDate } from "utils/format-date";
 import { generateTradeGroupId } from "utils/generate-trade-group-id";
 import { getOutcomeNameWithOutcome } from "utils/get-outcome";
@@ -37,9 +37,7 @@ export const placeMarketTrade = ({
   const displayAmount = tradeInProgress.numShares;
   const orderType = tradeInProgress.side === BUY ? 0 : 1;
   const expirationTime = tradeInProgress.expirationTime ? createBigNumber(tradeInProgress.expirationTime) : undefined;
-
-  const fingerprint = undefined; // TODO: get this from state
-  const tradeGroupId = generateTradeGroupId();
+  const tradeGroupId = generatePendingOrderId(displayAmount, displayPrice, outcomeId, marketId, market.tickSize, market.minPrice);
   dispatch(addPendingOrder(
     {
       ...tradeInProgress,
@@ -62,7 +60,6 @@ export const placeMarketTrade = ({
     market.id,
     market.numOutcomes,
     parseInt(outcomeId, 10),
-    fingerprint,
     doNotCreateOrders,
     market.numTicks,
     market.minPrice,

--- a/packages/augur-ui/src/modules/trades/actions/place-market-trade.ts
+++ b/packages/augur-ui/src/modules/trades/actions/place-market-trade.ts
@@ -2,7 +2,6 @@ import { createBigNumber } from "utils/create-big-number";
 import {
   BUY, INVALID_OUTCOME_ID, MODAL_ERROR,
 } from "modules/common/constants";
-import logError from "utils/log-error";
 import { AppState } from "store";
 import { ThunkDispatch } from "redux-thunk";
 import { Action } from "redux";
@@ -19,7 +18,6 @@ export const placeMarketTrade = ({
   outcomeId,
   tradeInProgress,
   doNotCreateOrders,
-  callback = logError,
 }: any) => async (dispatch: ThunkDispatch<void, any, Action>, getState: () => AppState) => {
   if (!marketId) return null;
   const { marketInfos, loginAccount, blockchain } = getState();
@@ -73,11 +71,8 @@ export const placeMarketTrade = ({
     displayPrice,
     userShares,
     expirationTime,
-  ).then(() => {
-    dispatch(removePendingOrder(tradeGroupId, market.id));
-    callback(null, null)
-  })
-    .catch((err) => {
+    tradeGroupId,
+  ).catch((err) => {
       console.log(err);
       dispatch(
         updateModal({
@@ -88,6 +83,5 @@ export const placeMarketTrade = ({
       dispatch(
         updatePendingOrderStatus(tradeGroupId, marketId, TXEventName.Failure, null)
       );
-      callback(err, null)
     });
 };

--- a/packages/augur-ui/src/modules/trading/components/wrapper.tsx
+++ b/packages/augur-ui/src/modules/trading/components/wrapper.tsx
@@ -19,10 +19,9 @@ import {
   formatNumber,
 } from 'utils/format-number';
 import convertExponentialToDecimal from 'utils/convert-exponential';
-import { MarketData, OutcomeFormatted, OutcomeOrderBook } from 'modules/types';
+import { MarketData, OutcomeFormatted } from 'modules/types';
 import { calculateTotalOrderValue } from 'modules/trades/helpers/calc-order-profit-loss-percents';
 import { formatDai } from 'utils/format-number';
-import { GnosisSafeState } from '@augurproject/gnosis-relay-api';
 import { Moment } from 'moment';
 
 export interface SelectedOrderProperties {

--- a/packages/augur-ui/src/modules/trading/containers/wrapper.ts
+++ b/packages/augur-ui/src/modules/trading/containers/wrapper.ts
@@ -96,8 +96,6 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     outcomeId,
     tradeInProgress,
     doNotCreateOrders,
-    callback,
-    onComplete
   ) =>
     dispatch(
       placeMarketTrade({
@@ -105,8 +103,6 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         outcomeId,
         tradeInProgress,
         doNotCreateOrders,
-        callback,
-        onComplete,
       })
     ),
     orderSubmitted: (type, marketId) => dispatch(orderSubmitted(type, marketId))

--- a/packages/augur-ui/src/utils/get-fingerprint.ts
+++ b/packages/augur-ui/src/utils/get-fingerprint.ts
@@ -23,7 +23,7 @@ async function calculateFingerprint(): Promise<string> {
           32
         );
         fingerprint = formatBytes32String(value);
-        console.log('fingerprint', fingerprint);
+        // console.log('fingerprint', fingerprint);
         resolve(fingerprint);
       });
     }, 500)


### PR DESCRIPTION
if user is just creating an order clear pending order when zeroX order is created `handleOrderCreatedLog` method in log-handler.

If user is matching an existing order and a trade takes place remove pending order when SDK has been updated and `handleOrderFilledLog` event comes in. This way pending order gets removed right before user's position and frozen funds gets updated. 

https://github.com/AugurProject/augur/issues/6384