### PR TITLE
Remove ; in category-filters

### DIFF
--- a/packages/augur-ui/src/modules/app/components/inner-nav/category-filters.tsx
+++ b/packages/augur-ui/src/modules/app/components/inner-nav/category-filters.tsx
@@ -124,7 +124,7 @@ export default class CategoryFilters extends React.Component<
               category={item.category}
               icon={item.icon}
               loading={true}
-              count={null} />;
+              count={null} />
           </div>
         );
       }


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/6421
Before the PR:
![Screen Shot 2020-02-25 at 3 48 16 PM](https://user-images.githubusercontent.com/58647954/75226219-00c20a80-57e7-11ea-8a0f-c4f44f06d20d.png)

After the PR:
![Screen Shot 2020-02-25 at 3 57 45 PM](https://user-images.githubusercontent.com/58647954/75226615-9fe70200-57e7-11ea-9342-0e59e7693cb6.png)

I think we don't need ```;```
