### PR TITLE
fix staking message if tentative winner has more staked then disputin…

### DIFF
--- a/packages/augur-ui/src/modules/common/form.tsx
+++ b/packages/augur-ui/src/modules/common/form.tsx
@@ -785,6 +785,7 @@ export const ReportingRadioBarGroup = ({
       notNewTentativeWinner = createBigNumber(winning.stakeCurrent).gt(
         disputeOutcome.bondSizeCurrent
       );
+      // double pre-filled to make new outcome tentative winner.
       winningStakeCurrent = formatAttoRep(createBigNumber(winning.stakeCurrent).times(2)).formatted;
       remainingState = formatAttoRep(disputeOutcome.stakeRemaining).formatted;
     }

--- a/packages/augur-ui/src/modules/common/form.tsx
+++ b/packages/augur-ui/src/modules/common/form.tsx
@@ -280,7 +280,6 @@ export interface ReportingRadioBarProps extends BaseRadioButtonProp {
   userOutcomeCurrentRoundDispute: Getters.Accounts.UserCurrentOutcomeDisputeStake | null;
   hideButton?: boolean;
   isDisputing: boolean;
-  Gnosis_ENABLED: boolean;
 }
 
 export interface RadioTwoLineBarProps extends BaseRadioButtonProp {
@@ -777,8 +776,8 @@ export const ReportingRadioBarGroup = ({
     radioButton => radioButton.stake.tentativeWinning
   );
   let winningStakeCurrent = '0';
-  let disputeAmount = '0';
   let notNewTentativeWinner = false;
+  let remainingState = '0';
   if (tentativeWinning) {
     const winning = disputeInfo.stakes.find(s => s.tentativeWinning);
     const disputeOutcome = disputeInfo.stakes.find(s => s.outcome === selected);
@@ -786,8 +785,8 @@ export const ReportingRadioBarGroup = ({
       notNewTentativeWinner = createBigNumber(winning.stakeCurrent).gt(
         disputeOutcome.bondSizeCurrent
       );
-      disputeAmount = formatAttoRep(disputeOutcome.bondSizeCurrent).formatted;
-      winningStakeCurrent = formatAttoRep(winning.stakeCurrent).formatted;
+      winningStakeCurrent = formatAttoRep(createBigNumber(winning.stakeCurrent).times(2)).formatted;
+      remainingState = formatAttoRep(disputeOutcome.stakeRemaining).formatted;
     }
   }
 
@@ -832,8 +831,8 @@ export const ReportingRadioBarGroup = ({
         notNewTentativeWinner &&
         tentativeWinning.id !== selected && (
           <Error
-            header={`Filling this bond of ${disputeAmount} REP only completes this current round`}
-            subheader={`Tentative Winning outcome has ${winningStakeCurrent} REP already staked for next round. More REP will be needed to make this outcome the Tentative Winner. This will require an additional transaction.`}
+            header={`Filling this bond of ${remainingState} REP only completes this current round`}
+            subheader={`${winningStakeCurrent} additional REP will still be needed to make it Tentative Winning Outcome. This will require an additional transaction.`}
           />
         )}
       {radioButtons.map(
@@ -948,11 +947,10 @@ export class ReportingRadioBar extends Component<ReportingRadioBarProps, {}> {
       userOutcomeCurrentRoundDispute,
       hideButton,
       isDisputing,
-      Gnosis_ENABLED,
     } = this.props;
 
     let { stake } = this.props;
-    const { disputeInfo, reportingState, marketType } = market;
+    const { disputeInfo, marketType } = market;
     const isScalar = marketType === SCALAR;
     if (isScalar) {
       for (const index in disputeInfo.stakes) {


### PR DESCRIPTION
…g outcome bond, new bond will be twice the pre-filled amount. this is only the case when pre-filled on tentative winning outcome is greater than disputing bond amount.

https://github.com/AugurProject/augur/issues/5805


![image](https://user-images.githubusercontent.com/3970376/75300979-2529e100-57ff-11ea-9ca7-e91e2a7c7bfc.png)
