### PR TITLE
add REP at the end of staked rep on market cards

### DIFF
--- a/packages/augur-ui/src/modules/market-cards/market-card.tsx
+++ b/packages/augur-ui/src/modules/market-cards/market-card.tsx
@@ -233,7 +233,7 @@ export default class MarketCard extends React.Component<
         : undefined;
 
     const restOfOutcomes = isScalar && inDispute ? disputeInfo.stakes.length - showOutcomeNumber - 1 : outcomesFormatted.length - showOutcomeNumber;
-  
+
     return (
       <div
         className={classNames(Styles.MarketCard, {
@@ -264,7 +264,7 @@ export default class MarketCard extends React.Component<
               <LabelValue
                 condensed
                 label="Total Dispute Stake"
-                value={formatAttoRep(disputeInfo.stakeCompletedTotal).formatted}
+                value={formatAttoRep(disputeInfo.stakeCompletedTotal).full}
               />
             )}
             <div className={Styles.hoverIconTray}>{InfoIcons}</div>


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/5876

![image](https://user-images.githubusercontent.com/3970376/75302202-b6e71d80-5802-11ea-8797-b821e42d17e8.png)


add REP on the total disputed stake on market card