### PR TITLE
use market id to create unque key for tooltips

### DIFF
--- a/packages/augur-ui/src/modules/market-cards/common.tsx
+++ b/packages/augur-ui/src/modules/market-cards/common.tsx
@@ -378,6 +378,7 @@ export const LabelValue = (props: LabelValueProps) => (
 );
 
 export interface HoverIconProps {
+  id: string;
   icon: JSX.Element;
   hoverText: string;
   label: string;
@@ -387,11 +388,11 @@ export const HoverIcon = (props: HoverIconProps) => (
   <div
     className={Styles.HoverIcon}
     data-tip
-    data-for={`tooltip-${props.label}`}
+    data-for={`tooltip-${props.id}${props.label}`}
   >
     {props.icon}
     <ReactTooltip
-      id={`tooltip-${props.label}`}
+      id={`tooltip-${props.id}${props.label}`}
       className={TooltipStyles.Tooltip}
       effect="solid"
       place="top"

--- a/packages/augur-ui/src/modules/market-cards/market-card.tsx
+++ b/packages/augur-ui/src/modules/market-cards/market-card.tsx
@@ -153,10 +153,11 @@ export default class MarketCard extends React.Component<
       );
     }
 
-    const InfoIcons = (
+    const InfoIcons = ({ id }) => (
       <>
         {address && isSameAddress(address, author) && (
           <HoverIcon
+            id={id}
             label="marketCreator"
             icon={MarketCreator}
             hoverText="Market Creator"
@@ -164,6 +165,7 @@ export default class MarketCard extends React.Component<
         )}
         {address && isSameAddress(address, designatedReporter) && (
           <HoverIcon
+            id={id}
             label="reporter"
             icon={DesignatedReporter}
             hoverText="Designated Reporter"
@@ -171,6 +173,7 @@ export default class MarketCard extends React.Component<
         )}
         {hasPosition && (
           <HoverIcon
+            id={id}
             label="Position"
             icon={PositionIcon}
             hoverText="Position"
@@ -178,6 +181,7 @@ export default class MarketCard extends React.Component<
         )}
         {hasStaked && (
           <HoverIcon
+            id={id}
             label="dispute"
             icon={DisputeStake}
             hoverText="Dispute Stake"
@@ -372,7 +376,7 @@ export default class MarketCard extends React.Component<
             />
           )}
         </>
-        <div>{InfoIcons}</div>
+        <div><InfoIcons id={id} /></div>
       </div>
     );
   }


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/5887

unique key for tooltips. issue showed tooltip getting activated for more than one.
![image](https://user-images.githubusercontent.com/3970376/75303150-82289580-5805-11ea-9599-3b4a2ece3676.png)
