### PR TITLE
categorical template with dep outcome dropdown was throwing exception

### DIFF
--- a/packages/augur-ui/src/modules/create-market/components/common.tsx
+++ b/packages/augur-ui/src/modules/create-market/components/common.tsx
@@ -1582,12 +1582,14 @@ export const CategoricalTemplateDropdowns = (
           data,
         });
       });
-      setSourceUserInput(source && source.userInput);
-      setdropdownList(
-        isDepDropdown
-          ? createTemplateValueList(depDropdownInput.values[source.userInput])
-          : createTemplateValueList(depDropdownInput.values)
-      );
+      if (source && source.userInput !== undefined) {
+        setSourceUserInput(source.userInput);
+        setdropdownList(
+          isDepDropdown
+            ? createTemplateValueList(depDropdownInput.values[source.userInput])
+            : createTemplateValueList(depDropdownInput.values)
+        );
+      }
     } else {
       if (outcomeList.length == 0 && defaultOutcomeItems.length > 0) {
         defaultOutcomeItems.map((i: CategoricalDropDownItem) =>
@@ -1596,6 +1598,7 @@ export const CategoricalTemplateDropdowns = (
       }
 
       if (isDepDropdown && sourceUserInput !== source.userInput) {
+        setSourceUserInput(source.userInput);
         dispatch({ type: ACTIONS.REMOVE_ALL, data: null });
         setdropdownList(
           isDepDropdown


### PR DESCRIPTION
sports -> american football -> categorical market template `Which NFL team will win the ....` template was blowing up. not sure how we didn't catch this before. 

need to not set outcome dep list if source input hasn't been populated.


fixes

![image](https://user-images.githubusercontent.com/3970376/75306188-ecddcf00-580d-11ea-9ee5-1618342961e8.png)
