### PR TITLE
realized p/l text style color was getting overwritten

### DIFF
--- a/packages/augur-ui/src/modules/app/components/top-bar.styles.less
+++ b/packages/augur-ui/src/modules/app/components/top-bar.styles.less
@@ -143,7 +143,6 @@
 
       > div {
         .mono-11-medium;
-        color: @color-positive;
       }
     }
 


### PR DESCRIPTION
negative is suppose to be red.

![image](https://user-images.githubusercontent.com/3970376/75309038-7e047400-5815-11ea-9580-30b041cd1e13.png)

grey if 0.00
![image](https://user-images.githubusercontent.com/3970376/75309115-a9875e80-5815-11ea-8875-4ba930e45771.png)

positive
![image](https://user-images.githubusercontent.com/3970376/75309877-e0f70a80-5817-11ea-8136-aeed3581b985.png)
