### PR TITLE
user clicking on already clicked outcome clears inputs, it's confusing

### DIFF
--- a/packages/augur-ui/src/modules/common/form.tsx
+++ b/packages/augur-ui/src/modules/common/form.tsx
@@ -983,7 +983,7 @@ export class ReportingRadioBar extends Component<ReportingRadioBarProps, {}> {
         })}
         role="button"
         onClick={e => {
-          !hideButton && updateChecked(id, isInvalid);
+          !checked && !hideButton && updateChecked(id, isInvalid);
         }}
       >
         {checked ? FilledRadio : EmptyRadio}


### PR DESCRIPTION
super confusing for user. clicking on already clicked outcome in reporting form clears the form.

https://github.com/AugurProject/augur/issues/5787