### PR TITLE
multiple events are coming in for migrate rep, just need one alert

### DIFF
--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -655,7 +655,6 @@ export const handleTokensMintedLog = (log: Logs.TokensMinted) => (
   if (log.tokenType === Logs.TokenType.ReputationToken && !isForking) {
     const isUserDataUpdate = isSameAddress(log.target, userAddress);
     if (isUserDataUpdate) {
-      console.log('MIGRATE_FROM_LEG_REP_TOKEN', log.blockNumber, log.blockHash)
       dispatch(
         updateAlert(log.blockHash, {
           id: log.blockHash,

--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -655,15 +655,16 @@ export const handleTokensMintedLog = (log: Logs.TokensMinted) => (
   if (log.tokenType === Logs.TokenType.ReputationToken && !isForking) {
     const isUserDataUpdate = isSameAddress(log.target, userAddress);
     if (isUserDataUpdate) {
+      console.log('MIGRATE_FROM_LEG_REP_TOKEN', log.blockNumber, log.blockHash)
       dispatch(
-        addAlert({
-          id: MIGRATE_FROM_LEG_REP_TOKEN,
-          uniqueId: MIGRATE_FROM_LEG_REP_TOKEN,
+        updateAlert(log.blockHash, {
+          id: log.blockHash,
+          uniqueId: log.blockHash,
           params: {...log},
           status: TXEventName.Success,
           timestamp: getState().blockchain.currentAugurTimestamp * 1000,
           name: MIGRATE_FROM_LEG_REP_TOKEN,
-        })
+        }, false)
       );
       dispatch(removePendingData(MIGRATE_V1_V2, MIGRATE_V1_V2))
     }


### PR DESCRIPTION
for some reason SDK sends multiple token minted events. multiple bell alerts are showing up. need to only have one. 