### PR TITLE
Show custom migration modal for non-safae wallets with V1 REP

### DIFF
--- a/packages/augur-tools/src/flash/scripts.ts
+++ b/packages/augur-tools/src/flash/scripts.ts
@@ -253,19 +253,33 @@ export function addScripts(flash: FlashSession) {
         abbr: 't',
         description: 'Account to send funds (defaults to current user)',
         required: false
+      },
+      {
+        name: 'useLegacyRep',
+        abbr: 'r',
+        flag: true,
+        description: 'faucet legacy rep',
+        required: false
       }
     ],
     async call(this: FlashSession, args: FlashArguments) {
       if (this.noProvider()) return;
+      const useLegacyRep = Boolean(args.useLegacyRep)
       const user = await this.ensureUser();
       const amount = Number(args.amount);
       const atto = new BigNumber(amount).times(_1_ETH);
 
-      await user.repFaucet(atto);
+      console.log('useLegacyRep', useLegacyRep);
+      await user.repFaucet(atto, useLegacyRep);
 
       // if we have a target we transfer from current account to target.
       if(args.target) {
-        await user.augur.contracts.reputationToken.transfer(String(args.target), atto);
+        if (useLegacyRep) {
+          console.log('useLegacyRep', useLegacyRep, args.target);
+          await user.augur.contracts.legacyReputationToken.transfer(String(args.target), atto);
+        } else {
+          await user.augur.contracts.reputationToken.transfer(String(args.target), atto);
+        }
       }
     },
   });

--- a/packages/augur-tools/src/flash/scripts.ts
+++ b/packages/augur-tools/src/flash/scripts.ts
@@ -269,13 +269,11 @@ export function addScripts(flash: FlashSession) {
       const amount = Number(args.amount);
       const atto = new BigNumber(amount).times(_1_ETH);
 
-      console.log('useLegacyRep', useLegacyRep);
       await user.repFaucet(atto, useLegacyRep);
 
       // if we have a target we transfer from current account to target.
       if(args.target) {
         if (useLegacyRep) {
-          console.log('useLegacyRep', useLegacyRep, args.target);
           await user.augur.contracts.legacyReputationToken.transfer(String(args.target), atto);
         } else {
           await user.augur.contracts.reputationToken.transfer(String(args.target), atto);

--- a/packages/augur-tools/src/libs/contract-api.ts
+++ b/packages/augur-tools/src/libs/contract-api.ts
@@ -582,7 +582,6 @@ export class ContractAPI {
   async repFaucet(attoRep: BigNumber, useLegacy: boolean = false): Promise<void> {
     let reputationToken = this.augur.contracts.getReputationToken();
     if (useLegacy) {
-      console.log('useLegacyRep', useLegacy)
       await this.augur.contracts.legacyReputationToken.faucet(attoRep);
     } else {
       if (typeof reputationToken['faucet'] === 'function') {

--- a/packages/augur-tools/src/libs/contract-api.ts
+++ b/packages/augur-tools/src/libs/contract-api.ts
@@ -579,12 +579,17 @@ export class ContractAPI {
     await this.augur.contracts.cashFaucet.faucet(attoCash, { sender: account });
   }
 
-  async repFaucet(attoRep: BigNumber): Promise<void> {
-    const reputationToken = this.augur.contracts.getReputationToken();
-    if (typeof reputationToken['faucet'] === 'function') {
-      await reputationToken['faucet'](attoRep);
+  async repFaucet(attoRep: BigNumber, useLegacy: boolean = false): Promise<void> {
+    let reputationToken = this.augur.contracts.getReputationToken();
+    if (useLegacy) {
+      console.log('useLegacyRep', useLegacy)
+      await this.augur.contracts.legacyReputationToken.faucet(attoRep);
     } else {
-      throw Error('Cannot faucet REP with non-test version of REP contract.');
+      if (typeof reputationToken['faucet'] === 'function') {
+        await reputationToken['faucet'](attoRep);
+      } else {
+        throw Error('Cannot faucet REP with non-test version of REP contract.');
+      }
     }
   }
 

--- a/packages/augur-ui/src/modules/app/components/app.tsx
+++ b/packages/augur-ui/src/modules/app/components/app.tsx
@@ -40,6 +40,7 @@ import {
   LoginAccount,
   EnvObject,
   Notification,
+  AccountBalances,
 } from 'modules/types';
 import ForkingBanner from 'modules/reporting/containers/forking-banner';
 import parseQuery, { parseLocation } from 'modules/routes/helpers/parse-query';
@@ -88,7 +89,7 @@ interface AppProps {
   isHelpMenuOpen: boolean;
   showGlobalChat: Function;
   migrateV1Rep: Function;
-  showMigrateRepButton: boolean;
+  walletBalances: AccountBalances;
   saveAffilateAddress: Function;
 }
 
@@ -364,7 +365,7 @@ export default class AppView extends Component<AppProps> {
       isConnectionTrayOpen,
       updateConnectionTray,
       migrateV1Rep,
-      showMigrateRepButton,
+      walletBalances,
       updateModal,
       isHelpMenuOpen,
       updateHelpMenuState,
@@ -377,6 +378,7 @@ export default class AppView extends Component<AppProps> {
     const onTradingTutorial =
       parseQuery(location.search)[MARKET_ID_PARAM_NAME] === TRADING_TUTORIAL;
 
+    const showMigrateRepButton = walletBalances.legacyRep > 0 || walletBalances.legacyRepNonSafe > 0;
     return (
       <main>
         <HelmetTag {...APP_HEAD_TAGS} />
@@ -450,6 +452,7 @@ export default class AppView extends Component<AppProps> {
                 showGlobalChat={() => this.props.showGlobalChat()}
                 migrateV1Rep={migrateV1Rep}
                 showMigrateRepButton={showMigrateRepButton}
+                walletBalances={walletBalances}
                 updateModal={updateModal}
               />
 
@@ -460,6 +463,7 @@ export default class AppView extends Component<AppProps> {
                 currentBasePath={sidebarStatus.currentBasePath}
                 migrateV1Rep={migrateV1Rep}
                 showMigrateRepButton={showMigrateRepButton}
+                walletBalances={walletBalances}
                 updateModal={updateModal}
               />
             </section>

--- a/packages/augur-ui/src/modules/app/components/side-nav/side-nav.tsx
+++ b/packages/augur-ui/src/modules/app/components/side-nav/side-nav.tsx
@@ -7,7 +7,7 @@ import makePath from 'modules/routes/helpers/make-path';
 import ConnectDropdown from 'modules/auth/containers/connect-dropdown';
 import ConnectAccount from 'modules/auth/containers/connect-account';
 import { LogoutIcon, PlusCircleIcon } from 'modules/common/icons';
-import { NavMenuItem } from 'modules/types';
+import { NavMenuItem, AccountBalances } from 'modules/types';
 import Styles from 'modules/app/components/side-nav/side-nav.styles.less';
 import { HelpIcon, HelpMenuList } from 'modules/app/components/help-resources';
 import { SecondaryButton, ProcessingButton } from 'modules/common/buttons';
@@ -26,6 +26,7 @@ interface SideNavProps {
   showGlobalChat: Function;
   migrateV1Rep: Function;
   showMigrateRepButton: boolean;
+  walletBalances: AccountBalances;
   isHelpMenuOpen: boolean;
   updateHelpMenuState: Function;
   updateConnectionTray: Function;
@@ -43,6 +44,7 @@ const SideNav = ({
   showGlobalChat,
   migrateV1Rep,
   showMigrateRepButton,
+  walletBalances,
   isHelpMenuOpen,
   updateHelpMenuState,
   updateConnectionTray,
@@ -114,7 +116,7 @@ const SideNav = ({
               {showMigrateRepButton && (
                 <span className={Styles.SideNavMigrateRep}>
                   <ProcessingButton
-                    text="Migrate V1 to V2 REP"
+                    text={walletBalances.legacyRep > 0 ? 'Migrate V1 to V2 REP' : ' Migrate V1 REP'}
                     action={() => migrateV1Rep()}
                     queueName={MIGRATE_V1_V2}
                     queueId={MIGRATE_V1_V2}
@@ -130,9 +132,9 @@ const SideNav = ({
                   <ReactTooltip
                     id={'migrateRep'}
                     className={TooltipStyles.Tooltip}
-                    effect="solid"
-                    place="top"
-                    type="light"
+                    effect='solid'
+                    place='top'
+                    type='light'
                   >
                     <p>
                       {
@@ -149,7 +151,7 @@ const SideNav = ({
             <div className={Styles.GlobalChat}>
               <SecondaryButton
                 action={showGlobalChat}
-                text="Global Chat"
+                text='Global Chat'
                 icon={Chevron}
               />
             </div>

--- a/packages/augur-ui/src/modules/app/components/top-nav/top-nav.tsx
+++ b/packages/augur-ui/src/modules/app/components/top-nav/top-nav.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactTooltip from 'react-tooltip';
 import TooltipStyles from 'modules/common/tooltip.styles.less';
-
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import makePath from 'modules/routes/helpers/make-path';
@@ -11,11 +10,11 @@ import {
   ProcessingButton,
 } from 'modules/common/buttons';
 import { GlobalChat } from 'modules/global-chat/components/global-chat';
-
-import Styles from 'modules/app/components/top-nav/top-nav.styles.less';
-import { NavMenuItem } from 'modules/types';
+import { NavMenuItem, AccountBalances } from 'modules/types';
 import { helpIcon, PlusCircleIcon, Dot } from 'modules/common/icons';
 import { MODAL_ADD_FUNDS, MIGRATE_V1_V2 } from 'modules/common/constants';
+
+import Styles from 'modules/app/components/top-nav/top-nav.styles.less';
 
 interface TopNavProps {
   isLogged: boolean;
@@ -24,6 +23,7 @@ interface TopNavProps {
   isDisabled?: boolean;
   migrateV1Rep: Function;
   showMigrateRepButton: boolean;
+  walletBalances: AccountBalances;
   updateModal: Function;
 }
 
@@ -36,6 +36,7 @@ const TopNav = ({
   currentBasePath,
   migrateV1Rep,
   showMigrateRepButton = false,
+  walletBalances,
   updateModal,
 }: TopNavProps) => {
   const isCurrentItem = item => {
@@ -74,7 +75,7 @@ const TopNav = ({
                 <li>
                   <div className={Styles.MigrateRep}>
                     <ProcessingButton
-                      text="Migrate V1 to V2 REP"
+                      text={walletBalances.legacyRep > 0 ? 'Migrate V1 to V2 REP' : ' Migrate V1 REP'}
                       action={() => migrateV1Rep()}
                       queueName={MIGRATE_V1_V2}
                       queueId={MIGRATE_V1_V2}

--- a/packages/augur-ui/src/modules/app/containers/app.ts
+++ b/packages/augur-ui/src/modules/app/containers/app.ts
@@ -34,8 +34,7 @@ import { saveAffiliateAddress } from "modules/account/actions/login-account";
 const mapStateToProps = state => {
   const { alerts } = selectInfoAlertsAndSeenCount(state);
   const notifications = selectNotifications(state);
-  const v1RepBalance = state.loginAccount.balances;
-  const showMigrateRepButton = v1RepBalance.legacyAttoRep > 0;
+  const walletBalances = state.loginAccount.balances;
 
   return {
     notifications,
@@ -56,7 +55,7 @@ const mapStateToProps = state => {
     useWeb3Transport: isGlobalWeb3(),
     sidebarStatus: state.sidebarStatus,
     isConnectionTrayOpen: state.authStatus.isConnectionTrayOpen,
-    showMigrateRepButton,
+    walletBalances,
   }
 };
 

--- a/packages/augur-ui/src/modules/auth/actions/update-assets.ts
+++ b/packages/augur-ui/src/modules/auth/actions/update-assets.ts
@@ -20,10 +20,13 @@ export const updateAssets = (
   getState: () => AppState
 ) => {
   const { loginAccount, universe } = getState();
-  const { address } = loginAccount;
+  const { address, meta } = loginAccount;
+  const nonSafeWallet = meta.signer._address;
+
   return updateBalances(
     universe.id,
     address,
+    nonSafeWallet,
     dispatch,
     callback
   );
@@ -32,6 +35,7 @@ export const updateAssets = (
 function updateBalances(
   universe: string,
   address: string,
+  nonSafeWallet: string,
   dispatch: ThunkDispatch<void, any, Action>,
   callback: NodeStyleCallback
 ) {
@@ -40,15 +44,30 @@ function updateBalances(
     getDaiBalance(address),
     getEthBalance(address),
     getLegacyRepBalance(address),
+    getLegacyRepBalance(nonSafeWallet),
   ]).then(amounts => {
     const attoRep = amounts[0].toString();
     const legacyAttoRep = amounts[3].toString();
+    const legacyAttoRepNonSafe = amounts[4].toString();
     const rep = formatAttoRep(attoRep).value;
     const legacyRep = formatAttoRep(legacyAttoRep).value;
+    const legacyRepNonSafe = formatAttoRep(legacyAttoRepNonSafe).value;
     const dai = amounts[1];
     const eth = amounts[2];
-    dispatch(addedDaiEvent(dai)); 
-    dispatch(updateLoginAccount({ balances: { attoRep, rep, dai, eth, legacyAttoRep, legacyRep } }));
+    dispatch(addedDaiEvent(dai));
+    dispatch(
+      updateLoginAccount({
+        balances: {
+          attoRep,
+          rep,
+          dai,
+          eth,
+          legacyAttoRep,
+          legacyRep,
+          legacyRepNonSafe,
+        },
+      })
+    );
     return callback(null, { rep, dai, eth });
   });
 }

--- a/packages/augur-ui/src/modules/auth/reducers/login-account.ts
+++ b/packages/augur-ui/src/modules/auth/reducers/login-account.ts
@@ -13,8 +13,9 @@ const DEFAULT_STATE: LoginAccount = {
     rep: 0,
     dai: 0,
     legacyRep: 0,
-    attoRep: "0",
-    legacyAttoRep: "0",
+    legacyRepNonSafe: 0,
+    attoRep: '0',
+    legacyAttoRep: '0',
   },
   reporting: {
     profitLoss: ZERO,
@@ -24,10 +25,10 @@ const DEFAULT_STATE: LoginAccount = {
     participationTokens: null,
   },
   allowance: ZERO,
-  totalOpenOrdersFrozenFunds: "0",
+  totalOpenOrdersFrozenFunds: '0',
   allowanceFormatted: formatAttoDai(ZERO),
   tradingPositionsTotal: {
-    unrealizedRevenue24hChangePercent: "0",
+    unrealizedRevenue24hChangePercent: '0',
   },
   settings: {
     showInvalidMarketsBannerFeesOrLiquiditySpread: true,

--- a/packages/augur-ui/src/modules/modal/containers/modal-migrate-rep.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-migrate-rep.ts
@@ -17,6 +17,7 @@ const mapStateToProps = (state: AppState) => ({
   Gnosis_ENABLED: state.appStatus.gnosisEnabled,
   ethToDaiRate: state.appStatus.ethToDaiRate,
   gasPrice: getGasPrice(state),
+  walletBalances: state.loginAccount.balances,
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({
@@ -27,14 +28,19 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({
     dispatch(addPendingData(pendingId, queueName, status, hash, info)),
 });
 
-const mergeProps = (sP: any, dP: any, oP: any) => ({
-  ...dP,
-  loginAccount: sP.loginAccount,
-  ethToDaiRate: sP.ethToDaiRate,
-  Gnosis_ENABLED: sP.Gnosis_ENABLED,
-  gasPrice: sP.gasPrice,
-  closeAction: () => dP.closeModal(),
-});
+const mergeProps = (sP: any, dP: any, oP: any) => {
+  const showForSafeWallet = sP.walletBalances.legacyRep > 0;
+
+  return {
+    ...dP,
+    loginAccount: sP.loginAccount,
+    ethToDaiRate: sP.ethToDaiRate,
+    Gnosis_ENABLED: sP.Gnosis_ENABLED,
+    gasPrice: sP.gasPrice,
+    closeAction: () => dP.closeModal(),
+    showForSafeWallet,
+  };
+};
 
 export default withRouter(
   connect(

--- a/packages/augur-ui/src/modules/modal/migrate-rep.tsx
+++ b/packages/augur-ui/src/modules/modal/migrate-rep.tsx
@@ -127,7 +127,7 @@ export const MigrateRep = (props: MigrateRepForm) => {
             In order to migrate your V1 REP to V2 REP to use it in Augur V2, you
             need to send your V1 REP to your Augur Account Address shown below.
             <p />
-            hen your V1 REP is in your Augur Account Address you will see a
+            then your V1 REP is in your Augur Account Address you will see a
             button named “Migrate V1 to V2 REP” in the Augur app navigation.
             From here you can migrate all V1 REP in your account to V2 REP.
             <ExternalLinkButton

--- a/packages/augur-ui/src/modules/modal/migrate-rep.tsx
+++ b/packages/augur-ui/src/modules/modal/migrate-rep.tsx
@@ -1,16 +1,21 @@
 import React, { useState, useEffect } from 'react';
 
-import { ButtonsRow, Title } from 'modules/modal/common';
+import { ButtonsRow, Title, AccountAddressDisplay } from 'modules/modal/common';
 import { formatRep, formatGasCostToEther } from 'utils/format-number';
-import Styles from 'modules/modal/modal.styles.less';
-import { createBigNumber, BigNumber } from 'utils/create-big-number';
+import { BigNumber } from 'utils/create-big-number';
+import { toChecksumAddress } from 'ethereumjs-util';
 import { LoginAccount } from 'modules/types';
 import { ExternalLinkButton } from 'modules/common/buttons';
 import { LinearPropertyLabel } from 'modules/common/labels';
 import { InfoIcon } from 'modules/common/icons';
 import { displayGasInDai } from 'modules/app/actions/get-ethToDai-rate';
-import { V1_REP_MIGRATE_ESTIMATE, MIGRATE_V1_V2 } from 'modules/common/constants';
+import {
+  V1_REP_MIGRATE_ESTIMATE,
+  MIGRATE_V1_V2,
+} from 'modules/common/constants';
 import { TXEventName } from '@augurproject/sdk/src';
+
+import Styles from 'modules/modal/modal.styles.less';
 
 interface MigrateRepForm {
   closeAction: Function;
@@ -21,6 +26,7 @@ interface MigrateRepForm {
   convertV1ToV2Estimate: Function;
   gasPrice: number;
   addPendingData: Function;
+  showForSafeWallet: boolean;
 }
 
 export const MigrateRep = (props: MigrateRepForm) => {
@@ -32,7 +38,8 @@ export const MigrateRep = (props: MigrateRepForm) => {
     convertV1ToV2Estimate,
     ethToDaiRate,
     gasPrice,
-    addPendingData
+    addPendingData,
+    showForSafeWallet,
   } = props;
 
   const [gasLimit, setGasLimit] = useState(V1_REP_MIGRATE_ESTIMATE);
@@ -48,55 +55,111 @@ export const MigrateRep = (props: MigrateRepForm) => {
   const gasEstimate = formatGasCostToEther(
     gasLimit,
     { decimalsRounded: 4 },
-    gasPrice,
+    gasPrice
+  );
+
+  const safeWalletContent = (
+    <>
+      <div>
+        <span>V1 REP to migrate</span>
+        <span>{formatRep(loginAccount.balances.legacyRep).formattedValue}</span>
+      </div>
+      <div>
+        <LinearPropertyLabel
+          key="cost"
+          label={Gnosis_ENABLED ? 'Transaction Fee' : 'Gas Cost'}
+          value={
+            Gnosis_ENABLED
+              ? displayGasInDai(gasEstimate, ethToDaiRate)
+              : gasEstimate
+          }
+        />
+      </div>
+      <div>
+        {InfoIcon} Your wallet will need to sign <span>2</span> transactions
+      </div>
+    </>
+  );
+
+  const mainWalletContent = (
+    <>
+      <h3>Augur account address</h3>
+      <AccountAddressDisplay
+        copyable
+        address={toChecksumAddress(loginAccount.address)}
+      />
+      <ExternalLinkButton
+        URL="https://docs.augur.net/"
+        label={'Learn about your address'}
+      />
+    </>
   );
 
   return (
-    <div className={Styles.MigrateRep}>
-      <Title title={'Migrate Rep'} closeAction={closeAction} />
+    <div
+      className={showForSafeWallet ? Styles.MigrateRep : Styles.MigrateRepInfo}
+    >
+      <Title
+        title={showForSafeWallet ? 'Migrate Rep' : 'Migrate V1 REP'}
+        closeAction={closeAction}
+      />
 
       <main>
-        <h1>You have V1 REP in your wallet</h1>
-        <h2>
-          Migrate your V1 REP to V2 REP to use it in Augur V2. The quantity of V1 REP shown below will migrate to an equal amount of V2 REP. For example 100 V1 REP will migrate to 100 V2 REP.
-          <ExternalLinkButton label='Learn more' URL='http://docs.augur.net/' />
-        </h2>
-        <div>
-          <span>V1 REP to migrate</span>
-          <span>
-            {formatRep(loginAccount.balances.legacyRep).formattedValue}
-          </span>
-        </div>
-        <div>
-          <LinearPropertyLabel
-            key='cost'
-            label={Gnosis_ENABLED ? 'Transaction Fee' : 'Gas Cost'}
-            value={
-              Gnosis_ENABLED
-                ? displayGasInDai(gasEstimate, ethToDaiRate)
-                : gasEstimate
-            }
-          />
-        </div>
+        {showForSafeWallet && (
+          <h1>You have V1 REP in your Augur account address</h1>
+        )}
+        {!showForSafeWallet && <h1>You have V1 REP in your wallet</h1>}
 
-        <div>
-          {InfoIcon} Your wallet will need to sign <span>2</span> transactions
-        </div>
+        {showForSafeWallet && (
+          <h2>
+            Migrate your V1 REP to V2 REP to use it in Augur V2. The quantity of
+            V1 REP shown below will migrate to an equal amount of V2 REP. For
+            example 100 V1 REP will migrate to 100 V2 REP.
+            <ExternalLinkButton
+              label="Learn more"
+              URL="http://docs.augur.net/"
+            />
+          </h2>
+        )}
+
+        {!showForSafeWallet && (
+          <h2>
+            In order to migrate your V1 REP to V2 REP to use it in Augur V2, you
+            need to send your V1 REP to your Augur Account Address shown below.
+            <p />
+            hen your V1 REP is in your Augur Account Address you will see a
+            button named “Migrate V1 to V2 REP” in the Augur app navigation.
+            From here you can migrate all V1 REP in your account to V2 REP.
+            <ExternalLinkButton
+              label="Learn more"
+              URL="http://docs.augur.net/"
+            />
+          </h2>
+        )}
+
+        {showForSafeWallet ? safeWalletContent : mainWalletContent}
       </main>
       <ButtonsRow
         buttons={[
           {
-            text: 'Migrate',
-            action: () => {
-              closeAction();
-              addPendingData(MIGRATE_V1_V2, MIGRATE_V1_V2, TXEventName.Pending, MIGRATE_V1_V2);
-              convertV1ToV2();
-            },
+            text: showForSafeWallet ? 'Migrate' : 'OK',
+            action: showForSafeWallet
+              ? () => {
+                  closeAction();
+                  addPendingData(
+                    MIGRATE_V1_V2,
+                    MIGRATE_V1_V2,
+                    TXEventName.Pending,
+                    MIGRATE_V1_V2
+                  );
+                  convertV1ToV2();
+                }
+              : () => closeAction(),
             disabled:
               formatRep(loginAccount.balances.legacyRep).fullPrecision < 0,
           },
           {
-            text: 'Cancel',
+            text: 'Close',
             action: closeAction,
           },
         ]}

--- a/packages/augur-ui/src/modules/modal/modal.styles.less
+++ b/packages/augur-ui/src/modules/modal/modal.styles.less
@@ -711,6 +711,24 @@ div.ButtonsRow:last-of-type {
   max-width: 20rem;
 }
 
+.DescriptionWithLink {
+  > p {
+    .text-14-paragraph;
+
+    @media @breakpoint-mobile {
+      .text-12-paragraph;
+    }
+
+    color: @color-primary-text;
+    line-height: 150%;
+    margin: 0 0 @size-2 0;
+  }
+
+  > a {
+    color: @color-primary-action
+  }
+}
+
 .Message {
   .Container;
 
@@ -1374,12 +1392,12 @@ div.ButtonsRow:last-of-type {
       }
 
       > button {
-        .text-14;
+        .text-10;
 
         background: none;
         border: none;
         margin-left: @size-3;
-        text-transform: unset;
+        text-transform: uppercase;
       }
     }
 
@@ -1452,6 +1470,72 @@ div.ButtonsRow:last-of-type {
         }
       }
     }
+  }
+
+  > div {
+    border-top: 1px solid @color-secondary-action-outline;
+  }
+}
+
+.MigrateRepInfo {
+  .Message;
+  max-width: 614px;
+
+  > main {
+    margin: @size-22 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    > h1 {
+      .text-16-medium;
+
+      color: @color-primary-text;
+      margin: 0 0 @size-16 0;
+      text-transform: unset;
+    }
+
+    > h2 {
+      .text-14;
+
+      color: @color-secondary-text;
+      line-height: 140%;
+      margin-bottom: @size-28;
+      padding: 0 @size-50;
+      text-align: center;
+      @media @breakpoint-mobile {
+        padding: 0;
+      }
+
+      > button {
+        .text-10;
+
+        background: none;
+        border: none;
+        text-transform: uppercase;
+      }
+    }
+
+    > h3 {
+      margin-bottom: @size-4;
+      text-transform: uppercase;
+    }
+
+    > span {
+      margin-bottom: @size-16;
+    }
+
+    > button {
+      .text-10;
+
+      background: none;
+      border: none;
+      text-transform: uppercase;
+    }
+  }
+
+  > div {
+    border-top: 1px solid @color-secondary-action-outline;
   }
 }
 

--- a/packages/augur-ui/src/modules/types.ts
+++ b/packages/augur-ui/src/modules/types.ts
@@ -628,6 +628,7 @@ export interface AccountBalances {
   rep: number;
   dai: number;
   legacyRep: number;
+  legacyRepNonSafe: number;
   attoRep: string;
   legacyAttoRep: string;
 }


### PR DESCRIPTION
## Show custom migration modal for non-safae wallets with V1 REP

To Test:
1) Disable Gnosis in network.json
2) Use the V1 faucet
3) Enable Gnosis in network.json
4) Login with Gnosis
5) You should see one of the below paths depending if you have V1 REP in either/or/both Safe address or non-safe address.

IF user has V1 REP in GS, THEN show option 1
IF user has V1 REP in wallet, THEN show option 2
IF user has V1 REP in GS AND WALLET, THEN show option 1, when complete, THEN show option 2

#### OPTION 1

<img width="155" src="https://user-images.githubusercontent.com/1683736/75490079-75c94780-5981-11ea-86d4-ab1ca15900b6.png">

<img width="323" src="https://user-images.githubusercontent.com/1683736/75490085-795cce80-5981-11ea-8d79-93491b749b44.png">

#### OPTION 2
<img width="155" src="https://user-images.githubusercontent.com/1683736/75490078-75c94780-5981-11ea-8861-1b862a659e9f.png">

<img width="323" src="https://user-images.githubusercontent.com/1683736/75490088-7b269200-5981-11ea-8efa-1cd3f2b8cbaf.png">

Relates to..
- Support wallets that have REP for migration even if they're operating with a Gnosis Safe #4898
- REP migration update #6486

