### PR TITLE
allow ownProps disabled to be passed to component for processing button

### DIFF
--- a/packages/augur-ui/src/modules/common/buttons.tsx
+++ b/packages/augur-ui/src/modules/common/buttons.tsx
@@ -183,7 +183,7 @@ const ProcessingButtonComponent = (props: DefaultButtonProps) => {
   let buttonText = props.text;
   if (props.status === TXEventName.Pending) {
     buttonText = 'Processing...';
-  } 
+  }
   const failed = props.status === TXEventName.Failure;
   const confirmed = props.status === TXEventName.Success;
   return (
@@ -220,12 +220,12 @@ const mapStateToPropsProcessingButton = (state: AppState, ownProps) => {
   const { pendingQueue } = state;
   let disabled = false;
 
-  const pendingData = 
+  const pendingData =
   pendingQueue[ownProps.queueName] &&
   pendingQueue[ownProps.queueName][ownProps.queueId];
 
   let status = pendingData && pendingData.status;
-  
+
   if (ownProps.matchingId !== undefined && pendingData) {
     if (pendingData.data.matchingId.toString() !== ownProps.matchingId.toString()) {
       status = null;
@@ -234,7 +234,7 @@ const mapStateToPropsProcessingButton = (state: AppState, ownProps) => {
   }
 
   return {
-    disabled,
+    disabled: ownProps.disabled || disabled,
     status,
   };
 };


### PR DESCRIPTION
designated reporter upcoming showed reporting button active should be disabled.