### PR TITLE
remove finalize notification, not needed any more

### DIFF
--- a/packages/augur-ui/src/modules/account/components/notifications.tsx
+++ b/packages/augur-ui/src/modules/account/components/notifications.tsx
@@ -93,18 +93,6 @@ class Notifications extends React.Component<
         };
         break;
 
-      case NOTIFICATION_TYPES.finalizeMarkets:
-        buttonAction = () => {
-          this.markAsRead(notification);
-          this.disableNotification(notification.id, true);
-          if (notification.market) {
-            this.props.finalizeMarketModal(notification.market.id, () =>
-              this.disableNotification(notification.id, false)
-            );
-          }
-        };
-        break;
-
       case NOTIFICATION_TYPES.marketsInDispute:
         buttonAction = () => {
           this.markAsRead(notification);
@@ -271,9 +259,6 @@ class Notifications extends React.Component<
               isDisabled={isDisabled}
               {...templateProps}
             />
-          ) as any : null}
-          {type === NOTIFICATION_TYPES.finalizeMarkets ? (
-            <FinalizeTemplate isDisabled={isDisabled} {...templateProps} />
           ) as any : null}
           {type === NOTIFICATION_TYPES.marketsInDispute ? (
             <DisputeTemplate isDisabled={isDisabled} {...templateProps} />

--- a/packages/augur-ui/src/modules/account/containers/notifications.ts
+++ b/packages/augur-ui/src/modules/account/containers/notifications.ts
@@ -32,8 +32,6 @@ const mapStateToProps = (state: AppState) => {
 const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({
   updateReadNotifications: (notifications: Notification[]) =>
     dispatch(updateReadNotifications(notifications)),
-  finalizeMarketModal: (marketId: string, cb: NodeStyleCallback) =>
-    dispatch(updateModal({ type: MODAL_FINALIZE_MARKET, marketId, cb })),
   claimMarketsProceeds: (marketIds: string[], cb: NodeStyleCallback) =>
     dispatch(
       updateModal({ type: MODAL_CLAIM_MARKETS_PROCEEDS, marketIds, cb })

--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -821,14 +821,12 @@ export const NEW = 'New';
 export const RESOLVED_MARKETS_OPEN_ORDERS_TITLE =
   'Open Orders in Resolved Market';
 export const REPORTING_ENDS_SOON_TITLE = 'You need to report';
-export const FINALIZE_MARKET_TITLE = 'Finalize Market';
 export const SIGN_SEND_ORDERS = 'Sign to approve your orders';
 export const CLAIM_REPORTING_FEES_TITLE = 'Claim Stake and Fees';
 export const PROCEEDS_TO_CLAIM_TITLE = 'Claim Proceeds';
 export const MARKET_IS_MOST_LIKELY_INVALID_TITLE = 'Market is Failing Invalid Filter';
 export const OPEN_ORDERS_RESOLVED_MARKET = 'resolvedMarketsOpenOrders';
 export const REPORT_ON_MARKET = 'reportOnMarkets';
-export const FINALIZE_MARKET = 'finalizeMarkets';
 export const MARKET_IN_DISPUTE = 'marketsInDispute';
 export const CLAIM_REPORTING_FEES = 'claimReportingFees';
 export const UNSIGNED_ORDERS = 'unsignedOrders';
@@ -838,7 +836,6 @@ export const MARKET_IS_MOST_LIKELY_INVALID = 'marketIsMostLikelyInvalid';
 export const NOTIFICATION_TYPES = {
   [OPEN_ORDERS_RESOLVED_MARKET]: OPEN_ORDERS_RESOLVED_MARKET,
   [REPORT_ON_MARKET]: REPORT_ON_MARKET,
-  [FINALIZE_MARKET]: FINALIZE_MARKET,
   [MARKET_IN_DISPUTE]: MARKET_IN_DISPUTE,
   [CLAIM_REPORTING_FEES]: CLAIM_REPORTING_FEES,
   [UNSIGNED_ORDERS]: UNSIGNED_ORDERS,

--- a/packages/augur-ui/src/modules/notifications/selectors/notification-state.ts
+++ b/packages/augur-ui/src/modules/notifications/selectors/notification-state.ts
@@ -10,7 +10,6 @@ import {
 import { MarketReportingState } from '@augurproject/sdk';
 import {
   CLAIM_REPORTING_FEES_TITLE,
-  FINALIZE_MARKET_TITLE,
   MARKET_IS_MOST_LIKELY_INVALID_TITLE,
   NOTIFICATION_TYPES,
   PROCEEDS_TO_CLAIM_TITLE,
@@ -180,7 +179,6 @@ export const selectUnsignedOrders = createSelector(
 export const selectNotifications = createSelector(
   selectReportOnMarkets,
   selectResolvedMarketsOpenOrders,
-  selectFinalizeMarkets,
   selectMarketsInDispute,
   selectReportingWinningsByMarket,
   selectUnsignedOrders,
@@ -189,7 +187,6 @@ export const selectNotifications = createSelector(
   (
     reportOnMarkets,
     resolvedMarketsOpenOrder,
-    finalizeMarkets,
     marketsInDispute,
     claimReportingFees,
     unsignedOrders,
@@ -204,10 +201,6 @@ export const selectNotifications = createSelector(
     const resolvedMarketsOpenOrderNotifications = generateCards(
       resolvedMarketsOpenOrder,
       NOTIFICATION_TYPES.resolvedMarketsOpenOrders
-    );
-    const finalizeMarketsNotifications = generateCards(
-      finalizeMarkets,
-      NOTIFICATION_TYPES.finalizeMarkets
     );
     const marketsInDisputeNotifications = generateCards(
       marketsInDispute,
@@ -226,7 +219,6 @@ export const selectNotifications = createSelector(
     let notifications = [
       ...reportOnMarketsNotifications,
       ...resolvedMarketsOpenOrderNotifications,
-      ...finalizeMarketsNotifications,
       ...marketsInDisputeNotifications,
       ...unsignedOrdersNotifications,
       ...mostLikelyInvalidMarketsNotifications,
@@ -318,14 +310,6 @@ const generateCards = (markets, type) => {
       isNew: true,
       title: REPORTING_ENDS_SOON_TITLE,
       buttonLabel: TYPE_REPORT,
-    };
-  } else if (type === NOTIFICATION_TYPES.finalizeMarkets) {
-    defaults = {
-      type,
-      isImportant: false,
-      isNew: true,
-      title: FINALIZE_MARKET_TITLE,
-      buttonLabel: TYPE_VIEW_DETAILS,
     };
   } else if (type === NOTIFICATION_TYPES.marketsInDispute) {
     defaults = {


### PR DESCRIPTION
finalize market notification isn't needed market creator gets a claim REP and fees notification which would auto-finalize the market.