### PR TITLE
convert payout numerators for warp sync in getter

### DIFF
--- a/packages/augur-ui/src/modules/common/labels.tsx
+++ b/packages/augur-ui/src/modules/common/labels.tsx
@@ -51,6 +51,7 @@ export interface MarketTypeProps {
 }
 
 export interface MarketStatusProps {
+  marketStatus: string;
   reportingState: string;
   endTimeFormatted: DateFormattedObject;
   currentAugurTimestamp: number;

--- a/packages/augur-ui/src/modules/market-cards/common.tsx
+++ b/packages/augur-ui/src/modules/market-cards/common.tsx
@@ -96,6 +96,7 @@ export interface DisputeOutcomeProps {
   canDispute: boolean;
   canSupport: boolean;
   marketId: string;
+  isWarpSync?: boolean;
 }
 
 export const DisputeOutcome = (props: DisputeOutcomeProps) => {
@@ -114,7 +115,7 @@ export const DisputeOutcome = (props: DisputeOutcomeProps) => {
         [Styles[`Outcome-${props.index}`]]: !props.invalid,
       })}
     >
-      <span>{props.description}</span>
+      <span>{props.isWarpSync ? props.stake.warpSyncHash : props.description}</span>
       {props.stake && props.stake.tentativeWinning ? (
         <span>tentative winner</span>
       ) : (
@@ -245,6 +246,7 @@ export interface OutcomeGroupProps {
   canDispute: boolean;
   canSupport: boolean;
   marketId: string;
+  isWarpSync?: boolean;
 }
 
 export const OutcomeGroup = (props: OutcomeGroupProps) => {
@@ -254,7 +256,7 @@ export const OutcomeGroup = (props: OutcomeGroupProps) => {
     props.stakes
   );
 
-  const { inDispute, showOutcomeNumber } = props;
+  const { inDispute, showOutcomeNumber, isWarpSync } = props;
   let disputingOutcomes = sortedStakeOutcomes;
   let outcomesCopy = props.outcomes.slice(0);
   const removedInvalid = outcomesCopy.splice(0, 1)[0];
@@ -341,6 +343,7 @@ export const OutcomeGroup = (props: OutcomeGroupProps) => {
                   id={outcome.id}
                   canDispute={props.canDispute}
                   canSupport={props.canSupport}
+                  isWarpSync={isWarpSync}
                 />
               </>
             ) : (

--- a/packages/augur-ui/src/modules/market-cards/market-card.tsx
+++ b/packages/augur-ui/src/modules/market-cards/market-card.tsx
@@ -226,6 +226,7 @@ export default class MarketCard extends React.Component<
     const canSupport = !disputeInfo.disputePacingOn;
 
     const expandedOptionShowing =
+      !isWarpSync &&
       outcomesFormatted &&
       outcomesFormatted.length > showOutcomeNumber &&
       !expandedView;
@@ -348,6 +349,7 @@ export default class MarketCard extends React.Component<
                 canDispute={canDispute}
                 canSupport={canSupport}
                 marketId={id}
+                isWarpSync={market.isWarpSync}
               />
               {expandedOptionShowing && (
                 <button onClick={this.expand}>

--- a/packages/augur-ui/src/modules/modal/reporting.tsx
+++ b/packages/augur-ui/src/modules/modal/reporting.tsx
@@ -156,7 +156,7 @@ export default class ModalReporting extends Component<
           id: String(outcome.id),
           header: outcome.description,
           value: outcome.id,
-          description: stake.outcome,
+          description: stake && stake.outcome ? stake.outcome : '',
           checked: checked === outcome.id.toString(),
           isInvalid: outcome.id === 0,
           stake,

--- a/packages/augur-ui/src/utils/convert-marketInfo-marketData.ts
+++ b/packages/augur-ui/src/utils/convert-marketInfo-marketData.ts
@@ -1,5 +1,5 @@
 import { Getters } from '@augurproject/sdk';
-import { MarketData, Consensus, OutcomeFormatted } from 'modules/types';
+import { MarketData, OutcomeFormatted } from 'modules/types';
 import {
   REPORTING_STATE,
   MARKET_OPEN,
@@ -70,7 +70,8 @@ export function convertMarketInfoToMarketData(
     disputeInfo: processDisputeInfo(
       marketInfo.marketType,
       marketInfo.disputeInfo,
-      marketInfo.outcomes
+      marketInfo.outcomes,
+      marketInfo.isWarpSync,
     ),
   };
 
@@ -144,7 +145,8 @@ function getEmptyStake(outcomeId: string | null, bondSizeOfNewStake: string) {
 function processDisputeInfo(
   marketType: string,
   disputeInfo: Getters.Markets.DisputeInfo,
-  outcomes: Getters.Markets.MarketInfoOutcome[]
+  outcomes: Getters.Markets.MarketInfoOutcome[],
+  isWarpSync: boolean,
 ): Getters.Markets.DisputeInfo {
   if (!disputeInfo) return disputeInfo;
   if (marketType === SCALAR) {
@@ -153,7 +155,7 @@ function processDisputeInfo(
     );
     // add blank outcome
     const blankStake = getEmptyStake(null, disputeInfo.bondSizeOfNewStake);
-    if (invalidIncluded) {
+    if (invalidIncluded || isWarpSync) {
       return { ...disputeInfo, stakes: [...disputeInfo.stakes, blankStake] };
     } else {
       return {

--- a/packages/augur-ui/src/utils/convert-marketInfo-marketData.ts
+++ b/packages/augur-ui/src/utils/convert-marketInfo-marketData.ts
@@ -103,7 +103,7 @@ function getMarketStatus(reportingState: string) {
 function processOutcomes(
   market: Getters.Markets.MarketInfo
 ): OutcomeFormatted[] {
-  return market.outcomes.map(outcome => ({
+  return market.outcomes.filter(o => market.isWarpSync ? o.id !== 0 : true).map(outcome => ({
     ...outcome,
     marketId: market.id,
     lastPricePercent: outcome.price


### PR DESCRIPTION
show warp synch hash value for outcome.

![Screen Shot 2020-03-02 at 6 39 49 PM](https://user-images.githubusercontent.com/3970376/75731476-59951580-5cb5-11ea-841e-4bbc522c3c80.png)
