### PR TITLE
filter out warp sync market if ten winning outcome is equal to curren…

### DIFF
--- a/packages/augur-sdk/src/api/WarpSync.ts
+++ b/packages/augur-sdk/src/api/WarpSync.ts
@@ -47,7 +47,7 @@ export class WarpSync {
     const bytes = bs58.decode(warpSyncHash)
     const encodedWarpSyncHash = bytes.toString('hex');
     // first 6 characters of the hex ipfs hash are always 0x1220
-    const payout = new BigNumber(`0x${encodedWarpSyncHash.slice(6)}`, 16);
+    const payout = new BigNumber(`0x${encodedWarpSyncHash.slice(4)}`, 16);
     return [new BigNumber(0), MAX_PAYOUT.minus(payout), payout];
   }
 

--- a/packages/augur-sdk/src/state/db/MarketDB.ts
+++ b/packages/augur-sdk/src/state/db/MarketDB.ts
@@ -354,17 +354,28 @@ export class MarketDB extends DerivedDB {
     log['outcomes'] = _.map(log['outcomes'], (rawOutcome) => {
       return Buffer.from(rawOutcome.replace('0x', ''), 'hex').toString().trim().replace(/\0/g, '');
     });
+
     try {
       log['extraInfo'] = JSON.parse(log['extraInfo']);
-      log['extraInfo'].categories = log['extraInfo'].categories.map((category) => category.toLowerCase());
+    } catch (err) {
+      log['extraInfo'] = {};
+    }
+    try {
+      if (log['extraInfo'].categories)
+        log['extraInfo'].categories = log['extraInfo'].categories.map((category) => category.toLowerCase());
+    } catch (err) {
+      log['extraInfo'].categories = [];
+    }
+    try {
       if(log['extraInfo'].template) {
         let errors = [];
         log['isTemplate'] = isTemplateMarket(log['extraInfo'].description, log['extraInfo'].template, log['outcomes'], log['extraInfo'].longDescription, log['endTime'], errors);
         if (errors.length > 0) console.error(log['extraInfo'].description, errors);
       }
     } catch (err) {
-      log['extraInfo'] = {};
+      log['extraInfo'].isTemplate = false;
     }
+
     if (this.augur.syncableFlexSearch) {
       this.augur.syncableFlexSearch.addMarketCreatedDocs([log as unknown as MarketData]);
     }

--- a/packages/augur-sdk/src/state/getter/Markets.ts
+++ b/packages/augur-sdk/src/state/getter/Markets.ts
@@ -550,14 +550,10 @@ export class Markets {
     if (params.includeWarpSyncMarkets) {
       const marketId = await augur.contracts.warpSync.markets_(params.universe);
       const warpSyncMarket = await db.Markets.where("market").anyOf(marketId).first();
-      if (warpSyncMarket) {
-        if (!warpSyncMarket.tentativeWinningPayoutNumerators) {
-          tentativeWinningHashMatch = false;
-        } else {
-          const tentativeWinningHash = augur.getWarpSyncHashFromPayout(warpSyncMarket.tentativeWinningPayoutNumerators.map(p => new BigNumber(p)));
-          const currentWarpSyncHash = await db.warpSync.table.orderBy('end.number').last();
-          tentativeWinningHashMatch = tentativeWinningHash && currentWarpSyncHash ? tentativeWinningHash === currentWarpSyncHash.hash : false;
-        }
+      if (warpSyncMarket && warpSyncMarket.tentativeWinningPayoutNumerators) {
+        const tentativeWinningHash = augur.getWarpSyncHashFromPayout(warpSyncMarket.tentativeWinningPayoutNumerators.map(p => new BigNumber(p)));
+        const currentWarpSyncHash = await db.warpSync.table.orderBy('end.number').last();
+        tentativeWinningHashMatch = tentativeWinningHash && currentWarpSyncHash ? tentativeWinningHash === currentWarpSyncHash.hash : false;
       }
     }
 

--- a/packages/augur-test/src/tests/api/WarpSync.test.ts
+++ b/packages/augur-test/src/tests/api/WarpSync.test.ts
@@ -77,6 +77,14 @@ describe('WarpSync', () => {
     );
   });
 
+  test('Warp Sync :: getWarpSyncHashFromPayout to Hash', async () => {
+    const hashValue = 'Qme6s3PJJxqmCfgY7o5pK6sgSpem6ysgosYRuCSCNQ2X6t';
+    const calculatedPayouts = await john.getPayoutFromWarpSyncHash(hashValue);
+    const warpSyncHash = await john.getWarpSyncHashFromPayout(calculatedPayouts);
+    await expect(warpSyncHash).toEqual(hashValue);
+  });
+
+
   test('Warp Sync :: getPayoutFromWarpSyncHash', async () => {
     const warpSyncHash = 'QmNLei78zWmzUdbeRB3CiUfAizWUrbeeZh5K1rhAQKChD2';
     const payout = await john.getPayoutFromWarpSyncHash(warpSyncHash);

--- a/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
+++ b/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
@@ -462,6 +462,7 @@ export interface doReportDisputeAddStake {
 }
 
 export async function doInitialReport_estimaetGas(report: doReportDisputeAddStake) {
+  if(report.isWarpSync) return doInitialReportWarpSync_estimaetGas(report);
   const market = getMarket(report.marketId);
   if (!market) return false;
   const payoutNumerators = await getPayoutNumerators(report);
@@ -473,10 +474,35 @@ export async function doInitialReport_estimaetGas(report: doReportDisputeAddStak
 }
 
 export async function doInitialReport(report: doReportDisputeAddStake) {
+  if(report.isWarpSync) return doInitialReportWarpSync(report);
   const market = getMarket(report.marketId);
   if (!market) return false;
   const payoutNumerators = await getPayoutNumerators(report);
   return market.doInitialReport(
+    payoutNumerators,
+    report.description,
+    createBigNumber(report.attoRepAmount || '0')
+  );
+}
+
+export async function doInitialReportWarpSync_estimaetGas(report: doReportDisputeAddStake) {
+  const Augur = augurSdk.get();
+  const universe = Augur.contracts.universe.address;
+  const payoutNumerators = await getPayoutNumerators(report);
+  return Augur.contracts.warpSync.doInitialReport_estimateGas(
+    universe,
+    payoutNumerators,
+    report.description,
+    createBigNumber(report.attoRepAmount || '0')
+  );
+}
+
+export async function doInitialReportWarpSync(report: doReportDisputeAddStake) {
+  const Augur = augurSdk.get();
+  const universe = Augur.contracts.universe.address;
+  const payoutNumerators = await getPayoutNumerators(report);
+  return Augur.contracts.warpSync.doInitialReport(
+    universe,
     payoutNumerators,
     report.description,
     createBigNumber(report.attoRepAmount || '0')

--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -494,9 +494,10 @@ export const handleInitialReporterTransferredLog = (logs: any) => (
   dispatch: ThunkDispatch<void, any, Action>,
   getState: () => AppState
 ) => {
-  const address = getState().loginAccount.address
-  if (logs.filter(log => isSameAddress(log.from, address) ||
-    isSameAddress(log.to, address)).length > 0) {
+  const address = getState().loginAccount.address;
+  const userLogs = logs.filter(log => isSameAddress(log.from, address) ||
+    isSameAddress(log.to, address));
+  if (userLogs.length > 0) {
     dispatch(loadAccountReportingHistory());
   }
   const marketIds = userLogs.map(log => log.market)

--- a/packages/augur-ui/src/modules/modal/reporting.tsx
+++ b/packages/augur-ui/src/modules/modal/reporting.tsx
@@ -188,7 +188,7 @@ export default class ModalReporting extends Component<
           radioButtons.push({
             id: String(stake.outcome),
             header: warpSyncHashValue || `Enter a hash value`,
-            value: warpSyncHashValue || null,
+            value: warpSyncHashValue || warpSyncHash,
             description: warpSyncHashValue || stake.outcome,
             checked: checked === stake.outcome,
             isInvalid: false,

--- a/packages/augur-ui/src/modules/modal/reporting.tsx
+++ b/packages/augur-ui/src/modules/modal/reporting.tsx
@@ -263,7 +263,7 @@ export default class ModalReporting extends Component<
         : this.state.inputtedReportingStake.inputToAttoRep,
       outcomeId,
       isInvalid: isSelectedOutcomeInvalid,
-      warpSyncHash: selectedRadio.value,
+      warpSyncHash: isWarpSync && selectedRadio.value || this.state.inputScalarOutcome,
       isWarpSync,
     };
 

--- a/packages/augur-ui/src/modules/reporting/common.tsx
+++ b/packages/augur-ui/src/modules/reporting/common.tsx
@@ -441,6 +441,7 @@ export class DisputingBondsView extends Component<
       stakeRemaining,
       tentativeWinning,
       isInvalid,
+      warpSyncHash,
     } = this.props;
     let inputToAttoRep = null;
     const { isScalar } = this.state;
@@ -452,11 +453,12 @@ export class DisputingBondsView extends Component<
       );
     }
     if (
-      isNaN(Number(inputStakeValue)) ||
+      !!!warpSyncHash &&
+      (isNaN(Number(inputStakeValue)) ||
       inputStakeValue === '' ||
       inputStakeValue === '0' ||
       inputStakeValue === '.' ||
-      inputStakeValue === '0.'
+      inputStakeValue === '0.')
     ) {
       this.setState({ stakeError: 'Enter a valid number', disabled: true });
       return updateInputtedStake({ inputStakeValue, ZERO });
@@ -491,7 +493,7 @@ export class DisputingBondsView extends Component<
       this.setState({ stakeError: '' });
       if (
         (this.state.scalarError === '' &&
-          ((isScalar && inputScalarOutcome !== '') || isInvalid)) ||
+          ((isScalar && inputScalarOutcome !== '') || isInvalid || !!warpSyncHash)) ||
         !isScalar
       ) {
         this.setState({ disabled: false });


### PR DESCRIPTION
…t warp sync hash, fix blank title  parsing error with warp sync market. checkpoint on allowing users to report on warp sync market when in DR

1. fix parsing title of warp sync.
2. filter out warp sync market from disputes page if ten win outcome is same as current warp synch hash
3. unit test for testing hash
4. allow user to report on warp sync market during designated reporting state.