### PR TITLE
align trading history

### DIFF
--- a/packages/augur-ui/src/modules/market/components/market-trade-history/market-trade-history.styles.less
+++ b/packages/augur-ui/src/modules/market/components/market-trade-history/market-trade-history.styles.less
@@ -64,13 +64,13 @@
 
     > li:first-of-type {
       color: @color-primary-text;
-      margin-left: auto;
+      margin-left: @size-32;
       text-align: right;
     }
 
     > li:nth-of-type(2) {
       color: @color-positive;
-      text-align: right;
+      text-align: center;
     }
 
     > li:last-of-type {


### PR DESCRIPTION
Trade history: price and quantity columns aren't lined up with labels #6086
<img width="222" src="https://user-images.githubusercontent.com/1683736/75825997-7e9c8d80-5d74-11ea-8645-d4845277a3ad.png">
<img width="222" src="https://user-images.githubusercontent.com/1683736/75826012-84926e80-5d74-11ea-93d3-9403cec5e797.png">
