### PR TITLE
workaround for safes blocked by nonce issues

### DIFF
--- a/packages/contract-dependencies-gnosis/src/ContractDependenciesGnosis.ts
+++ b/packages/contract-dependencies-gnosis/src/ContractDependenciesGnosis.ts
@@ -325,11 +325,12 @@ export class ContractDependenciesGnosis extends ContractDependenciesEthers {
         const exception = (response.data || {}).exception;
         const status = response.status;
         const isServerError = status >= 500;
+        const isMultiError = 'SafeMultisigTxExists';
         console.error(`Gnosis Relay ${status} Error: ${exception}`);
         if (exception && exception.includes('There are too many transactions in the queue')) {
           throw TransactionStatus.FEE_TOO_LOW;
-        } else if (isServerError || exception && exception.includes('funds')) {
-          // In the event of a 5XX error or when the relayer has no funds we should consider the relay down
+        } else if (isServerError || exception && exception.includes('funds') || exception && exception.includes(isMultiError)) {
+          // In the event of a SafeMultisigTxExists, 5XX error or when the relayer has no funds we should consider the relay down
           this.setUseRelay(false);
           this.setStatus(GnosisSafeState.ERROR);
           throw TransactionStatus.RELAYER_DOWN;


### PR DESCRIPTION
### throw relayer down Error when gnosis relayer returns `SafeMultisigTxExists`

Sometimes transactions sent from the relayer can go MIA in which case the relayer will block any TX's from going through. 

If we send a transaction directly, without the relayer, it will fix the problem since the relayer will stop trying to validate the previous broken nonce.