### PR TITLE
consistent labeling on market trading page

### DIFF
--- a/packages/augur-ui/src/modules/common/labels.styles.less
+++ b/packages/augur-ui/src/modules/common/labels.styles.less
@@ -10,7 +10,6 @@
 
     color: @color-secondary-text;
     line-height: @size-14;
-    text-transform: uppercase;
     line-height: 160%;
   }
 


### PR DESCRIPTION
have consistent labeling case on core market properties

![image](https://user-images.githubusercontent.com/3970376/75987160-10abaf80-5eb5-11ea-9c04-11cd0913366b.png)
