### PR TITLE
add missing help center links

### DIFF
--- a/packages/augur-ui/src/modules/app/components/help-resources.tsx
+++ b/packages/augur-ui/src/modules/app/components/help-resources.tsx
@@ -5,7 +5,13 @@ import { QuestionIcon } from 'modules/common/icons';
 import { ExternalLinkButton } from 'modules/common/buttons';
 
 import Styles from 'modules/app/components/help-resources.styles.less';
-import { TRADING_TUTORIAL } from 'modules/common/constants';
+import {
+  TRADING_TUTORIAL,
+  HELP_CENTER,
+  HELP_CENTER_ADD_FUNDS,
+  HELP_CENTER_HOW_TO_TRADE,
+  HELP_CENTER_HOW_TO_DISPUTE,
+} from 'modules/common/constants';
 import { MARKET } from 'modules/routes/constants/views';
 import makeQuery from 'modules/routes/helpers/make-query';
 import { MARKET_ID_PARAM_NAME } from 'modules/routes/constants/param-names';
@@ -29,19 +35,19 @@ const HELP_LINKS = [
   },
   {
     label: 'help center',
-    link: 'https://docs.augur.net',
+    link: HELP_CENTER,
   },
   {
     label: 'how to add funds',
-    link: 'https://docs.augur.net',
+    link: HELP_CENTER_ADD_FUNDS,
   },
   {
     label: 'how to trade',
-    link: 'https://docs.augur.net',
+    link: HELP_CENTER_HOW_TO_TRADE,
   },
   {
     label: 'how to dispute',
-    link: 'https://docs.augur.net',
+    link: HELP_CENTER_HOW_TO_DISPUTE,
   },
 ];
 
@@ -68,9 +74,7 @@ interface HelpMenuProps {
   closeHelpMenu: Function;
 }
 
-export const HelpMenu = ({
-  closeHelpMenu
-}: HelpMenuProps) => {
+export const HelpMenu = ({ closeHelpMenu }: HelpMenuProps) => {
   return (
     <div className={classNames(Styles.HelpMenu)}>
       <span>popular help resources</span>
@@ -90,7 +94,6 @@ export const HelpMenu = ({
   );
 };
 
-
 interface HelpIconProps {
   isHelpMenuOpen: boolean;
   updateHelpMenuState: Function;
@@ -98,7 +101,7 @@ interface HelpIconProps {
 
 export const HelpIcon = ({
   updateHelpMenuState,
-  isHelpMenuOpen
+  isHelpMenuOpen,
 }: HelpIconProps) => {
   return (
     <div
@@ -132,8 +135,13 @@ export const HelpResources = ({
       })}
       onClick={event => event.stopPropagation()}
     >
-      <HelpIcon updateHelpMenuState={updateHelpMenuState} isHelpMenuOpen={isHelpMenuOpen} />
-      {isHelpMenuOpen && (<HelpMenu closeHelpMenu={() => updateHelpMenuState(false)}/>)}
+      <HelpIcon
+        updateHelpMenuState={updateHelpMenuState}
+        isHelpMenuOpen={isHelpMenuOpen}
+      />
+      {isHelpMenuOpen && (
+        <HelpMenu closeHelpMenu={() => updateHelpMenuState(false)} />
+      )}
     </div>
   );
 };

--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -1317,3 +1317,15 @@ export enum HEADER_TYPE {
 }
 
 export const LOGGED_IN_USER_LOCAL_STORAGE_KEY = 'loggedInUser';
+
+
+// Help Center links
+export const HELP_CENTER = 'https://augur.gitbook.io/help-center/';
+export const HELP_CENTER_ADD_FUNDS = 'https://augur.gitbook.io/help-center/trading-ui-1/adding-funds';
+export const HELP_CENTER_HOW_TO_TRADE = 'https://augur.gitbook.io/help-center/market-creation-1/how-to-make-a-trade';
+export const HELP_CENTER_HOW_TO_DISPUTE = 'https://augur.gitbook.io/help-center/disputing-explained';
+// TODO update with GSN
+export const HELP_CENTER_LEARN_ABOUT_ADDRESS = 'https://augur.gitbook.io/help-center/trading-ui-1/logging-in#what-is-gnosis-safe';
+export const HELP_CENTER_MIGRATE_REP = 'https://augur.gitbook.io/help-center/migrating-rep-v1-greater-than-v2';
+export const HELP_CENTER_PARTICIPATION_TOKENS = 'https://augur.gitbook.io/help-center/reporting-or-disputing-faq#what-are-participation-tokens';
+export const HELP_CENTER_INVALID_MARKETS = 'https://augur.gitbook.io/help-center/market-creation-1/trading-faq#what-does-invalid-mean';

--- a/packages/augur-ui/src/modules/markets-list/components/markets-view.tsx
+++ b/packages/augur-ui/src/modules/markets-list/components/markets-view.tsx
@@ -12,6 +12,7 @@ import {
   TYPE_TRADE,
   MAX_FEE_100_PERCENT,
   MAX_SPREAD_ALL_SPREADS,
+  HELP_CENTER_INVALID_MARKETS,
 } from 'modules/common/constants';
 import { MarketData } from 'modules/types';
 import { Getters } from '@augurproject/sdk';
@@ -342,7 +343,7 @@ export default class MarketsView extends Component<
             <span>
               Invalid markets are no longer hidden. This puts you at risk of
               trading on invalid markets.{' '}
-              <a href="https://augur.net" target="_blank">
+              <a href={HELP_CENTER_INVALID_MARKETS} target="_blank" rel="noopener noreferrer">
                 Learn more
               </a>
             </span>
@@ -360,7 +361,7 @@ export default class MarketsView extends Component<
           content={
             <span>
               {feesLiquidityMessage}{' '}
-              <a href="https://augur.net" target="_blank">
+              <a href={HELP_CENTER_INVALID_MARKETS} target="_blank" rel="noopener noreferrer">
                 Learn more
               </a>
             </span>

--- a/packages/augur-ui/src/modules/modal/common.tsx
+++ b/packages/augur-ui/src/modules/modal/common.tsx
@@ -28,7 +28,7 @@ import {
   ConfirmedLabel,
 } from 'modules/common/labels';
 import Styles from 'modules/modal/modal.styles.less';
-import { PENDING, SUCCESS, DAI, FAILURE, ACCOUNT_TYPES, ETH } from 'modules/common/constants';
+import { PENDING, SUCCESS, DAI, FAILURE, ACCOUNT_TYPES, ETH, HELP_CENTER_ADD_FUNDS, HELP_CENTER_LEARN_ABOUT_ADDRESS } from 'modules/common/constants';
 import { LinkContent, LoginAccount } from 'modules/types';
 import { DismissableNotice, DISMISSABLE_NOTICE_BUTTON_TYPES } from 'modules/reporting/common';
 import { toChecksumAddress } from 'ethereumjs-util';
@@ -470,7 +470,7 @@ export const ActionRows = (props: ActionRowsProps) =>
         </div>
       </section>
       <div>
-        <ProcessingButton 
+        <ProcessingButton
           text={row.text}
           queueName={row.queueName}
           queueId={row.queueId}
@@ -583,7 +583,7 @@ export const FundsHelp = ({ fundType = DAI }: FundsHelpProps) => (
     <p>Need help?</p>
     <div>
       <span>Learn how to buy {fundType === DAI ? `Dai ($)` : fundType} {fundType === DAI ? generateDaiTooltip() : ''} and  send it to your Augur account address.</span>
-      <ExternalLinkButton URL='https://docs.augur.net/' label='Learn More' />
+      <ExternalLinkButton URL={HELP_CENTER_ADD_FUNDS} label='Learn More' />
     </div>
   </div>
 );
@@ -831,7 +831,7 @@ export const Coinbase = ({
     />
     {fundTypeToUse !== ETH && (
       <ExternalLinkButton
-        URL='https://docs.augur.net/'
+        URL={HELP_CENTER_LEARN_ABOUT_ADDRESS}
         label={'Learn about your address'}
       />
     )}
@@ -868,7 +868,7 @@ export const Transfer = ({
           fundTypeLabel
         )}{' '}
         using an app or exchange (see our list of{' '}
-        <a target='_blank' href='https://docs.augur.net/'>
+        <a target='_blank' href={HELP_CENTER_ADD_FUNDS}>
           popular ways to buy {fundTypeLabel})
         </a>
       </li>
@@ -883,7 +883,7 @@ export const Transfer = ({
     />
     {fundTypeToUse !== ETH && (
       <ExternalLinkButton
-        URL='https://docs.augur.net/'
+        URL={HELP_CENTER_LEARN_ABOUT_ADDRESS}
         label={'Learn about your address'}
       />
     )}

--- a/packages/augur-ui/src/modules/modal/containers/modal-buy-dai.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-buy-dai.ts
@@ -7,7 +7,7 @@ import { updateModal } from 'modules/modal/actions/update-modal';
 import { AppState } from 'store';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
-import { MODAL_ADD_FUNDS, MODAL_TEST_BET } from 'modules/common/constants';
+import { MODAL_ADD_FUNDS, MODAL_TEST_BET, HELP_CENTER_ADD_FUNDS} from 'modules/common/constants';
 import { OnboardingPaymentIcon } from 'modules/common/icons';
 import { BUY_DAI, track } from 'services/analytics/helpers';
 
@@ -33,7 +33,7 @@ const mergeProps = (sP: any, dP: any, oP: any) => ({
     },
     {
       content: 'LEARN MORE',
-      link: 'https://docs.augur.net',
+      link: HELP_CENTER_ADD_FUNDS,
     },
   ],
   buttons: [

--- a/packages/augur-ui/src/modules/modal/migrate-rep.tsx
+++ b/packages/augur-ui/src/modules/modal/migrate-rep.tsx
@@ -10,7 +10,7 @@ import { LinearPropertyLabel } from 'modules/common/labels';
 import { InfoIcon } from 'modules/common/icons';
 import { displayGasInDai } from 'modules/app/actions/get-ethToDai-rate';
 import {
-  V1_REP_MIGRATE_ESTIMATE,
+  V1_REP_MIGRATE_ESTIMATE, HELP_CENTER_LEARN_ABOUT_ADDRESS, HELP_CENTER_MIGRATE_REP,
 } from 'modules/common/constants';
 
 import Styles from 'modules/modal/modal.styles.less';
@@ -86,7 +86,7 @@ export const MigrateRep = (props: MigrateRepForm) => {
         address={toChecksumAddress(loginAccount.address)}
       />
       <ExternalLinkButton
-        URL="https://docs.augur.net/"
+        URL={HELP_CENTER_LEARN_ABOUT_ADDRESS}
         label={'Learn about your address'}
       />
     </>
@@ -114,7 +114,7 @@ export const MigrateRep = (props: MigrateRepForm) => {
             example 100 V1 REP will migrate to 100 V2 REP.
             <ExternalLinkButton
               label="Learn more"
-              URL="http://docs.augur.net/"
+              URL={HELP_CENTER_MIGRATE_REP}
             />
           </h2>
         )}
@@ -129,7 +129,7 @@ export const MigrateRep = (props: MigrateRepForm) => {
             From here you can migrate all V1 REP in your account to V2 REP.
             <ExternalLinkButton
               label="Learn more"
-              URL="http://docs.augur.net/"
+              URL={HELP_CENTER_MIGRATE_REP}
             />
           </h2>
         )}

--- a/packages/augur-ui/src/modules/reporting/common.tsx
+++ b/packages/augur-ui/src/modules/reporting/common.tsx
@@ -13,8 +13,9 @@ import {
   INVALID_OUTCOME_ID,
   SUBMIT_REPORT,
   BUYPARTICIPATIONTOKENS,
-   TRANSACTIONS,
-   REDEEMSTAKE
+  TRANSACTIONS,
+  REDEEMSTAKE,
+  HELP_CENTER_PARTICIPATION_TOKENS,
 } from 'modules/common/constants';
 import {
   FormattedNumber,
@@ -28,6 +29,7 @@ import {
   CancelTextButton,
   PrimaryButton,
   ProcessingButton,
+  ExternalLinkButton,
 } from 'modules/common/buttons';
 import { Checkbox, TextInput } from 'modules/common/form';
 import {
@@ -426,7 +428,11 @@ export class DisputingBondsView extends Component<
       this.setState({ scalarError: 'Enter a valid number', disabled: true });
     } else {
       this.setState({ scalarError: '' });
-      if (this.state.stakeError === '' && stakeValue !== '' && stakeValue !== '0') {
+      if (
+        this.state.stakeError === '' &&
+        stakeValue !== '' &&
+        stakeValue !== '0'
+      ) {
         this.setState({ disabled: false });
       }
     }
@@ -456,10 +462,10 @@ export class DisputingBondsView extends Component<
     if (
       !!!warpSyncHash &&
       (isNaN(Number(inputStakeValue)) ||
-      inputStakeValue === '' ||
-      inputStakeValue === '0' ||
-      inputStakeValue === '.' ||
-      inputStakeValue === '0.')
+        inputStakeValue === '' ||
+        inputStakeValue === '0' ||
+        inputStakeValue === '.' ||
+        inputStakeValue === '0.')
     ) {
       this.setState({ stakeError: 'Enter a valid number', disabled: true });
       return updateInputtedStake({ inputStakeValue, ZERO });
@@ -493,7 +499,10 @@ export class DisputingBondsView extends Component<
     } else {
       this.setState({ stakeError: '' });
       if (
-        ((isScalar && inputScalarOutcome !== '') || isInvalid || !!warpSyncHash) || !isScalar
+        (isScalar && inputScalarOutcome !== '') ||
+        isInvalid ||
+        !!warpSyncHash ||
+        !isScalar
       ) {
         this.setState({ disabled: false });
       }
@@ -529,7 +538,7 @@ export class DisputingBondsView extends Component<
       id,
       Gnosis_ENABLED,
       ethToDaiRate,
-      warpSyncHash
+      warpSyncHash,
     } = this.props;
 
     const {
@@ -550,7 +559,11 @@ export class DisputingBondsView extends Component<
       <div className={classNames(Styles.DisputingBondsView)}>
         {isScalar && id === 'null' && (
           <ScalarOutcomeView
-            inputScalarOutcome={!inputScalarOutcome && market.isWarpSync ? warpSyncHash : inputScalarOutcome}
+            inputScalarOutcome={
+              !inputScalarOutcome && market.isWarpSync
+                ? warpSyncHash
+                : inputScalarOutcome
+            }
             updateScalarOutcome={this.updateScalarOutcome}
             scalarDenomination={market.scalarDenomination}
             scalarError={scalarError}
@@ -1169,7 +1182,7 @@ export const ParticipationTokensView = (
         <span>Don’t see any reports that need disputing? </span>
         You can earn a proportional share of the profits from this dispute
         window.
-        <span>Learn more</span>
+        <span><a href={HELP_CENTER_PARTICIPATION_TOKENS} target="_blank" rel="noopener noreferrer">Learn more</a></span>
       </span>
 
       <Subheaders


### PR DESCRIPTION
- Fee and Liquidity spread banner learn more goes to wrong destination #5625
- Participation tokens learn more needs a link #5889
- URLs needed for migrate rep modal - HC links #6501
- Added a few other missing links (Helper menu/ Add Funds)
- Created a TODO for update gnosis -> gsn for wallet info post