### PR TITLE
use blocktime not users timestamp. change message to give user an ide…

### DIFF
--- a/packages/augur-ui/src/modules/trading/components/form.tsx
+++ b/packages/augur-ui/src/modules/trading/components/form.tsx
@@ -409,13 +409,13 @@ class Form extends Component<FromProps, FormState> {
     const gasConfirmEstimate = this.state
       ? this.state.confirmationTimeEstimation * 1.5
       : 0; // In Seconds
-    const earliestExp = minOrderLifespan + gasConfirmEstimate;
+    const earliestExp = Math.ceil((minOrderLifespan + gasConfirmEstimate) / 60);
     const expiryTime = expiration - gasConfirmEstimate - currentTimestamp;
     if (expiration && expiryTime < minOrderLifespan) {
       errorCount += 1;
       passedTest = false;
       errors[this.INPUT_TYPES.EXPIRATION_DATE].push(
-        `Order expires to soon! earilest expiration is ${earliestExp} seconds)`
+        `Order expires to soon! earilest expiration is ${earliestExp} minutes)`
       );
     }
     return { isOrderValid: passedTest, errors, errorCount };

--- a/packages/augur-ui/src/modules/trading/components/form.tsx
+++ b/packages/augur-ui/src/modules/trading/components/form.tsx
@@ -415,7 +415,7 @@ class Form extends Component<FromProps, FormState> {
       errorCount += 1;
       passedTest = false;
       errors[this.INPUT_TYPES.EXPIRATION_DATE].push(
-        `Order expires to soon! earilest expiration is ${earliestExp} minutes)`
+        `Order expires to soon! Earilest expiration is ${earliestExp} minutes`
       );
     }
     return { isOrderValid: passedTest, errors, errorCount };

--- a/packages/augur-ui/src/modules/trading/components/form.tsx
+++ b/packages/augur-ui/src/modules/trading/components/form.tsx
@@ -329,7 +329,7 @@ class Form extends Component<FromProps, FormState> {
     expiration?
   ): TestResults {
     const props = nextProps || this.props;
-    const { market } = props;
+    const { market, currentTimestamp } = props;
     const isScalar: boolean = market.marketType === SCALAR;
     let errorCount = 0;
     let passedTest = !!isOrderValid;
@@ -409,12 +409,13 @@ class Form extends Component<FromProps, FormState> {
     const gasConfirmEstimate = this.state
       ? this.state.confirmationTimeEstimation * 1.5
       : 0; // In Seconds
-    const expiryTime = expiration - gasConfirmEstimate - moment().unix();
+    const earliestExp = minOrderLifespan + gasConfirmEstimate;
+    const expiryTime = expiration - gasConfirmEstimate - currentTimestamp;
     if (expiration && expiryTime < minOrderLifespan) {
       errorCount += 1;
       passedTest = false;
       errors[this.INPUT_TYPES.EXPIRATION_DATE].push(
-        'Order expires less than 70 seconds into the future (after est confirmation time)'
+        `Order expires to soon! earilest expiration is ${earliestExp} seconds)`
       );
     }
     return { isOrderValid: passedTest, errors, errorCount };


### PR DESCRIPTION
…a of earliest expiration of order.

Changed message, user has no idea what the earliest expiration time they could use. this way that have an idea. Show in minutes since that is the smallest unit in the dropdown.

![image](https://user-images.githubusercontent.com/3970376/76147614-aa18c400-6063-11ea-855e-eb1292bc75f8.png)

