### PR TITLE
fix issue where rounding on scalar causes amount to be 0

### DIFF
--- a/packages/augur-ui/src/modules/trading/components/confirm.tsx
+++ b/packages/augur-ui/src/modules/trading/components/confirm.tsx
@@ -285,12 +285,17 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
 
     let newOrderAmount = formatShares('0').rounded;
     if (numShares && totalCost.fullPrecision && shareCost.fullPrecision) {
-      newOrderAmount = formatShares(
-        createBigNumber(numShares).minus(shareCost.fullPrecision),
-        {
-          decimalsRounded: UPPER_FIXED_PRECISION_BOUND,
-        }
-      ).rounded;
+      newOrderAmount =
+        marketType !== SCALAR
+          ? formatShares(
+              createBigNumber(numShares).minus(shareCost.fullPrecision),
+              {
+                decimalsRounded: UPPER_FIXED_PRECISION_BOUND,
+              }
+            ).rounded
+          : formatShares(
+              createBigNumber(numShares).minus(shareCost.fullPrecision)
+            ).rounded;
     }
 
     const notProfitable =


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/6661

shares were getting rounded to 0.  don't round for scalar markets