### PR TITLE
Update MetaMask to use eth_requestAccounts

### DIFF
--- a/packages/augur-ui/src/modules/app/actions/init-augur.ts
+++ b/packages/augur-ui/src/modules/app/actions/init-augur.ts
@@ -41,7 +41,6 @@ import { Augur, Provider } from '@augurproject/sdk';
 import { getLoggedInUserFromLocalStorage } from 'services/storage/localStorage';
 import { getFingerprint } from 'utils/get-fingerprint';
 import { tryToPersistStorage } from 'utils/storage-manager';
-import Torus from '@toruslabs/torus-embed';
 import { isDevNetworkId, SDKConfiguration } from '@augurproject/artifacts';
 import { getNetwork } from 'utils/get-network-name';
 import { buildConfig } from '@augurproject/artifacts';
@@ -193,9 +192,13 @@ export function connectAugur(
         provider = new Web3Provider(windowRef.web3.currentProvider);
       } else {
         // Use torus provider
-        const host = getNetwork(networkId);
-        const torus: any = new Torus({});
 
+        // Use require instead of import for wallet SDK packages
+        // to conditionally load web3 into the DOM
+        const Torus = require('@toruslabs/torus-embed').default;
+        const torus = new Torus({});
+
+        const host = getNetwork(networkId);
         await torus.init({
           network: { host },
           showTorusButton: false,

--- a/packages/augur-ui/src/modules/auth/actions/login-with-fortmatic.ts
+++ b/packages/augur-ui/src/modules/auth/actions/login-with-fortmatic.ts
@@ -4,7 +4,6 @@ import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
 import { PersonalSigningWeb3Provider } from 'utils/personal-signing-web3-provider';
 import Fortmatic from 'fortmatic';
-import Web3 from 'web3';
 import { ACCOUNT_TYPES, FORTMATIC_API_KEY, FORTMATIC_API_TEST_KEY, NETWORK_IDS, NETWORK_NAMES } from 'modules/common/constants';
 import { windowRef } from 'utils/window-ref';
 import { AppState } from 'store';
@@ -21,12 +20,12 @@ export const loginWithFortmatic = () => async (
   if (supportedNetwork) {
     try {
       const fm = new Fortmatic(networkId === NETWORK_IDS.Kovan ? FORTMATIC_API_TEST_KEY : FORTMATIC_API_KEY, supportedNetwork);
-      const web3 = new Web3(fm.getProvider());
       const provider = new PersonalSigningWeb3Provider(fm.getProvider());
 
       windowRef.fm = fm;
 
-      const accounts = await web3.currentProvider.enable();
+      const accounts = await fm.user.login();
+
       const account = toChecksumAddress(accounts[0]);
 
       const accountObject = {

--- a/packages/augur-ui/src/modules/auth/actions/login-with-injected-web3.ts
+++ b/packages/augur-ui/src/modules/auth/actions/login-with-injected-web3.ts
@@ -20,7 +20,7 @@ import { logout } from 'modules/auth/actions/logout';
 import { AppState } from 'store';
 
 // MetaMask, dapper, Mobile wallets
-export const loginWithInjectedWeb3 = () => (
+export const loginWithInjectedWeb3 = () => async (
   dispatch: ThunkDispatch<void, any, Action>,
   getState: () => AppState,
 ) => {
@@ -84,9 +84,18 @@ export const loginWithInjectedWeb3 = () => (
     }
   };
 
-  return windowRef.ethereum
+  try {
+    // This is equivalent to ethereum.enable()
+    // Handle connecting, per EIP 1102
+    const request = await windowRef.ethereum.send('eth_requestAccounts');
+    const address = request.result[0];
+    success(address, false);
+  }
+  catch (err) {
+    return windowRef.ethereum
     .enable()
     .then((resolve: string[]) => success(resolve[0], false), failure);
+  }
 };
 
 const login = (account: string) => (

--- a/packages/augur-ui/src/modules/auth/actions/login-with-portis.ts
+++ b/packages/augur-ui/src/modules/auth/actions/login-with-portis.ts
@@ -3,7 +3,6 @@ import { toChecksumAddress } from 'ethereumjs-util';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
 import { PersonalSigningWeb3Provider } from 'utils/personal-signing-web3-provider';
-import Web3 from 'web3';
 import {
   ACCOUNT_TYPES,
   PORTIS_API_KEY,
@@ -28,8 +27,10 @@ import { getNetwork } from 'utils/get-network-name';
 
   if (portisNetwork) {
     try {
-      // Only inject Portis if we are using Portis
+      // Use require instead of import for wallet SDK packages
+      // to conditionally load web3 into the DOM
       const Portis = require('@portis/web3');
+      const Web3 = require('web3');
       const portis = new Portis(PORTIS_API_KEY, portisNetwork === 'localhost' ? localPortisNetwork : portisNetwork, {
         scope: ['email'],
         registerPageByDefault: forceRegisterPage,

--- a/packages/augur-ui/src/modules/auth/actions/login-with-torus.ts
+++ b/packages/augur-ui/src/modules/auth/actions/login-with-torus.ts
@@ -3,8 +3,6 @@ import { toChecksumAddress } from 'ethereumjs-util';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
 import { PersonalSigningWeb3Provider } from 'utils/personal-signing-web3-provider';
-import Torus from '@toruslabs/torus-embed';
-import Web3 from 'web3';
 import { ACCOUNT_TYPES } from 'modules/common/constants';
 import { windowRef } from 'utils/window-ref';
 import { LoginAccount } from 'modules/types';
@@ -20,9 +18,12 @@ export const loginWithTorus = () => async (
   const torusNetwork = getNetwork(networkId);
   let accountObject: Partial<LoginAccount> = {};
 
-  if (torusNetwork) {
-    const torus = new Torus({});
+  // Use require instead of import for wallet SDK packages
+  // to conditionally load web3 into the DOM
+  const Torus = require('@toruslabs/torus-embed').default;
+  const torus = new Torus({});
 
+  if (torusNetwork) {
     if (torusNetwork === 'localhost') {
       throw new Error('localhost currently not working for torus')
     }
@@ -33,14 +34,11 @@ export const loginWithTorus = () => async (
         showTorusButton: false,
       });
 
-      await torus.login({verifier: 'google'});
-
-      const web3 = new Web3(torus.provider);
+      const accounts = await torus.login({verifier: 'google'});
       const provider = new PersonalSigningWeb3Provider(torus.provider);
       const isWeb3 = true;
       windowRef.torus = torus;
 
-      const accounts = await web3.eth.getAccounts();
       const account = toChecksumAddress(accounts[0]);
       accountObject = {
         address: account,

--- a/packages/augur-ui/src/modules/types.ts
+++ b/packages/augur-ui/src/modules/types.ts
@@ -660,6 +660,10 @@ export interface WindowApp extends Window {
   ethereum: {
     selectedAddress;
     networkVersion: string;
+    isMetaMask?: boolean;
+    on?: Function;
+    enable?: Function;
+    send?: Function;
   };
   localStorage: Storage;
   integrationHelpers: any;


### PR DESCRIPTION

- Update MetaMask to use eth_requestAccounts [ #4664]
- prevent wallet sdks from overwriting  injected web3s