### PR TITLE
remove displaying incorrect date for cancelled orders

### DIFF
--- a/packages/augur-ui/src/modules/modal/transactions.tsx
+++ b/packages/augur-ui/src/modules/modal/transactions.tsx
@@ -306,7 +306,7 @@ export const Transactions: React.FC<TransactionsProps> = props => {
   };
 
   const addTransactionRow = (tx: TransactionInfo) => {
-    const timestamp = moment(tx.timestamp * 1000).format('D MMM YYYY HH:mm:ss');
+    const timestamp = tx.timestamp ? moment(tx.timestamp * 1000).format('D MMM YYYY HH:mm:ss') : null;
     const key = `${tx.transactionHash}-${tx.timestamp}-${tx.action}-${tx.outcomeDescription}`;
     // we never show the coin type outside of tx.coin so we can just format by shares always here.
     const quantity = formatShares(createBigNumber(tx.quantity));
@@ -490,7 +490,7 @@ export const Transactions: React.FC<TransactionsProps> = props => {
           </>
         </section>
       </div>
-      
+
       <div>
         <Pagination {...pageInfo} updateLimit={() => {}} />
         <FormDropdown


### PR DESCRIPTION
cancelled orders don't have timestamp, need to remove instead of using 1969 date. 

![image](https://user-images.githubusercontent.com/3970376/76314790-72995a00-62a5-11ea-8dd2-373d82423763.png)
