### PR TITLE
show toggle for market details by default

### DIFF
--- a/packages/augur-ui/src/modules/market/components/market-header/market-header.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-header/market-header.tsx
@@ -91,7 +91,7 @@ export default class MarketHeader extends Component<
     super(props);
     this.state = {
       showReadMore: false,
-      showProperties: false,
+      showProperties: true,
       detailsHeight: 0,
       headerCollapsed: false,
       showCopied: false,


### PR DESCRIPTION
show toggle so users can see market details when market is in-reporting or resolved.

![image](https://user-images.githubusercontent.com/3970376/76319402-2e11bc80-62ad-11ea-88d4-bfcfe0d0927b.png)

https://github.com/AugurProject/augur/issues/6676