### PR TITLE
disable gnosis on googlebot

### DIFF
--- a/packages/augur-ui/src/modules/app/actions/init-augur.ts
+++ b/packages/augur-ui/src/modules/app/actions/init-augur.ts
@@ -218,9 +218,10 @@ export function connectAugur(
       provider = new JsonRpcProvider(config.ethereum.http);
     }
 
-    // Disable mesh for googleBot
+    // Disable mesh/gnosis for googleBot
     if (isGoogleBot()) {
-      config.zeroX.mesh.enabled = false
+      config.zeroX.mesh.enabled = false;
+      config.gnosis.enabled = false;
     }
 
     let sdk: Augur<Provider> = null;


### PR DESCRIPTION
Currently google search console isn't loading the page. I notice we still had some gas/gnosis errors in the console. 

I disabled gnosis on googlebot since it was throwing some gas errors.

The errors that remain are below, TBD if i need to quiet them also.
<img width="1155" src="https://user-images.githubusercontent.com/1683736/76558303-711d8c80-6473-11ea-8467-d1edadb52ec4.png">
