### PR TITLE
use users local time to show smooth timers

### DIFF
--- a/packages/augur-ui/src/modules/account/components/notifications-templates.tsx
+++ b/packages/augur-ui/src/modules/account/components/notifications-templates.tsx
@@ -84,7 +84,6 @@ const Template = ({
   type,
   message,
   buttonAction,
-  currentTime,
   isDisabled,
   buttonLabel,
   queueName,
@@ -98,7 +97,7 @@ const Template = ({
         className={Styles.BottomRow}
       >
         {showCounter && (
-          <Counter type={type} market={market} currentTime={currentTime} />
+          <Counter type={type} market={market} />
         )}
         {queueName && (queueId || (market && market.id)) ?
           <ProcessingButton
@@ -151,31 +150,27 @@ const TemplateBody = (props: TemplateBodyProps) => {
 interface CounterProps {
   type: string;
   market: MarketData;
-  currentTime?: DateFormattedObject;
   disputingWindowEndTime?: DateFormattedObject;
 }
 
-const Counter = ({ market, type, currentTime }: CounterProps) => {
+const Counter = ({ market, type }: CounterProps) => {
   let counter: any = null;
   const { endTime, reportingState, finalizationTime, disputeInfo } = market;
   const endTimeFormatted = formatTime(endTime);
   const finalizationTimeFormatted = formatTime(finalizationTime);
   if (
     type === NOTIFICATION_TYPES.proceedsToClaim &&
-    finalizationTimeFormatted &&
-    currentTime
+    finalizationTimeFormatted
   ) {
     counter = (
       <div className={Styles.Countdown}>
         <CountdownProgress
           label={MARKET_STATUS_MESSAGES.WAITING_PERIOD_ENDS}
           time={finalizationTimeFormatted}
-          currentTime={formatTime(currentTime)}
         />
       </div>
     );
   } else {
-    // if (currentTime && disputeInfo.disputeWindow.endTime) {
       const label =
         type === NOTIFICATION_TYPES[MARKET_IN_DISPUTE]
           ? DISPUTE_ENDS
@@ -184,14 +179,12 @@ const Counter = ({ market, type, currentTime }: CounterProps) => {
         <div className={Styles.Countdown}>
           <MarketProgress
             reportingState={reportingState}
-            currentTime={currentTime}
             endTimeFormatted={endTimeFormatted}
             reportingWindowEndTime={disputeInfo.disputeWindow.endTime}
             customLabel={label}
           />
         </div>
       );
-    // }
   }
   return counter;
 };

--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -99,7 +99,8 @@ export const AUTH_TYPES = {
 export const DEFAULT_AUTH_TYPE = REGISTER;
 const SECONDS_PER_DAY = 3600 * 24;
 export const SIXTY_DAYS = 60 * SECONDS_PER_DAY;
-
+export const SECONDS_IN_HOUR = 60 * 60;
+export const SECONDS_IN_MINUTE = 60;
 export const EDGE_WALLET_TYPE = 'wallet:ethereum';
 
 // Add Funds types

--- a/packages/augur-ui/src/modules/common/labels.tsx
+++ b/packages/augur-ui/src/modules/common/labels.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames';
 import * as constants from 'modules/common/constants';
 import Styles from 'modules/common/labels.styles.less';
@@ -45,6 +45,7 @@ import { EventDetailsContent } from 'modules/create-market/constants';
 import { ExplainerBlock } from 'modules/create-market/components/common';
 import { hasTemplateTextInputs } from '@augurproject/artifacts';
 import { getDurationBetween } from 'utils/format-date';
+import { useTimer } from 'modules/common/progress';
 
 export interface MarketTypeProps {
   marketType: string;
@@ -228,17 +229,23 @@ interface TimeLabelProps {
 
 interface CountdownLabelProps {
   expiry: DateFormattedObject;
-  currentTimestamp: Number;
 }
 
-export const CountdownLabel = ({ expiry, currentTimestamp }: CountdownLabelProps) => {
+export const CountdownLabel = ({ expiry }: CountdownLabelProps) => {
   if (!expiry) return null;
-  const duration = getDurationBetween(expiry.timestamp, currentTimestamp);
-  const hours = duration.asHours();
-  if (hours > 1) return null;
+  const currentTime = useTimer();
+  const duration = getDurationBetween(expiry.timestamp, currentTime);
+  let durationValue = duration.asSeconds();
+  let unit = 'm';
+  if (durationValue > constants.SECONDS_IN_HOUR) return null;
+  if (durationValue > constants.SECONDS_IN_MINUTE) {
+    durationValue = Math.round(duration.asMinutes());
+  } else {
+    unit = 's';
+  }
   return (
     <div className={Styles.CountdownLabel}>
-      {Math.round(duration.asMinutes())}m
+      {durationValue}{unit}
     </div>
   );
 };

--- a/packages/augur-ui/src/modules/common/progress.tsx
+++ b/packages/augur-ui/src/modules/common/progress.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useState, useEffect } from 'react';
 import Styles from 'modules/common/progress.styles.less';
 import * as format from 'utils/format-date';
 import classNames from 'classnames';
@@ -7,7 +7,6 @@ import { REPORTING_STATE } from 'modules/common/constants';
 
 export interface CountdownProgressProps {
   time?: DateFormattedObject;
-  currentTime?: DateFormattedObject;
   label: string;
   countdownBreakpoint?: number;
   firstColorBreakpoint?: number;
@@ -28,7 +27,6 @@ export interface TimeProgressBarProps {
 
 export interface MarketProgressProps {
   reportingState: string;
-  currentTime: DateFormattedObject | number;
   endTimeFormatted: DateFormattedObject;
   reportingWindowEndTime: DateFormattedObject | number;
   customLabel?: string;
@@ -148,13 +146,11 @@ const reportingStateToLabelTime = (
 export const MarketProgress = (props: MarketProgressProps) => {
   const {
     reportingState,
-    currentTime,
     endTimeFormatted,
     reportingWindowEndTime,
     customLabel,
     alignRight,
   } = props;
-  const currTime = formatTime(currentTime);
   const reportingEndTime = formatTime(reportingWindowEndTime);
   const { label, time } = reportingStateToLabelTime(
     reportingState,
@@ -167,22 +163,34 @@ export const MarketProgress = (props: MarketProgressProps) => {
     <CountdownProgress
       label={customLabel || label}
       time={time}
-      currentTime={currTime}
       alignRight={alignRight}
     />
   );
 };
 
-export const CountdownProgress = (props: CountdownProgressProps) => {
-  const {
-    label,
-    time,
-    currentTime,
-    countdownBreakpoint,
-    firstColorBreakpoint,
-    finalColorBreakpoint,
-    alignRight,
-  } = props;
+export const useTimer = () => {
+  const [currentTime, setCurrentTime] = useState(Math.floor(Date.now() / 1000));
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+        setCurrentTime(seconds => seconds + 1);
+      }, 1000);
+    return () => clearInterval(interval);
+  }, [currentTime]);
+
+  return currentTime;
+}
+
+export const CountdownProgress = ({
+  label,
+  time,
+  countdownBreakpoint,
+  firstColorBreakpoint,
+  finalColorBreakpoint,
+  alignRight,
+}: CountdownProgressProps) => {
+  const currentTime = useTimer();
+
   let valueString = '';
   let timeLeft = 1;
   let countdown = false;
@@ -191,23 +199,23 @@ export const CountdownProgress = (props: CountdownProgressProps) => {
   if (time && time !== null && currentTime) {
     const daysRemaining = format.getDaysRemaining(
       time.timestamp,
-      currentTime.timestamp
+      currentTime
     );
     const hoursRemaining = format.getHoursMinusDaysRemaining(
       time.timestamp,
-      currentTime.timestamp
+      currentTime
     );
     const minutesRemaining = format.getMinutesMinusHoursRemaining(
       time.timestamp,
-      currentTime.timestamp
+      currentTime
     );
 
     const secondsRemaining = format.getSecondsMinusMinutesRemaining(
       time.timestamp,
-      currentTime.timestamp
+      currentTime
     );
 
-    timeLeft = time.timestamp - currentTime.timestamp;
+    timeLeft = time.timestamp - currentTime;
     countdown = (countdownBreakpoint || OneWeek) >= timeLeft && timeLeft > 0;
     valueString = countdown
       ? `${daysRemaining}:${

--- a/packages/augur-ui/src/modules/reporting/forking-banner.tsx
+++ b/packages/augur-ui/src/modules/reporting/forking-banner.tsx
@@ -13,7 +13,6 @@ interface ForkingProps {
   hasRepBalance?: boolean;
   isForking?: boolean;
   forkTime?: DateFormattedObject;
-  currentTime?: DateFormattedObject;
   hasStakedRepAction: Function;
   hasRepMigrationAction: Function;
 }
@@ -51,7 +50,6 @@ export const Forking = (props: ForkingProps) => (
       <CountdownProgress
         label={'Time remaining in Fork Window'}
         time={props.forkTime}
-        currentTime={props.currentTime}
         countdownBreakpoint={SIXTY_DAYS}
       />
     </div>


### PR DESCRIPTION
smooth timers

![2020-03-13 12 21 00](https://user-images.githubusercontent.com/3970376/76649336-72f85600-652e-11ea-8477-4915e9d1d628.gif)


![2020-03-13 13 22 38](https://user-images.githubusercontent.com/3970376/76649317-65db6700-652e-11ea-9c13-f6f19870396c.gif)
