### PR TITLE
show confirmation section when user is going to create a valid open o…

### DIFF
--- a/packages/augur-ui/src/modules/trades/actions/update-trade-cost-shares.ts
+++ b/packages/augur-ui/src/modules/trades/actions/update-trade-cost-shares.ts
@@ -1,5 +1,5 @@
 import { createBigNumber } from 'utils/create-big-number';
-import { BUY, ZERO, ZEROX_GAS_FEE } from 'modules/common/constants';
+import { BUY, ZERO, ZEROX_GAS_FEE, BUY_INDEX } from 'modules/common/constants';
 import logError from 'utils/log-error';
 import { generateTrade } from 'modules/trades/helpers/generate-trade';
 import { AppState } from 'store';
@@ -164,9 +164,8 @@ async function runSimulateTrade(
   const fingerprint = undefined; // TODO: get this from state
   const doNotCreateOrders = false; // TODO: this needs to be passed from order form
 
-  let userShares = createBigNumber(marketOutcomeShares[outcomeId] || 0);
-
-  if (orderType === 0) {
+  let userShares = (orderType !== BUY_INDEX) ? createBigNumber(marketOutcomeShares[outcomeId] || 0) : ZERO;
+  if (!!reversal) {
     // ignore trading outcome shares and find min across all other outcome shares.
     const userSharesBalancesRemoveOutcome = Object.keys(
       marketOutcomeShares
@@ -230,7 +229,7 @@ async function runSimulateTrade(
     // Plus ZeroX Fee (150k Gas)
     gasLimit = gasLimit.plus(ZEROX_GAS_FEE);
   }
-  // ignore share cost when user is shorting another outcome or longing another outcome
+  // ignore share cost when user is shorting or longing another outcome
   // and the user doesn't have shares on the traded outcome
   if (
     reversal === null &&

--- a/packages/augur-ui/src/modules/trades/helpers/calc-order-profit-loss-percents.ts
+++ b/packages/augur-ui/src/modules/trades/helpers/calc-order-profit-loss-percents.ts
@@ -15,7 +15,6 @@ import { SCALAR, BUY } from "modules/common/constants";
  *    potentialDaiLoss:       number, maximum number of ether that can be lost according to the current numShares and limit price
  *    potentialProfitPercent: number, the maximum percentage profit that can be earned with current numShares and limit price,
  *                                    excluding first 100% (so a 2x is a 100% return and not a 200% return). For BUYs, loss is always 100% (exc. fees)
- *    potentialLossPercent:   number, the max percentage loss that can be lost with current numShares and limit price; for SELLs loss is always 100%
  */
 
 export const calcOrderProfitLossPercents = (
@@ -83,19 +82,11 @@ export const calcOrderProfitLossPercents = (
   const potentialDaiLoss =
     side === BUY ? longETHpotentialProfit : shortETHpotentialProfit;
 
-  const potentialProfitPercent =
-    side === BUY ? shortETHPercentProfit : longETHPercentProfit;
-
-  const potentialLossPercent =
-    side === BUY ? shortETHPercentNoFee : longETHPercentNoFee;
-
   const tradingFees = winningSettlementCost;
 
   return {
     potentialDaiProfit,
     potentialDaiLoss,
-    potentialProfitPercent,
-    potentialLossPercent,
     tradingFees,
   };
 };

--- a/packages/augur-ui/src/modules/trades/helpers/generate-trade.ts
+++ b/packages/augur-ui/src/modules/trades/helpers/generate-trade.ts
@@ -104,12 +104,6 @@ export const generateTrade = memoize(
       potentialDaiLoss: preOrderProfitLoss
         ? formatDaiValue(preOrderProfitLoss.potentialDaiLoss)
         : null,
-      potentialLossPercent: preOrderProfitLoss
-        ? formatDaiValue(preOrderProfitLoss.potentialLossPercent)
-        : null,
-      potentialProfitPercent: preOrderProfitLoss
-        ? formatDaiValue(preOrderProfitLoss.potentialProfitPercent)
-        : null,
       tradingFees: preOrderProfitLoss
         ? formatDaiValue(preOrderProfitLoss.tradingFees)
         : null,

--- a/packages/augur-ui/src/modules/trading/components/confirm.tsx
+++ b/packages/augur-ui/src/modules/trading/components/confirm.tsx
@@ -263,6 +263,7 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
       orderShareProfit,
       orderShareTradingFee,
       numFills,
+      sharesFilled,
     } = trade;
 
     const { messages } = this.state;
@@ -316,6 +317,8 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
           : formatShares(
               createBigNumber(numShares).minus(shareCost.fullPrecision)
             ).rounded;
+    } else if (sharesFilled && sharesFilled.fullPrecision) {
+      newOrderAmount = sharesFilled.rounded;
     }
 
     const notProfitable =

--- a/packages/augur-ui/src/modules/trading/components/wrapper.tsx
+++ b/packages/augur-ui/src/modules/trading/components/wrapper.tsx
@@ -511,6 +511,11 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
     const orderEmpty =
       orderPrice === '' && orderQuantity === '' && orderDaiEstimate === '';
     const showTip = !hasHistory && orderEmpty;
+    const showConfirm =
+      (!!trade &&
+        (trade.potentialDaiLoss && trade.potentialDaiLoss.value !== 0)) ||
+      (trade.orderShareProfit && trade.orderShareProfit.value !== 0) ||
+      (trade.sharesFilled && trade.sharesFilled.value !== 0);
     return (
       <section className={Styles.Wrapper}>
         <div>
@@ -581,9 +586,7 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
             />
           )}
         </div>
-        {trade &&
-          ((trade.shareCost && trade.shareCost.value !== 0) ||
-            (trade.totalCost && trade.totalCost.value !== 0)) && (
+        { showConfirm && (
             <Confirm
               initialLiquidity={initialLiquidity}
               numOutcomes={market.numOutcomes}


### PR DESCRIPTION
…rder or make a trade. doesn't matter if shares are involved or not.

https://github.com/AugurProject/augur/issues/6786

scenario

user has position on outcome A
wants to buy or sell on outcome B. 

position can be long or short. the confirmation section should always show for valid orders/trades