### PR TITLE
fix bug when user has rep stake to claim and no PT to claim. modal bl…

### DIFF
--- a/packages/augur-ui/src/modules/modal/containers/modal-claim-fees.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-claim-fees.ts
@@ -190,7 +190,7 @@ const mergeProps = (sP: any, dP: any, oP: any) => {
         },
         {
           label: 'Reporting Fees',
-          value: `$${daiFormatted.formatted}`,
+          value: `$${daiFormatted.formattedValue}`,
         },
         {
           label: 'Transaction Fee',
@@ -224,7 +224,7 @@ const mergeProps = (sP: any, dP: any, oP: any) => {
     },
     {
       label: 'Total DAI',
-      value: daiFormatted,
+      value: `$${daiFormatted.formattedValue}`,
     },
   ] : null;
 
@@ -270,7 +270,7 @@ const mergeProps = (sP: any, dP: any, oP: any) => {
       dP.closeModal();
     },
     estimateGas: async () => {
-      if (breakdown) {
+      if (!!breakdown) {
         const gas = await dP.redeemStakeGas(allRedeemStakeOptions);
         const displayfee = sP.GsnEnabled ? displayGasInDai(gas) : formatEther(gas).formattedValue;
         return {

--- a/packages/augur-ui/src/modules/modal/proceeds.tsx
+++ b/packages/augur-ui/src/modules/modal/proceeds.tsx
@@ -44,7 +44,7 @@ export const Proceeds = ({
   useEffect(() => {
     const timer = setTimeout(async () => {
       const transactionFee = await estimateGas();
-      if (transactionFee) {
+      if (transactionFee && !!breakdown) {
         setBreakdown([...fullBreakdown, transactionFee]);
       }
     }, 100);


### PR DESCRIPTION
…ows up because of format issue

modal to claim reporting fees and rep blows up if user doesn't have PT to claim. 
formatted value object passed to value label. 