### PR TITLE
run 3rd party tests in serial in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -505,7 +505,7 @@ jobs:
       - bash: |
           set -exuo pipefail
           free -m
-          yarn test --config=packages/augur-test/src/tests/3rd-party/jest.config.js --verbose --ci --reporters=default --reporters=jest-junit
+          yarn test --config=packages/augur-test/src/tests/3rd-party/jest.config.js --runInBand --verbose --ci --reporters=default --reporters=jest-junit
         displayName: Test 3rd party integratios
       - bash: |
           set -exuo pipefail


### PR DESCRIPTION
We're getting sporadic failures of the 3rd party tests in CI. I suspect this is because the 3rd party tests share blockchain and other 3rd party state, so I'm running them in serial to ensure they don't interact randomly.

This is [WIP] so this doesn't automerge before I get the chance to re-run CI for this branch a few times to verify that the error went away.