### PR TITLE
simplify faucet section and show faucet buttons in transactions section

### DIFF
--- a/packages/augur-tools/src/flash/scripts.ts
+++ b/packages/augur-tools/src/flash/scripts.ts
@@ -249,6 +249,7 @@ export function addScripts(flash: FlashSession) {
     ],
     async call(this: FlashSession, args: FlashArguments) {
       if (this.noProvider()) return;
+      this.config.gsn.enabled = false;
       const user = await this.ensureUser();
 
       const target = String(args.target);

--- a/packages/augur-ui/src/modules/account/components/transactions.tsx
+++ b/packages/augur-ui/src/modules/account/components/transactions.tsx
@@ -27,7 +27,7 @@ interface TransactionsProps {
   fundGsnWallet: Function;
   targetAddress: string;
   signingEth: number;
-  gsnCreated: boolean;
+  signingWalletNoEth: boolean;
   localLabel: string;
 }
 
@@ -42,7 +42,7 @@ export const Transactions = ({
   fundGsnWallet,
   targetAddress,
   signingEth,
-  gsnCreated,
+  signingWalletNoEth,
   localLabel
 }: TransactionsProps) => (
   <QuadBox
@@ -58,25 +58,6 @@ export const Transactions = ({
           <DepositButton action={addFunds} />
           <WithdrawButton action={withdraw} />
         </div>
-        {!gsnCreated && (
-          <div>
-            <h4>Fund GSN Wallet</h4>
-            <FundGSNWalletButton
-              action={fundGsnWallet}
-              disabled={signingEth === 0}
-              title={signingEth === 0 ? 'Get ETH to fund GSN Wallet' : 'Click to Fund GSN Wallet'}
-            />
-            <ExternalLinkButton
-              URL={!localLabel ? "https://faucet.kovan.network/" : null}
-              showNonLink={!!localLabel}
-              label={localLabel ? localLabel : "faucet.kovan.network"}
-            />
-            <AccountAddressDisplay
-              copyable
-              address={targetAddress ? toChecksumAddress(targetAddress) : 'loading...'}
-            />
-          </div>
-        )}
         {showFaucets && (
           <div>
             <h4>REP for test net</h4>
@@ -91,6 +72,19 @@ export const Transactions = ({
             <REPFaucetButton
               title="Legacy REP Faucet"
               action={legacyRepFaucet}
+            />
+          </div>
+        )}
+        {signingWalletNoEth && (
+          <div>
+            <ExternalLinkButton
+              URL={!localLabel ? "https://faucet.kovan.network/" : null}
+              showNonLink={!!localLabel}
+              label={localLabel ? localLabel : "faucet.kovan.network"}
+            />
+            <AccountAddressDisplay
+              copyable
+              address={targetAddress ? toChecksumAddress(targetAddress) : 'loading...'}
             />
           </div>
         )}

--- a/packages/augur-ui/src/modules/account/containers/transactions.ts
+++ b/packages/augur-ui/src/modules/account/containers/transactions.ts
@@ -10,34 +10,34 @@ import {
   MODAL_TRANSACTIONS,
   MODAL_ACCOUNT_APPROVAL,
   MODAL_GSN_FAUCET,
+  ZERO,
 } from 'modules/common/constants';
 import { AppState } from 'appStore';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
 import { getNetworkId, getLegacyRep } from 'modules/contracts/actions/contractCalls'
 import { isGSNUnavailable } from 'modules/app/selectors/is-gsn-unavailable';
+import { createBigNumber } from 'utils/create-big-number';
 
 const mapStateToProps = (state: AppState) => {
   const { loginAccount } = state;
-  const { meta, balances, address } = loginAccount;
+  const { meta, balances } = loginAccount;
   const signingWallet = meta.signer?._address;
   const networkId = getNetworkId();
-  const gsnEnabled = state.appStatus.gsnEnabled;
   const gsnCreated = !isGSNUnavailable(state);
 
-  const showFaucets = gsnEnabled
-    ? networkId !== NETWORK_IDS.Mainnet && gsnCreated
-    : networkId !== NETWORK_IDS.Mainnet;
+  const showFaucets = networkId !== NETWORK_IDS.Mainnet;
 
-  const localLabel = networkId !== NETWORK_IDS.Kovan ? 'Use flash to faucet DAI to address' : null;
-  const targetAddress = networkId !== NETWORK_IDS.Kovan ? address : signingWallet;
+  const localLabel = networkId !== NETWORK_IDS.Kovan ? 'Use flash to transfer ETH to address' : null;
+  const targetAddress = signingWallet;
+  const signingWalletNoEth = createBigNumber(balances.ethNonSafe).lte(ZERO);
 
   return {
     isMainnet: networkId === NETWORK_IDS.Mainnet,
     showFaucets,
     targetAddress,
     signingEth: balances.ethNonSafe,
-    gsnCreated,
+    signingWalletNoEth,
     localLabel
   };
 };


### PR DESCRIPTION
put the get ETH buttons under the faucet buttons. with recent changes user should not need to get ETH manually. I still see that signing wallet initially needs ETH. 

![image](https://user-images.githubusercontent.com/3970376/78360225-1364f780-757c-11ea-8aa1-0f1346c0d3d0.png)
