### PR TITLE
fixed rounding issue b/c sdk was cutting off unclaimed proceeds to 2 …

### DIFF
--- a/packages/augur-sdk/src/state/getter/Users.ts
+++ b/packages/augur-sdk/src/state/getter/Users.ts
@@ -848,7 +848,7 @@ export class Users {
                 marketTradingPositions[marketData.market].unclaimedProceeds
               )
                 .plus(unclaimedProceeds)
-                .toFixed(2);
+                .toFixed(4);
 
               marketTradingPositions[
                 marketData.market
@@ -858,7 +858,7 @@ export class Users {
                     marketTradingPositions[marketData.market].unrealizedCost
                   )
                 )
-                .toFixed(2);
+                .toFixed(4);
 
               marketTradingPositions[
                 marketData.market
@@ -866,7 +866,7 @@ export class Users {
                 marketTradingPositions[marketData.market].fee
               )
                 .plus(feeAmount)
-                .toFixed(2);
+                .toFixed(4);
             }
           }
         }

--- a/packages/augur-ui/src/modules/markets/selectors/select-user-market-positions.ts
+++ b/packages/augur-ui/src/modules/markets/selectors/select-user-market-positions.ts
@@ -20,14 +20,14 @@ export const selectUserMarketPositions = createSelector(
   selectMarketUserPositions,
   (marketInfo, marketAccountPositions): Getters.Users.TradingPosition[] => {
     if (!marketInfo || !marketAccountPositions || !marketAccountPositions.tradingPositions) return [];
-      const { marketType } = marketInfo;
+      const { marketType, reportingState } = marketInfo;
       const userPositions = Object.values(
         marketAccountPositions.tradingPositions || []
       ).map((value) => {
         const position = value as Getters.Users.TradingPosition;
         const outcome = marketInfo.outcomesFormatted[position.outcome];
         return {
-          ...positionSummary(position, outcome, marketType),
+          ...positionSummary(position, outcome, marketType, reportingState),
           outcomeName: outcome.description
         };
       });

--- a/packages/augur-ui/src/modules/positions/selectors/positions-summary.ts
+++ b/packages/augur-ui/src/modules/positions/selectors/positions-summary.ts
@@ -8,14 +8,16 @@ import {
   ZERO,
   BINARY_CATEGORICAL_FORMAT_OPTIONS,
   SCALAR,
+  REPORTING_STATE,
 } from 'modules/common/constants';
 import { formatDai, formatPercent, formatShares, formatNone } from 'utils/format-number';
 
 export const positionSummary = memoize(
-  (adjustedPosition, outcome, marketType) => {
+  (adjustedPosition, outcome, marketType, reportingState) => {
     if (!adjustedPosition) {
       return null;
     }
+
     const opts =
       marketType === SCALAR ? {} : { ...BINARY_CATEGORICAL_FORMAT_OPTIONS };
     const {
@@ -33,6 +35,7 @@ export const positionSummary = memoize(
       totalPercent,
       currentValue,
       unrealizedCost,
+      realizedCost,
       unrealizedRevenue24hChangePercent,
     } = adjustedPosition;
 
@@ -44,7 +47,8 @@ export const positionSummary = memoize(
     ) {
       type = CLOSED;
     }
-
+    const showRealizedCost =
+      reportingState === REPORTING_STATE.FINALIZED && type !== CLOSED;
     return {
       marketId,
       outcomeId,
@@ -65,7 +69,7 @@ export const positionSummary = memoize(
         timesHundred(unrealized24HrPercent || ZERO),
         { decimalsRounded: 2 }
       ),
-      totalCost: formatDai(unrealizedCost),
+      totalCost: formatDai(showRealizedCost ? realizedCost : unrealizedCost),
       totalValue: formatDai(currentValue),
       lastPrice: !!outcome.price ? formatDai(outcome.price) : formatNone(),
       totalReturns: formatDai(total || ZERO),


### PR DESCRIPTION
…decimals. show unrealized cost when market is not finalized and show realized cost when market is finalized for total cost in positions section in portfolio