### PR TITLE
scalar's average price doesn't get zero'd out when user claims, so lo…

### DIFF
--- a/packages/augur-ui/src/modules/positions/selectors/positions-summary.ts
+++ b/packages/augur-ui/src/modules/positions/selectors/positions-summary.ts
@@ -41,10 +41,7 @@ export const positionSummary = memoize(
 
     const quantity = createBigNumber(netPosition).abs();
     let type = createBigNumber(netPosition).gte('0') ? LONG : SHORT;
-    if (
-      createBigNumber(quantity).isEqualTo(ZERO) &&
-      createBigNumber(averagePrice).isEqualTo(ZERO)
-    ) {
+    if (createBigNumber(quantity).isEqualTo(ZERO)) {
       type = CLOSED;
     }
     const showRealizedCost =


### PR DESCRIPTION
…ng is shown incorrectly in type

![image](https://user-images.githubusercontent.com/3970376/78557891-40611680-77d7-11ea-8500-8bc0bee75e97.png)


fixes this issue, type is defaulted to long, needs to say closed.
![image](https://user-images.githubusercontent.com/3970376/78558136-ba919b00-77d7-11ea-8c3b-40c7119c8412.png)



