### PR TITLE
show init wallet modal on first tx

### DIFF
--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -561,6 +561,7 @@ export const MODAL_CLAIM_MARKETS_PROCEEDS = 'MODAL_CLAIM_MARKETS_PROCEEDS';
 export const MODAL_FINALIZE_MARKET = 'MODAL_FINALIZE_MARKET';
 export const MODAL_DISCARD = 'MODAL_DISCARD';
 export const DISCLAIMER_SEEN = 'disclaimerSeen';
+export const GSN_WALLET_SEEN = 'gsnWalletInfoSeen';
 export const MARKET_REVIEW_SEEN = 'marketReviewSeen';
 export const MODAL_MARKET_REVIEW = 'MODAL_MARKET_REVIEW';
 export const MODAL_OPEN_ORDERS = 'MODAL_OPEN_ORDERS';

--- a/packages/augur-ui/src/modules/create-market/components/form.tsx
+++ b/packages/augur-ui/src/modules/create-market/components/form.tsx
@@ -133,6 +133,9 @@ interface FormProps {
   marketCreationSaved: Function;
   maxMarketEndTime: number;
   GsnEnabled: boolean;
+  gsnUnavailable: boolean;
+  gsnWalletInfoSeen: boolean;
+  initializeGsnWallet: Function;
 }
 
 interface FormState {
@@ -763,6 +766,9 @@ export default class Form extends React.Component<FormProps, FormState> {
       isTemplate,
       currentTimestamp,
       GsnEnabled,
+      gsnUnavailable,
+      gsnWalletInfoSeen,
+      initializeGsnWallet,
     } = this.props;
     const { contentPages, categoryStats } = this.state;
 
@@ -811,6 +817,17 @@ export default class Form extends React.Component<FormProps, FormState> {
       validations && validations.description === draftError;
 
     const disabledNext = disabledFunction && disabledFunction(newMarket);
+
+    const createModalCallback = () => {
+      this.setState({ blockShown: true }, () => {
+        history.push({
+          pathname: makePath(MY_POSITIONS, null),
+          search: makeQuery({
+            [CREATE_MARKET_PORTFOLIO]: 3,
+          }),
+        });
+      });
+    }
 
     return (
       <div
@@ -946,16 +963,11 @@ export default class Form extends React.Component<FormProps, FormState> {
                       text="Create"
                       disabled={this.state.disableCreate}
                       action={() => {
-                        openCreateMarketModal(() => {
-                          this.setState({ blockShown: true }, () => {
-                            history.push({
-                              pathname: makePath(MY_POSITIONS, null),
-                              search: makeQuery({
-                                [CREATE_MARKET_PORTFOLIO]: 3,
-                              }),
-                            });
-                          });
-                        });
+                        gsnUnavailable && !gsnWalletInfoSeen
+                        ? initializeGsnWallet(() => setTimeout(() => {
+                          openCreateMarketModal(createModalCallback);
+                        }))
+                        : openCreateMarketModal(createModalCallback);
                       }}
                     />
                   )}

--- a/packages/augur-ui/src/modules/create-market/containers/form.ts
+++ b/packages/augur-ui/src/modules/create-market/containers/form.ts
@@ -11,22 +11,33 @@ import getValue from "utils/get-value";
 import {
   MODAL_DISCARD,
   MODAL_CREATE_MARKET,
-  ZERO
+  ZERO,
+  GSN_WALLET_SEEN,
+  MODAL_INITIALIZE_ACCOUNT
 } from "modules/common/constants";
 import { addDraft, updateDraft } from "modules/create-market/actions/update-drafts";
 import { updateModal } from "modules/modal/actions/update-modal";
 import { NodeStyleCallback } from "modules/types";
 import { marketCreationStarted, marketCreationSaved } from "services/analytics/helpers";
+import { isGSNUnavailable } from "modules/app/selectors/is-gsn-unavailable";
+import getValueFromlocalStorage from "utils/get-local-storage-value";
 
-const mapStateToProps = state => ({
-  newMarket: state.newMarket,
-  currentTimestamp: getValue(state, "blockchain.currentAugurTimestamp"),
-  drafts: state.drafts,
-  needsApproval: state.loginAccount.allowance.lte(ZERO),
-  GsnEnabled: state.appStatus.gsnEnabled,
-});
+const mapStateToProps = state => {
+  const gsnWalletInfoSeen = getValueFromlocalStorage(GSN_WALLET_SEEN);
+
+  return {
+    newMarket: state.newMarket,
+    currentTimestamp: getValue(state, "blockchain.currentAugurTimestamp"),
+    drafts: state.drafts,
+    needsApproval: state.loginAccount.allowance.lte(ZERO),
+    GsnEnabled: state.appStatus.gsnEnabled,
+    gsnUnavailable: isGSNUnavailable(state),
+    gsnWalletInfoSeen,
+  }
+}
 
 const mapDispatchToProps = dispatch => ({
+  initializeGsnWallet: (customAction = null) => dispatch(updateModal({ customAction, type: MODAL_INITIALIZE_ACCOUNT })),
   updateNewMarket: data => dispatch(updateNewMarket(data)),
   removeAllOrdersFromNewMarket: () => dispatch(removeAllOrdersFromNewMarket()),
   submitNewMarket: (data, cb) =>

--- a/packages/augur-ui/src/modules/modal/components/modal-participate.tsx
+++ b/packages/augur-ui/src/modules/modal/components/modal-participate.tsx
@@ -24,6 +24,10 @@ interface ModalParticipateProps {
   messages: AlertMessageProps[];
   title: string;
   GsnEnabled: boolean;
+  gsnWalletInfoSeen: boolean;
+  gsnUnavailable: boolean;
+  initializeGsnWallet: Function;
+
 }
 
 export const ModalParticipate = (props: ModalParticipateProps) => {
@@ -56,11 +60,20 @@ export const ModalParticipate = (props: ModalParticipateProps) => {
   }, []);
 
   const submitForm = () => {
-    const { purchaseParticipationTokens } = props;
-    purchaseParticipationTokens(quantity, false, err => {
-      if (err) console.log('ERR for purchaseParticipationTokens', err);
-      props.closeModal();
-    });
+    const { initializeGsnWallet, gsnUnavailable, gsnWalletInfoSeen, purchaseParticipationTokens } = props;
+    if (gsnUnavailable && !gsnWalletInfoSeen) {
+      initializeGsnWallet(() => {
+        purchaseParticipationTokens(quantity, false, err => {
+          if (err) console.log('ERR for purchaseParticipationTokens', err);
+          props.closeModal();
+        });
+      })
+    } else {
+      purchaseParticipationTokens(quantity, false, err => {
+        if (err) console.log('ERR for purchaseParticipationTokens', err);
+        props.closeModal();
+      });
+    }
   };
 
   const validateForm = quantity => {

--- a/packages/augur-ui/src/modules/modal/containers/modal-participate.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-participate.ts
@@ -7,22 +7,33 @@ import { AppState } from 'appStore';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
 import { getGasPrice } from 'modules/auth/selectors/get-gas-price';
+import { updateModal } from '../actions/update-modal';
+import { MODAL_INITIALIZE_ACCOUNT, GSN_WALLET_SEEN } from 'modules/common/constants';
+import { isGSNUnavailable } from 'modules/app/selectors/is-gsn-unavailable';
+import getValueFromlocalStorage from 'utils/get-local-storage-value';
 
-const mapStateToProps = (state: AppState) => ({
-  modal: state.modal,
-  rep: state.loginAccount.balances.rep,
-  gasPrice: getGasPrice(state),
-  messages: [
-    {
-      key: 'quant',
-      preText: 'Quantity (1 token @ 1 REP)',
-    },
-  ],
-  title: 'Buy Participation Tokens',
-  GsnEnabled: state.appStatus.gsnEnabled,
-});
+const mapStateToProps = (state: AppState) => {
+  const gsnWalletInfoSeen = getValueFromlocalStorage(GSN_WALLET_SEEN);
+
+  return {
+    modal: state.modal,
+    rep: state.loginAccount.balances.rep,
+    gasPrice: getGasPrice(state),
+    messages: [
+      {
+        key: 'quant',
+        preText: 'Quantity (1 token @ 1 REP)',
+      },
+    ],
+    title: 'Buy Participation Tokens',
+    GsnEnabled: state.appStatus.gsnEnabled,
+    gsnUnavailable: isGSNUnavailable(state),
+    gsnWalletInfoSeen,
+  }
+};
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({
+  initializeGsnWallet: (customAction = null) => dispatch(updateModal({ customAction, type: MODAL_INITIALIZE_ACCOUNT })),
   closeModal: () => dispatch(closeModal()),
   purchaseParticipationTokens: (amount, gasEstimate, callback) =>
     dispatch(purchaseParticipationTokens(amount, gasEstimate, callback)),

--- a/packages/augur-ui/src/modules/reporting/common.tsx
+++ b/packages/augur-ui/src/modules/reporting/common.tsx
@@ -393,6 +393,9 @@ export interface DisputingBondsViewProps {
   gasPrice: number;
   warpSyncHash: string;
   isWarpSync: boolean;
+  gsnUnavailable: boolean;
+  gsnWalletInfoSeen: boolean;
+  initializeGsnWallet: Function;
 }
 
 interface DisputingBondsViewState {
@@ -540,6 +543,9 @@ export class DisputingBondsView extends Component<
       id,
       GsnEnabled,
       warpSyncHash,
+      gsnUnavailable,
+      gsnWalletInfoSeen,
+      initializeGsnWallet,
     } = this.props;
 
     const {
@@ -609,7 +615,15 @@ export class DisputingBondsView extends Component<
         />
         <PrimaryButton
           text="Confirm"
-          action={() => reportAction(false)}
+          action={() => {
+            if (gsnUnavailable && !gsnWalletInfoSeen) {
+              initializeGsnWallet(() => {
+                reportAction(false);
+              });
+            } else {
+              reportAction(false);
+            }
+          }}
           disabled={disabled}
         />
       </div>
@@ -635,6 +649,9 @@ export interface ReportingBondsViewProps {
   openReporting: boolean;
   enoughRepBalance: boolean;
   userFunds: BigNumber;
+  gsnUnavailable: boolean;
+  gsnWalletInfoSeen: boolean;
+  initializeGsnWallet: Function;
 }
 
 interface ReportingBondsViewState {
@@ -766,6 +783,9 @@ export class ReportingBondsView extends Component<
       openReporting,
       enoughRepBalance,
       userFunds,
+      gsnUnavailable,
+      gsnWalletInfoSeen,
+      initializeGsnWallet,
     } = this.props;
 
     const {
@@ -938,7 +958,16 @@ export class ReportingBondsView extends Component<
               ? buttonDisabled || !readAndAgreedCheckbox
               : buttonDisabled
           }
-          action={() => reportAction()}
+          action={() => {
+            if (gsnUnavailable && !gsnWalletInfoSeen) {
+              initializeGsnWallet(() => {
+                reportAction();
+              });
+            } else {
+              reportAction();
+            }
+          }}
+
         />
       </div>
     );

--- a/packages/augur-ui/src/modules/reporting/containers/disputing-bonds-view.ts
+++ b/packages/augur-ui/src/modules/reporting/containers/disputing-bonds-view.ts
@@ -2,17 +2,26 @@ import { connect } from 'react-redux';
 import { DisputingBondsView } from 'modules/reporting/common';
 import { getGasPrice } from 'modules/auth/selectors/get-gas-price';
 import { AppState } from 'appStore';
+import { GSN_WALLET_SEEN, MODAL_INITIALIZE_ACCOUNT } from 'modules/common/constants';
+import { isGSNUnavailable } from 'modules/app/selectors/is-gsn-unavailable';
+import { updateModal } from 'modules/modal/actions/update-modal';
+import getValueFromlocalStorage from 'utils/get-local-storage-value';
 
 const mapStateToProps = (state: AppState) => {
+  const gsnWalletInfoSeen = getValueFromlocalStorage(GSN_WALLET_SEEN);
+
   return {
     warpSyncHash: state.universe.warpSyncHash,
     userAvailableRep: state.loginAccount.balances && state.loginAccount.balances.rep,
     GsnEnabled: state.appStatus.gsnEnabled,
     gasPrice: getGasPrice(state),
+    gsnUnavailable: isGSNUnavailable(state),
+    gsnWalletInfoSeen,
   };
 };
 
 const mapDispatchToProps = dispatch => ({
+  initializeGsnWallet: (customAction = null) => dispatch(updateModal({ customAction, type: MODAL_INITIALIZE_ACCOUNT })),
 });
 
 const DisputingBondsViewContainer = connect(

--- a/packages/augur-ui/src/modules/reporting/containers/reporting-bonds-view.ts
+++ b/packages/augur-ui/src/modules/reporting/containers/reporting-bonds-view.ts
@@ -1,11 +1,14 @@
 import { connect } from 'react-redux';
 import { ReportingBondsView } from 'modules/reporting/common';
 import { convertAttoValueToDisplayValue } from '@augurproject/sdk/src';
-import { ZERO, REPORTING_STATE } from 'modules/common/constants';
+import { ZERO, REPORTING_STATE, GSN_WALLET_SEEN, MODAL_INITIALIZE_ACCOUNT } from 'modules/common/constants';
 import { createBigNumber } from 'utils/create-big-number';
 import { AppState } from 'appStore';
 import { isSameAddress } from 'utils/isSameAddress';
 import getGasPrice from 'modules/auth/selectors/get-gas-price';
+import { isGSNUnavailable } from 'modules/app/selectors/is-gsn-unavailable';
+import { updateModal } from 'modules/modal/actions/update-modal';
+import getValueFromlocalStorage from 'utils/get-local-storage-value';
 
 const mapStateToProps = (state: AppState, ownProps) => {
   const { universe, loginAccount } = state;
@@ -21,6 +24,7 @@ const mapStateToProps = (state: AppState, ownProps) => {
   const openReporting = market.reportingState === REPORTING_STATE.OPEN_REPORTING;
   const owesRep = migrateMarket ? migrateMarket : (!openReporting && !universe.forkingInfo?.forkingMarket === market.id && !isSameAddress(market.author, loginAccount.address));
   const enoughRepBalance = owesRep ? userAttoRep.gte(createBigNumber(market.noShowBondAmount)) : true;
+  const gsnWalletInfoSeen = getValueFromlocalStorage(GSN_WALLET_SEEN);
 
   return {
     userFunds,
@@ -32,11 +36,14 @@ const mapStateToProps = (state: AppState, ownProps) => {
     GsnEnabled: state.appStatus.gsnEnabled,
     gasPrice: getGasPrice(state),
     openReporting,
-    enoughRepBalance
+    enoughRepBalance,
+    gsnUnavailable: isGSNUnavailable(state),
+    gsnWalletInfoSeen,
   };
 };
 
 const mapDispatchToProps = dispatch => ({
+  initializeGsnWallet: (customAction = null) => dispatch(updateModal({ customAction, type: MODAL_INITIALIZE_ACCOUNT })),
 });
 
 const ReportingBondsViewContainer = connect(

--- a/packages/augur-ui/src/modules/trading/components/wrapper.tsx
+++ b/packages/augur-ui/src/modules/trading/components/wrapper.tsx
@@ -49,6 +49,7 @@ interface WrapperProps {
   updateTradeCost: Function;
   updateTradeShares: Function;
   disclaimerSeen: boolean;
+  gsnWalletInfoSeen: boolean;
   gasPrice: number;
   GsnEnabled: boolean;
   hasFunds: boolean;
@@ -60,6 +61,7 @@ interface WrapperProps {
   currentTimestamp: number;
   availableDai: number;
   gsnUnavailable: boolean;
+  initializeGsnWallet: Function;
 }
 
 interface WrapperState {
@@ -443,6 +445,8 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
       hasHistory,
       availableDai,
       gsnUnavailable,
+      initializeGsnWallet,
+      gsnWalletInfoSeen,
     } = this.props;
     let {
       marketType,
@@ -489,11 +493,16 @@ class Wrapper extends Component<WrapperProps, WrapperState> {
             this.clearOrderForm();
           } else {
             if (disclaimerSeen) {
-              this.placeMarketTrade(market, selectedOutcome, this.state);
+              gsnUnavailable && !gsnWalletInfoSeen
+                ? initializeGsnWallet(() => this.placeMarketTrade(market, selectedOutcome, this.state))
+                : this.placeMarketTrade(market, selectedOutcome, this.state);
+
             } else {
               disclaimerModal({
                 onApprove: () =>
-                  this.placeMarketTrade(market, selectedOutcome, this.state),
+                  gsnUnavailable && !gsnWalletInfoSeen
+                  ? initializeGsnWallet(() => this.placeMarketTrade(market, selectedOutcome, this.state))
+                  : this.placeMarketTrade(market, selectedOutcome, this.state)
               });
             }
           }

--- a/packages/augur-ui/src/modules/trading/containers/confirm.ts
+++ b/packages/augur-ui/src/modules/trading/containers/confirm.ts
@@ -38,7 +38,7 @@ const mapStateToProps = (state: AppState, ownProps) => {
 };
 
 const mapDispatchToProps = (dispatch) => ({
-  initializeGsnWallet: () => dispatch(updateModal({ type: MODAL_INITIALIZE_ACCOUNT })),
+  initializeGsnWallet: (customAction = null) => dispatch(updateModal({ customAction, type: MODAL_INITIALIZE_ACCOUNT })),
   updateWalletStatus: () => {
     dispatch(removePendingTransaction(CREATEAUGURWALLET));
   }

--- a/packages/augur-ui/src/modules/trading/containers/wrapper.ts
+++ b/packages/augur-ui/src/modules/trading/containers/wrapper.ts
@@ -1,12 +1,13 @@
 import { connect } from 'react-redux';
 import Wrapper from 'modules/trading/components/wrapper';
-import { windowRef } from 'utils/window-ref';
 import {
   DISCLAIMER_SEEN,
   MODAL_DISCLAIMER,
   MODAL_ADD_FUNDS,
   MODAL_LOGIN,
   MODAL_SIGNUP,
+  MODAL_INITIALIZE_ACCOUNT,
+  GSN_WALLET_SEEN,
 } from 'modules/common/constants';
 import { updateModal } from 'modules/modal/actions/update-modal';
 import { getGasPrice } from 'modules/auth/selectors/get-gas-price';
@@ -23,6 +24,7 @@ import { orderSubmitted } from 'services/analytics/helpers';
 import { AppState } from 'appStore';
 import { totalTradingBalance } from 'modules/auth/selectors/login-account';
 import { isGSNUnavailable } from 'modules/app/selectors/is-gsn-unavailable';
+import getValueFromlocalStorage from 'utils/get-local-storage-value';
 
 const getMarketPath = id => {
   return {
@@ -63,6 +65,7 @@ const mapStateToProps = (state: AppState, ownProps) => {
 };
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
+  initializeGsnWallet: (customAction = null) => dispatch(updateModal({ customAction, type: MODAL_INITIALIZE_ACCOUNT })),
   handleFilledOnly: trade => null,
   updateTradeCost: (marketId, outcomeId, order, callback) =>
     dispatch(updateTradeCost({ marketId, outcomeId, ...order, callback })),
@@ -108,16 +111,15 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
 });
 
 const mergeProps = (sP, dP, oP) => {
-  const disclaimerSeen =
-    windowRef &&
-    windowRef.localStorage &&
-    windowRef.localStorage.getItem(DISCLAIMER_SEEN);
+  const disclaimerSeen = getValueFromlocalStorage(DISCLAIMER_SEEN);
+  const gsnWalletInfoSeen = getValueFromlocalStorage(GSN_WALLET_SEEN);
 
   return {
     ...oP,
     ...sP,
     ...dP,
     disclaimerSeen: !!disclaimerSeen,
+    gsnWalletInfoSeen: !!gsnWalletInfoSeen,
   };
 };
 

--- a/packages/augur-ui/src/utils/get-local-storage-value.ts
+++ b/packages/augur-ui/src/utils/get-local-storage-value.ts
@@ -1,0 +1,5 @@
+import { windowRef } from 'utils/window-ref';
+
+export default function getValueFromlocalStorage(key: string) {
+  return windowRef?.localStorage?.getItem(key);
+}

--- a/packages/contract-dependencies-gsn/src/ContractDependenciesGSN.ts
+++ b/packages/contract-dependencies-gsn/src/ContractDependenciesGSN.ts
@@ -21,7 +21,7 @@ const RELAY_HUB_ADDRESS = "0xD216153c06E857cD7f72665E0aF1d7D82172F494";
 const MIN_GAS_PRICE = new BigNumber(1e9); // Min: 1 Gwei
 const DEFAULT_GAS_PRICE = new BigNumber(4e9); // Default: GasPrice: 4 Gwei
 
-const DESIRED_SIGNER_ETH_BALANCE = `0x${new BigNumber(.1 * 10**18).toString(16)}`; // .1 ETH
+export const DESIRED_SIGNER_ETH_BALANCE = `0x${new BigNumber(.1 * 10**18).toString(16)}`; // .1 ETH
 const EXCHANGE_RATE_BUFFER_MULTIPLIER = 1.1;
 
 const OVEREAD_RELAY_GAS = 500000;


### PR DESCRIPTION
### user should see an explanation  of how transaction fees work during initial transaction #7084

- It should show up on the FIRST transaction that anyone ever does (initialize wallet or anything else).
 -- create market
 -- take trade 
 -- Dispute
 -- Report
 -- Buy PP

- It should have the following text (or similar)
![image](https://user-images.githubusercontent.com/1683736/78568710-824a8680-77f0-11ea-9b44-384e4b1a652a.png)

