### PR TITLE
added check for correct order amount based on market type, added chec…

### DIFF
--- a/packages/augur-sdk/src/api/ZeroX.ts
+++ b/packages/augur-sdk/src/api/ZeroX.ts
@@ -6,13 +6,14 @@ import { ethers } from 'ethers';
 import * as _ from 'lodash';
 import * as constants from '../constants';
 import { NULL_ADDRESS, } from '../constants';
-import { OrderEventLog, OrderEventUint256Value } from '../state/logs/types';
+import { OrderEventLog, OrderEventUint256Value, OrderType } from '../state/logs/types';
 import {
   convertDisplayAmountToOnChainAmount,
   convertDisplayPriceToOnChainPrice,
   convertOnChainAmountToDisplayAmount,
   numTicksToTickSizeWithDisplayPrices,
   QUINTILLION,
+  getTradeInterval,
 } from '../utils';
 import { Augur } from './../Augur';
 import {
@@ -326,27 +327,45 @@ export class ZeroX {
   async safePlaceOrders(params: ZeroXPlaceTradeDisplayParams[]): Promise<void> {
     if (!this.client) throw new Error('To place ZeroX trade, make sure Augur client instance was initialized with it enabled.');
     const onChainOrders = params.map((params) => ({...params, ...this.getOnChainTradeParams(params)}));
-    onChainOrders.forEach(async order => {
-      const invalidReason = await this.checkIfTradeValid(order);
-      if (invalidReason) throw new Error(invalidReason);
-    })
     const marketIds = _.keys(_.keyBy(onChainOrders, 'market'));
     const markets = await this.client.getMarketsInfo({ marketIds });
     const keyedMarkets = _.keyBy(markets, 'id');
-    Promise.all(onChainOrders.map(async order => {
+
+    const groupSorted = _.groupBy(_.sortBy(onChainOrders, ['direction', 'price']), 'direction');
+    const bestBid = _.last(groupSorted[OrderType.Bid]);
+    const bestAsk = _.first(groupSorted[OrderType.Ask]);
+    if (bestBid.price.gte(bestAsk.price)) {
+      throw new Error("Order collection has cross orderbook order(s)");
+    }
+
+    for (const order of onChainOrders) {
+      const market = keyedMarkets[order.market];
+      const maxPrice = new BigNumber(market.maxPrice);
+      const minPrice = new BigNumber(market.minPrice);
+      const displayPrice = new BigNumber(order.displayPrice);
+      if (displayPrice.gt(maxPrice) || displayPrice.lt(minPrice)) {
+        throw new Error("Order Price Out of Market Price Range");
+      }
+
+      const tradeInterval = getTradeInterval(minPrice, maxPrice, new BigNumber(market.numTicks));
+      const multipleOf = tradeInterval.dividedBy(market.tickSize).dividedBy(10 ** 18)
+      if (!order.amount.mod(multipleOf).eq(0)) {
+        throw new Error(`Order not multiple of ${multipleOf.toNumber()}`);
+      }
+
       const { orders } = await this.getMatchingOrders(
         order,
         []
       );
-      if (orders.length > 0) throw new Error("Order would cross Orderbook spread");
-      const market = keyedMarkets[order.market];
-      const maxPrice = new BigNumber(market.maxPrice);
-      const minPrice = new BigNumber(market.minPrice);
-      const price = new BigNumber(order.displayPrice);
-      if (price.gt(maxPrice) || price.lt(minPrice)) throw new Error("Order Price Out of Market Price Range");
-    })).then(async () => {
-      return await this.placeOnChainOrders(onChainOrders);
-    });
+      if (orders.length > 0) {
+        throw new Error("Order would cross Orderbook spread");
+      }
+
+      const invalidReason = await this.checkIfTradeValid(order);
+      if (invalidReason) throw new Error(invalidReason);
+    };
+
+    return await this.placeOnChainOrders(onChainOrders);
   }
 
   async placeOrder(params: ZeroXPlaceTradeDisplayParams): Promise<void> {

--- a/packages/augur-tools/src/libs/contract-api.ts
+++ b/packages/augur-tools/src/libs/contract-api.ts
@@ -243,6 +243,10 @@ export class ContractAPI {
     await this.augur.zeroX.placeOrders(params);
   }
 
+  async safePlaceOrders(params: ZeroXPlaceTradeDisplayParams[]): Promise<void> {
+    await this.augur.zeroX.safePlaceOrders(params);
+  }
+
   async placeZeroXTrade(params: ZeroXPlaceTradeDisplayParams): Promise<void> {
     const price = params.direction === 0 ? params.displayPrice : params.numTicks.minus(params.displayPrice);
     const cost = params.displayAmount.multipliedBy(price).multipliedBy(10**18);


### PR DESCRIPTION
…k for passed in orders cross it's own spread

Now `safePlaceOrders` throws for these reasons
1. `Order collection has cross orderbook order(s)`
2. `Order Price Out of Market Price Range`
3. `Order not multiple of ...`
4. `Order would cross Orderbook spread`
5.  invalid zerox order