### PR TITLE
issue because of recent change to add percentages to open orders for …

### DIFF
--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -436,6 +436,8 @@ export const PRICE_WIDTH_DEFAULT = 0.1;
 export const PRICE_WIDTH_MIN = 0.01;
 export const PRICE_DEPTH_DEFAULT = 0.1; // Not used yet
 export const IS_SIMULATION = false; // Not used yet
+export const DEFAULT_MIN_PRICE = 0;
+export const DEFAULT_MAX_PRICE = 100;
 
 // # Permissible Periods
 // Note: times are in seconds

--- a/packages/augur-ui/src/modules/portfolio/containers/open-order.ts
+++ b/packages/augur-ui/src/modules/portfolio/containers/open-order.ts
@@ -13,6 +13,7 @@ import { selectCancelingOrdersState } from 'appStore/select-state';
 import { removeCanceledOrder } from 'modules/pending-queue/actions/pending-queue-management';
 import { removePendingOrder } from 'modules/orders/actions/pending-orders-management';
 import { calcPercentageFromPrice } from 'utils/format-number';
+import { MIN_PRICE } from 'modules/create-market/constants';
 
 const { COLUMN_TYPES } = constants;
 
@@ -20,15 +21,22 @@ const mapStateToProps = (state: AppState, ownProps) => {
   const { blockchain, marketInfos} = state;
   const { openOrder, marketId }  = ownProps;
   const market = marketInfos[marketId];
-  const { outcomeId } = openOrder;
-  const usePercent = !!market && outcomeId === constants.INVALID_OUTCOME_ID && market.marketType === constants.SCALAR;
+  let usePercent = false;
+  const minPrice = market ? market.minPrice : constants.DEFAULT_MIN_PRICE;
+  const maxPrice = market ? market.maxPrice : constants.DEFAULT_MAX_PRICE;
+  const marketType = market ? market.marketType : constants.YES_NO;
+  if (market) {
+    const { outcomeId } = openOrder;
+    usePercent = !!market && outcomeId === constants.INVALID_OUTCOME_ID && market.marketType === constants.SCALAR;
+  }
+
   return {
     currentTimestamp: blockchain.currentAugurTimestamp,
     pendingOrderCancellations: selectCancelingOrdersState(state),
     usePercent,
-    marketType: market.marketType,
-    minPrice: market && market.minPrice,
-    maxPrice: market && market.maxPrice,
+    marketType,
+    minPrice,
+    maxPrice,
   }
 };
 


### PR DESCRIPTION
…scalar markets, which broke market preview b/c there isnt a marketId to look up. this PR defaults to YesNo if marketId is undefined. won't effect market preview for scalar markets since user can't click on Invalid outcome in preview.


![image](https://user-images.githubusercontent.com/3970376/78893384-e3609d00-7a30-11ea-809e-207079685905.png)
