### PR TITLE
Realized P/L and 3box comments were not showing for mobile

### DIFF
--- a/packages/augur-ui/src/modules/common/row.styles.less
+++ b/packages/augur-ui/src/modules/common/row.styles.less
@@ -22,7 +22,7 @@
 
     > span > label {
       .mono-10-bold;
-      
+
       margin-bottom: 0;
     }
 
@@ -335,7 +335,6 @@ div.SingleRow3 {
 
       &:last-of-type {
         > button,
-        > span,
         > div {
           display: none;
         }
@@ -449,7 +448,7 @@ div.SingleRow3 {
 
     > li {
       align-items: flex-end;
-      
+
       &:first-of-type {
         grid-column: unset;
         margin-bottom: 0;

--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -773,9 +773,7 @@ export default class MarketView extends Component<
                     </div>
                   </ModulePane>
                 </ModuleTabs>
-                {pane !== 'Market Info' && (
-                  <MarketComments marketId={marketId} networkId={networkId} />
-                )}
+                <MarketComments marketId={marketId} networkId={networkId} />
               </>
             ) : (
               <>


### PR DESCRIPTION
#7161

Chwy and I weren't able to reproduce the whole page being cut off but Chwy pointed a few things that were hidden/not showing, so I just added those to this ticket.
Realized PnL was hidden on mobile.
3box comment component was removed for market info tab.

![Captura de Tela 2020-04-09 às 10 11 24](https://user-images.githubusercontent.com/10351013/78899377-b53c8680-7a4b-11ea-94f7-ea51ace9c985.png)

![Captura de Tela 2020-04-09 às 10 21 07](https://user-images.githubusercontent.com/10351013/78899567-f92f8b80-7a4b-11ea-8a6c-47d793f34089.png)
