### PR TITLE
Ignore finalized pre load history

### DIFF
--- a/packages/augur-sdk/src/state/getter/Users.ts
+++ b/packages/augur-sdk/src/state/getter/Users.ts
@@ -62,6 +62,7 @@ const getProfitLossSummaryParams = t.partial({
   universe: t.string,
   account: t.string,
   endTime: t.number,
+  ignoreFinalizedMarkets: t.boolean
 });
 
 const getProfitLossParams = t.intersection([
@@ -70,6 +71,7 @@ const getProfitLossParams = t.intersection([
     startTime: t.number,
     periodInterval: t.number,
     outcome: t.number,
+    ignoreFinalizedMarkets: t.boolean,
   }),
 ]);
 
@@ -238,13 +240,19 @@ export class Users {
     let userPositions: UserTradingPositions = null;
     let userStakedRep: AccountReportingHistory = null;
 
+    marketList = await Markets.getMarkets(augur, db, {
+      creator: params.account,
+      universe: params.universe,
+    });
+
     userTradeHistory = await OnChainTrading.getTradingHistory(augur, db, {
       account: params.account,
       universe: params.universe,
       filterFinalized: true,
     });
 
-    const uniqMarketIds = Object.keys(userTradeHistory);
+    const userCreateMarketIds = _.map(marketList.markets, 'id');
+    const uniqMarketIds = Object.keys(userTradeHistory).concat(userCreateMarketIds);
 
     if (uniqMarketIds.length > 0) {
       marketTradeHistory = await OnChainTrading.getTradingHistory(augur, db, {
@@ -259,12 +267,6 @@ export class Users {
 
     userOpenOrders = await Users.getUserOpenOrders(augur, db, {
       account: params.account,
-      universe: params.universe,
-    });
-
-    marketList = await Markets.getMarkets(augur, db, {
-      creator: params.account,
-      designatedReporter: params.account,
       universe: params.universe,
     });
 
@@ -939,6 +941,7 @@ export class Users {
     profitLossSummary = await Users.getProfitLossSummary(augur, db, {
       universe,
       account: params.account,
+      ignoreFinalizedMarkets: true,
     });
 
     return {
@@ -1032,6 +1035,7 @@ export class Users {
         "'getProfitLoss' requires a 'startTime' param be provided"
       );
     }
+    const ignoreFinalizedMarkets = params.ignoreFinalizedMarkets;
     const now = await augur.contracts.augur.getTimestamp_();
     const startTime = params.startTime!;
     const endTime = params.endTime || now.toNumber();
@@ -1116,7 +1120,7 @@ export class Users {
                 ordersFilledResultsByMarketAndOutcome[marketId] &&
                 ordersFilledResultsByMarketAndOutcome[marketId][outcome]
               ) || finalized;
-              if (!latestOutcomePLValue || !hasOutcomeValues) {
+              if (!latestOutcomePLValue || !hasOutcomeValues || (ignoreFinalizedMarkets && finalized)) {
                 return {
                   timestamp: bucketTimestamp.toNumber(),
                   frozenFunds: '0',
@@ -1204,6 +1208,7 @@ export class Users {
           startTime,
           endTime,
           periodInterval,
+          ignoreFinalizedMarkets: params.ignoreFinalizedMarkets
         }
       );
 

--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -47,7 +47,6 @@ import {
   SUBMIT_DISPUTE,
   CLAIMMARKETSPROCEEDS,
   DISAVOWCROWDSOURCERS,
-  REDEEMDISPUTINGSTAKE,
   MARKETMIGRATED,
 } from 'modules/common/constants';
 import { loadAccountReportingHistory } from 'modules/auth/actions/load-account-reporting';
@@ -55,7 +54,6 @@ import { loadDisputeWindow } from 'modules/auth/actions/load-dispute-window';
 import {
   isOnDisputingPage,
   isOnReportingPage,
-  isOnTradePage,
 } from 'modules/trades/helpers/is-on-page';
 import {
   reloadDisputingPage,
@@ -281,9 +279,9 @@ export const handleReportingStateChanged = (event: any) => (
 ) => {
   if (event.data) {
     const marketIds = _.map(event.data, 'market');
-    dispatch(loadMarketsInfo(marketIds));
     if (isOnDisputingPage()) dispatch(reloadDisputingPage(marketIds));
     if (isOnReportingPage()) dispatch(reloadReportingPage(marketIds));
+    dispatch(checkUpdateUserPositions(marketIds));
   }
 };
 

--- a/packages/augur-ui/src/modules/markets/selectors/user-markets.ts
+++ b/packages/augur-ui/src/modules/markets/selectors/user-markets.ts
@@ -10,6 +10,7 @@ import selectAllMarkets from "modules/markets/selectors/markets-all";
 import { getLastTradeTimestamp } from "modules/portfolio/helpers/get-last-trade-timestamp";
 import { isSameAddress } from "utils/isSameAddress";
 import { generateTxParameterId } from 'utils/generate-tx-parameter-id';
+import { formatDate } from "utils/format-date";
 
 export const selectAuthorOwnedMarkets = createSelector(
   selectAllMarkets,
@@ -33,13 +34,18 @@ export const selectAuthorOwnedMarkets = createSelector(
       const pendingTradedId = m.transactionHash || generateTxParameterId(m.txParams);
       const marketId = m.id || pendingTradedId;
       const recentlyTraded = getLastTradeTimestamp(marketTradingHistory[marketId]);
+      const hasTradeHistory = (marketTradingHistory[marketId] || []).length > 0;
       return {
         ...m,
         hasPendingLiquidityOrders: !!pendingLiquidityOrders[pendingTradedId],
         orderBook: pendingLiquidityOrders[marketId],
         recentlyTraded,
-        recentlyDepleted: m.passDefaultLiquiditySpread ? recentlyTraded : ZERO,
-      }
+        recentlyDepleted: !m.passDefaultLiquiditySpread
+          ? hasTradeHistory
+            ? recentlyTraded
+            : m.creationTimeFormatted
+          : formatDate(ZERO),
+      };
     });
   }
 );

--- a/packages/augur-ui/src/modules/portfolio/components/markets/markets.tsx
+++ b/packages/augur-ui/src/modules/portfolio/components/markets/markets.tsx
@@ -42,7 +42,7 @@ const sortByOptions = [
     value: 'recentlyDepleted',
     comp(marketA, marketB) {
       return (
-        marketB.recentlyTraded.timestamp - marketA.recentlyTraded.timestamp
+        marketB.recentlyDepleted.timestamp - marketA.recentlyDepleted.timestamp
       );
     },
   },
@@ -175,6 +175,7 @@ class MyMarkets extends Component<MyMarketsProps> {
           'description',
           'reportingState',
           'recentlyTraded',
+          'recentlyDepleted',
           'creationTime',
           'endTime',
         ]}


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/6919
https://github.com/AugurProject/augur/issues/7251

1. filter markets in awaiting finalization and finalized when calculating user's 24 hour unrealized.
2. fix recently depleted sort in my markets section of portfolio.