### PR TITLE
hide notice if returning to trading page

### DIFF
--- a/packages/augur-ui/src/modules/trading/components/confirm.tsx
+++ b/packages/augur-ui/src/modules/trading/components/confirm.tsx
@@ -95,6 +95,12 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
     this.clearErrorMessage = this.clearErrorMessage.bind(this);
   }
 
+  componentDidMount() {
+    if (this.props.walletStatus === WALLET_STATUS_VALUES.CREATED && this.props.sweepStatus === TXEventName.Success) {
+      this.props.updateWalletStatus();
+    }
+  }
+
   componentDidUpdate(prevProps) {
     const {
       trade,


### PR DESCRIPTION
Initialized account via taking an order off the books but I'm still getting this confirmed message on every market I visit #7127

-- We will now remove the message (if it is shown) we when navigate to the trading page. 