### PR TITLE
create component to display when user has not initialized their accou…

### DIFF
--- a/packages/augur-ui/src/modules/common/labels.styles.less
+++ b/packages/augur-ui/src/modules/common/labels.styles.less
@@ -892,6 +892,14 @@ span.PendingLabel {
   }
 }
 
+.ModalMessageLabelInitWallet {
+  margin: unset;
+
+  @media @breakpoint-mobile {
+    margin: unset;
+  }
+}
+
 .MarketLabel {
   .text-12-semi-bold;
 

--- a/packages/augur-ui/src/modules/common/labels.tsx
+++ b/packages/augur-ui/src/modules/common/labels.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 import * as constants from 'modules/common/constants';
 import Styles from 'modules/common/labels.styles.less';
@@ -34,7 +35,6 @@ import {
   DISCORD_LINK,
   ACCOUNT_TYPES,
   CLOSED_SHORT,
-  CLOSED_LONG,
 } from 'modules/common/constants';
 import { ViewTransactionDetailsButton } from 'modules/common/buttons';
 import { formatNumber } from 'utils/format-number';
@@ -51,7 +51,8 @@ import { hasTemplateTextInputs } from '@augurproject/artifacts';
 import { getDurationBetween } from 'utils/format-date';
 import { useTimer } from 'modules/common/progress';
 import { Market } from 'modules/portfolio/components/common/market-row';
-import { AsyncBooleanResultCallback } from 'async';
+import { isGSNUnavailable } from 'modules/app/selectors/is-gsn-unavailable';
+import { AppState } from 'appStore';
 
 export interface MarketTypeProps {
   marketType: string;
@@ -1375,11 +1376,33 @@ export const BulkTxLabel = ({
     </div>
   ) : null;
 
-export const InsufficientModalLabel = (props: DismissableNoticeProps) => (
+export const ModalLabelNotice = (props: DismissableNoticeProps) => (
   <div className={classNames(Styles.ModalMessageLabel)}>
     <DismissableNotice {...props} />
   </div>
 );
+
+const mapStateToPropsInitWalletModal = (state: AppState) => ({
+  gsnUnavailable: isGSNUnavailable(state),
+});
+
+const InitializeWalletModalNoticeCmp = ({ gsnUnavailable }) => (
+  <>
+    {gsnUnavailable && (
+      <div className={classNames(Styles.ModalMessageLabelInitWallet)}>
+        <DismissableNotice
+          show
+          buttonType={DISMISSABLE_NOTICE_BUTTON_TYPES.NONE}
+          title={`The fee displayed is high than normal because it includes a one time only account initialization.`}
+        />
+      </div>
+    )}
+  </>
+);
+
+export const InitializeWalletModalNotice = connect(
+  mapStateToPropsInitWalletModal
+)(InitializeWalletModalNoticeCmp);
 
 export const ValueDenomination: React.FC<ValueDenominationProps> = ({
   className,

--- a/packages/augur-ui/src/modules/modal/components/modal-participate.tsx
+++ b/packages/augur-ui/src/modules/modal/components/modal-participate.tsx
@@ -16,6 +16,7 @@ import {
   Breakdown,
 } from '../common';
 import { displayGasInDai } from 'modules/app/actions/get-ethToDai-rate';
+import { InitializeWalletModalNotice } from 'modules/common/labels';
 
 interface ModalParticipateProps {
   rep: string;
@@ -153,6 +154,7 @@ export const ModalParticipate = (props: ModalParticipateProps) => {
           innerLabel={REP}
         />
         <Breakdown rows={items} />
+        <InitializeWalletModalNotice />
       </div>
       <ModalActions
         buttons={[

--- a/packages/augur-ui/src/modules/modal/containers/modal-participate.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-participate.ts
@@ -12,7 +12,7 @@ import { isGSNUnavailable } from 'modules/app/selectors/is-gsn-unavailable';
 import getValueFromlocalStorage from 'utils/get-local-storage-value';
 
 const mapStateToProps = (state: AppState) => {
-  const gsnWalletInfoSeen = getValueFromlocalStorage(GSN_WALLET_SEEN);
+  const gsnWalletInfoSeen = getValueFromlocalStorage(GSN_WALLET_SEEN) === "true" ? true : false;
 
   return {
     modal: state.modal,

--- a/packages/augur-ui/src/modules/modal/unsigned-orders.tsx
+++ b/packages/augur-ui/src/modules/modal/unsigned-orders.tsx
@@ -15,7 +15,7 @@ import {
   Breakdown,
 } from "modules/modal/common";
 import {
-  LinearPropertyLabelProps, PendingLabel, BulkTxLabel, InsufficientModalLabel,
+  LinearPropertyLabelProps, PendingLabel, BulkTxLabel, ModalLabelNotice,
 } from "modules/common/labels";
 import { BUY } from "modules/common/constants";
 import { formatShares, formatDai } from "utils/format-number";
@@ -148,7 +148,7 @@ export const UnsignedOrders = (props: UnsignedOrdersProps) => (
       {props.breakdown && <Breakdown rows={props.breakdown} short />}
     </main>
     <BulkTxLabel buttonName={"Submit All"} count={props.submitAllTxCount} needsApproval={props.needsApproval}/>
-    {props.insufficientFunds && <InsufficientModalLabel
+    {props.insufficientFunds && <ModalLabelNotice
       show
       buttonType={DISMISSABLE_NOTICE_BUTTON_TYPES.NONE}
       title={`You do not have enough DAI to place ${props.submitAllTxCount > 1 ? 'these orders' : 'this order'}`}

--- a/packages/augur-ui/src/modules/reporting/common.tsx
+++ b/packages/augur-ui/src/modules/reporting/common.tsx
@@ -38,6 +38,7 @@ import {
   RepBalance,
   MovementLabel,
   InReportingLabel,
+  InitializeWalletModalNotice,
 } from 'modules/common/labels';
 import { ButtonActionType } from 'modules/types';
 import {
@@ -619,6 +620,7 @@ export class DisputingBondsView extends Component<
           label={GsnEnabled ? 'Transaction Fee' : 'Gas Fee'}
           value={displayGasInDai(gasEstimate)}
         />
+        <InitializeWalletModalNotice />
         <PrimaryButton
           text="Confirm"
           action={() => {
@@ -921,6 +923,7 @@ export class ReportingBondsView extends Component<
               Insufficient Funds to complete transaction
             </span>
           )}
+          <InitializeWalletModalNotice />
         </div>
 
         {migrateRep &&


### PR DESCRIPTION
…nt (wallet) and the transaction fee is really high


![image](https://user-images.githubusercontent.com/3970376/79278052-946f9900-7e70-11ea-8ed7-a98e32b679f9.png)


![Screen Shot 2020-04-14 at 4 52 16 PM](https://user-images.githubusercontent.com/3970376/79277919-5bcfbf80-7e70-11ea-9aae-f40a3d2e801b.png)
![Screen Shot 2020-04-14 at 4 52 12 PM](https://user-images.githubusercontent.com/3970376/79277921-5e321980-7e70-11ea-94b6-427b228cad59.png)



![Screen Shot 2020-04-14 at 4 51 47 PM](https://user-images.githubusercontent.com/3970376/79277929-612d0a00-7e70-11ea-8676-9c9bd8e49306.png)

![Screen Shot 2020-04-14 at 4 51 39 PM](https://user-images.githubusercontent.com/3970376/79277934-64c09100-7e70-11ea-86d9-44f2627ad15e.png)


![Screen Shot 2020-04-14 at 4 50 02 PM](https://user-images.githubusercontent.com/3970376/79277943-67bb8180-7e70-11ea-9ce7-b71c1ff4c3a9.png)


![Screen Shot 2020-04-14 at 4 49 23 PM](https://user-images.githubusercontent.com/3970376/79277954-6ab67200-7e70-11ea-8499-509e859629af.png)



![Screen Shot 2020-04-14 at 4 46 23 PM](https://user-images.githubusercontent.com/3970376/79277975-76099d80-7e70-11ea-85f9-8902c9b64a22.png)


![Screen Shot 2020-04-14 at 4 46 03 PM](https://user-images.githubusercontent.com/3970376/79277983-7ace5180-7e70-11ea-93fa-3e15fd544d4d.png)

![Screen Shot 2020-04-14 at 4 45 50 PM](https://user-images.githubusercontent.com/3970376/79277994-7f930580-7e70-11ea-8fbe-2924f1b11d74.png)
