### PR TITLE
Move to Alchemy v2 endpoints

### DIFF
--- a/infra/modules/service-0x/main.tf
+++ b/infra/modules/service-0x/main.tf
@@ -153,7 +153,7 @@ module "task-0x-mesh-rpc" {
     },
     {
       name : "ETHEREUM_RPC_URL",
-      value : "https://eth-kovan.alchemyapi.io/jsonrpc/Kd37_uEmJGwU6pYq6jrXaJXXi8u9IoOM"
+      value : "https://eth-kovan.alchemyapi.io/v2/Kd37_uEmJGwU6pYq6jrXaJXXi8u9IoOM"
     },
     {
       name : "HTTP_RPC_ADDR",

--- a/infra/modules/service-gnosis/main.tf
+++ b/infra/modules/service-gnosis/main.tf
@@ -108,7 +108,7 @@ module "task-gnosis-web" {
     },
     {
       name : "ETHEREUM_NODE_URL",
-      value : "https://eth-kovan.alchemyapi.io/jsonrpc/Kd37_uEmJGwU6pYq6jrXaJXXi8u9IoOM"
+      value : "https://eth-kovan.alchemyapi.io/v2/Kd37_uEmJGwU6pYq6jrXaJXXi8u9IoOM"
     },
     {
       name : "PYTHONPATH",
@@ -342,7 +342,7 @@ module "task-gnosis-scheduler" {
     },
     {
       name : "ETHEREUM_NODE_URL",
-      value : "https://eth-kovan.alchemyapi.io/jsonrpc/Kd37_uEmJGwU6pYq6jrXaJXXi8u9IoOM"
+      value : "https://eth-kovan.alchemyapi.io/v2/Kd37_uEmJGwU6pYq6jrXaJXXi8u9IoOM"
     },
     {
       name : "PYTHONPATH",

--- a/packages/augur-artifacts/src/environments/demo.json
+++ b/packages/augur-artifacts/src/environments/demo.json
@@ -1,7 +1,7 @@
 {
   "networkId": "42",
   "ethereum": {
-    "http": "https://eth-kovan.alchemyapi.io/jsonrpc/1FomA6seLdWDvpIRvL9J5NhwPHLIGbWA",
+    "http": "https://eth-kovan.alchemyapi.io/v2/1FomA6seLdWDvpIRvL9J5NhwPHLIGbWA",
     "rpcRetryCount": 5,
     "rpcRetryInterval": 0,
     "rpcConcurrency": 40

--- a/packages/augur-artifacts/src/environments/kovan.json
+++ b/packages/augur-artifacts/src/environments/kovan.json
@@ -1,7 +1,7 @@
 {
   "networkId": "42",
   "ethereum": {
-    "http": "https://eth-kovan.alchemyapi.io/jsonrpc/1FomA6seLdWDvpIRvL9J5NhwPHLIGbWA",
+    "http": "https://eth-kovan.alchemyapi.io/v2/1FomA6seLdWDvpIRvL9J5NhwPHLIGbWA",
     "rpcRetryCount": 5,
     "rpcRetryInterval": 0,
     "rpcConcurrency": 40

--- a/packages/augur-artifacts/src/environments/mainnet.json
+++ b/packages/augur-artifacts/src/environments/mainnet.json
@@ -1,7 +1,7 @@
 {
   "networkId": "1",
   "ethereum": {
-    "http": "https://eth-mainnet.alchemyapi.io/jsonrpc/Kd37_uEmJGwU6pYq6jrXaJXXi8u9IoOM",
+    "http": "https://eth-mainnet.alchemyapi.io/v2/Kd37_uEmJGwU6pYq6jrXaJXXi8u9IoOM",
     "rpcRetryCount": 5,
     "rpcRetryInterval": 0,
     "rpcConcurrency": 40

--- a/packages/augur-artifacts/src/networks.json
+++ b/packages/augur-artifacts/src/networks.json
@@ -1,3 +1,3 @@
 {
-  "4": "https://eth-rinkeby.alchemyapi.io/jsonrpc/Kd37_uEmJGwU6pYq6jrXaJXXi8u9IoOM"
+  "4": "https://eth-rinkeby.alchemyapi.io/v2/Kd37_uEmJGwU6pYq6jrXaJXXi8u9IoOM"
 }

--- a/packages/augur-sdk/package.json
+++ b/packages/augur-sdk/package.json
@@ -21,7 +21,7 @@
     "rebuild": "yarn clean && yarn build",
     "clean-start": "yarn rebuild && yarn start",
     "clean-start-local": "yarn rebuild && ETHEREUM_HTTP=http://127.0.0.1:8545 ETHEREUM_WS=ws://127.0.0.1:8546 yarn start",
-    "start-kovan": "ETHEREUM_HTTP=https://eth-kovan.alchemyapi.io/jsonrpc/1FomA6seLdWDvpIRvL9J5NhwPHLIGbWA yarn start",
+    "start-kovan": "ETHEREUM_HTTP=https://eth-kovan.alchemyapi.io/v2/1FomA6seLdWDvpIRvL9J5NhwPHLIGbWA yarn start",
     "build:documentation": "yarn typedoc --theme markdown --mdDocusaurus --disableOutputCheck --ignoreCompilerErrors --out ../../docs/v2/docs/sdk ./src",
     "check": "gts check",
     "fix": "gts fix"

--- a/packages/augur-sdk/src/state/settings.json
+++ b/packages/augur-sdk/src/state/settings.json
@@ -2,8 +2,8 @@
     "blockstreamDelay": 10,
     "chunkSize": 100000,
     "ethNodeURLs": {
-        "4": "https://eth-rinkeby.alchemyapi.io/jsonrpc/Kd37_uEmJGwU6pYq6jrXaJXXi8u9IoOM",
-        "42": "https://eth-kovan.alchemyapi.io/jsonrpc/1FomA6seLdWDvpIRvL9J5NhwPHLIGbWA"
+        "4": "https://eth-rinkeby.alchemyapi.io/v2/Kd37_uEmJGwU6pYq6jrXaJXXi8u9IoOM",
+        "42": "https://eth-kovan.alchemyapi.io/v2/1FomA6seLdWDvpIRvL9J5NhwPHLIGbWA"
     },
     "meshClientURLs": {
         "12346": "ws://localhost:60557",


### PR DESCRIPTION
Change all references to alchemy URLs to use their v2 endpoints. These
wont really be used in the UI but are still relevant for the infra that
is being run for demo.