### PR TITLE
if user doesn't have eth in account don't show ETH as a swap option. …

### DIFF
--- a/packages/augur-ui/src/modules/swap/components/swap.tsx
+++ b/packages/augur-ui/src/modules/swap/components/swap.tsx
@@ -7,6 +7,7 @@ import {
   TRANSACTIONS,
   SWAPEXACTTOKENSFORTOKENS,
   SWAPETHFOREXACTTOKENS,
+  ZERO,
 } from 'modules/common/constants';
 import { AccountBalances, FormattedNumber } from 'modules/types';
 import {
@@ -45,7 +46,7 @@ export const Swap = ({
   REP_RATE,
 }: SwapProps) => {
 
-
+  const hasEth = createBigNumber(balances.eth).gt(ZERO);
   let formattedInputAmount: FormattedNumber;
   let outputAmount: FormattedNumber = formatEther(0);
 
@@ -108,17 +109,18 @@ export const Swap = ({
     setErrorMessage('');
     if (fromToken === REP) {
       if (fromTokenType === REP) {
-        setFromTokenType(ETH);
+        hasEth ? setFromTokenType(ETH) : REP;
       } else {
         setFromTokenType(REP);
       }
     } else if (fromToken === DAI) {
       if (fromTokenType === DAI) {
-        setFromTokenType(ETH);
+        hasEth ? setFromTokenType(ETH) : DAI;
       } else {
         setFromTokenType(DAI);
       }
     }
+    clearForm()
   }
 
   if (fromTokenType === DAI) {
@@ -158,7 +160,7 @@ export const Swap = ({
           amount={formatEther(inputAmount)}
           token={fromTokenType}
           label={'Input'}
-          showChevron={true}
+          showChevron={hasEth}
           balance={formattedInputAmount}
           logo={
             fromTokenType === DAI


### PR DESCRIPTION
…also clear swap inputs when user switches from token

https://github.com/AugurProject/augur/issues/7300

![2020-04-17 07 18 41](https://user-images.githubusercontent.com/3970376/79568796-20a1dc00-807c-11ea-80ba-06b897416fd2.gif)


![Screen Shot 2020-04-17 at 7 15 09 AM](https://user-images.githubusercontent.com/3970376/79568803-27305380-807c-11ea-9f42-3bc2362719ef.png)
![Screen Shot 2020-04-17 at 7 15 05 AM](https://user-images.githubusercontent.com/3970376/79568808-28fa1700-807c-11ea-861d-8384b1abccce.png)

when user doesn't have ETH
![Screen Shot 2020-04-17 at 7 14 16 AM](https://user-images.githubusercontent.com/3970376/79568817-2d263480-807c-11ea-864c-5a46121d67fb.png)
![Screen Shot 2020-04-17 at 7 14 03 AM](https://user-images.githubusercontent.com/3970376/79568824-2eeff800-807c-11ea-9472-60989ed1d84c.png)


