### PR TITLE
using wrong property from state props in merge props

### DIFF
--- a/packages/augur-ui/src/modules/create-market/containers/initial-liquidity.ts
+++ b/packages/augur-ui/src/modules/create-market/containers/initial-liquidity.ts
@@ -1,9 +1,7 @@
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
-import getValue from 'utils/get-value';
 import { AppState } from 'appStore';
 import * as constants from 'modules/common/constants';
-import { formatShares, formatDai, formatScalarShares, formatMarketShares } from 'utils/format-number';
+import { formatDai, formatMarketShares } from 'utils/format-number';
 import Row from 'modules/common/row';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
@@ -36,7 +34,7 @@ const mergeProps = (sP: any, dP: any, oP: any) => {
     {
       key: 'quantity',
       columnType: COLUMN_TYPES.VALUE,
-      value: formatMarketShares(sP.market.marketType, order.quantity),
+      value: formatMarketShares(sP.newMarket.marketType, order.quantity),
       keyId: 'order-quantity-' + order.id,
     },
     {


### PR DESCRIPTION
fix blow up in pre-liqudity from making quantity format changes.