### PR TITLE
update wallet error messages

### DIFF
--- a/packages/augur-ui/src/modules/auth/actions/login-with-portis.ts
+++ b/packages/augur-ui/src/modules/auth/actions/login-with-portis.ts
@@ -14,9 +14,9 @@ import { updateModal } from 'modules/modal/actions/update-modal';
 import { AppState } from 'appStore';
 import { getNetwork } from 'utils/get-network-name';
 
- export const loginWithPortis = (forceRegisterPage = false) => async (
+export const loginWithPortis = (forceRegisterPage = false) => async (
   dispatch: ThunkDispatch<void, any, Action>,
-  getState: () => AppState,
+  getState: () => AppState
 ) => {
   const useGSN = getState().env['gsn']?.enabled;
   const networkId: string = getState().env['networkId'];
@@ -32,10 +32,14 @@ import { getNetwork } from 'utils/get-network-name';
       // to conditionally load web3 into the DOM
       const Portis = require('@portis/web3');
       const Web3 = require('web3');
-      const portis = new Portis(PORTIS_API_KEY, portisNetwork === 'localhost' ? localPortisNetwork : portisNetwork, {
-        scope: ['email'],
-        registerPageByDefault: forceRegisterPage,
-      });
+      const portis = new Portis(
+        PORTIS_API_KEY,
+        portisNetwork === 'localhost' ? localPortisNetwork : portisNetwork,
+        {
+          scope: ['email'],
+          registerPageByDefault: forceRegisterPage,
+        }
+      );
 
       const web3 = new Web3(portis.provider);
       const provider = new PersonalSigningWeb3Provider(portis.provider);
@@ -62,27 +66,35 @@ import { getNetwork } from 'utils/get-network-name';
       };
 
       portis.onLogin((account, email) => {
-          initPortis(portis, account, email);
+        initPortis(portis, account, email);
       });
 
       portis.onError(error => {
         document.querySelector('.por_portis-container').remove();
-
-        if (error.message && error.message.toLowerCase().indexOf('cookies') !== -1) {
+        if (
+          error.message &&
+          error.message.toLowerCase().indexOf('cookies') !== -1
+        ) {
           dispatch(
             updateModal({
               type: MODAL_ERROR,
               title: 'Cookies are disabled',
-              error: 'Please enable cookies in your browser to proceed with Portis.',
+              error:
+                'Please enable cookies in your browser to proceed with Portis.',
               link: HELP_CENTER_THIRD_PARTY_COOKIES,
-              linkLabel: 'Learn more.'
+              linkLabel: 'Learn more.',
             })
           );
         } else {
+          const errorMessage = `There was an error while attempting to log in with Portis. Please try again, and if it is still not working checkout the help center for logging in.\n\n${
+            error.message
+              ? `Error: ${JSON.stringify(error.message)}`
+              : ''
+          }`;
           dispatch(
             updateModal({
               type: MODAL_ERROR,
-              error: JSON.stringify(error && error.message ? error.message : 'Sorry, something went wrong.'),
+              error: errorMessage,
             })
           );
         }

--- a/packages/augur-ui/src/modules/modal/containers/modal-signin.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-signin.ts
@@ -78,10 +78,24 @@ const mergeProps = (sP: any, dP: any, oP: any) => {
 
   const onError = (error, accountType) => {
     console.error(`ERROR:${accountType}`, error);
-    if (error.message && error.message.toLowerCase().indexOf('cookies') !== -1) {
+
+    const isPortisCancelError = accountType === ACCOUNT_TYPES.PORTIS && error.message.indexOf('User denied login') !== -1;
+    const isFortmaticCancelError =  accountType === ACCOUNT_TYPES.FORTMATIC &&  error.message.indexOf('User denied account access') !== -1;
+    const isTorusExitCancelError = accountType === ACCOUNT_TYPES.TORUS &&  error.indexOf('user closed popup') !== -1;
+
+    // If the error we get back from the wallet SDK is "User denied access", aka Cancel/Close wallet window, we should just close the modal
+    if (isTorusExitCancelError || isPortisCancelError || isFortmaticCancelError) {
+      dP.closeModal();
+      return;
+    }
+    if (error?.message.toLowerCase().indexOf('cookies') !== -1) {
       dP.errorModal(`Please enable cookies in your browser to proceed with ${accountType}.`, 'Cookies are disabled', HELP_CENTER_THIRD_PARTY_COOKIES, 'Learn more.');
     } else {
-      dP.errorModal(error.message ? error.message : error ? JSON.stringify(error) : '');
+      dP.errorModal(
+        `There was an error while attempting to log in with ${accountType}. Please try again, and if it is still not working checkout the help center for logging in.\n\n${
+          error?.message ? `Error: ${JSON.stringify(error.message)}` : ''
+        }`
+      );
     }
   };
 


### PR DESCRIPTION
#7479

- if the users denies access to the sdk wallet don't display (user closed popup) error, just close the signin modal
- update error message template for all non deny access errors

<img src="https://user-images.githubusercontent.com/1683736/80419163-99880b80-88a6-11ea-81e0-b072692669a4.png" width="433" />
