### PR TITLE
remove liquidity spread notice

### DIFF
--- a/packages/augur-ui/src/modules/markets-list/components/markets-view.tsx
+++ b/packages/augur-ui/src/modules/markets-list/components/markets-view.tsx
@@ -269,19 +269,6 @@ export default class MarketsView extends Component<
     } = this.state;
 
     const displayFee = this.props.maxFee !== MAX_FEE_100_PERCENT;
-    const displayLiquiditySpread =
-      this.props.maxLiquiditySpread !== MAX_SPREAD_ALL_SPREADS;
-    let feesLiquidityMessage = '';
-
-    if (!displayFee && !displayLiquiditySpread) {
-      feesLiquidityMessage =
-        '“Fee” and “Liquidity Spread” filters are set to “All”. This puts you at risk of trading on invalid markets.';
-    } else if (!displayFee || !displayLiquiditySpread) {
-      feesLiquidityMessage = `The ${
-        !displayFee ? '“Fee”' : '“Liquidity Spread”'
-      } filter is set to “All”. This puts you at risk of trading on invalid markets.`;
-    }
-
     return (
       <section
         className={Styles.MarketsView}
@@ -353,7 +340,7 @@ export default class MarketsView extends Component<
         />
 
         <FilterNotice
-          show={!displayFee || !displayLiquiditySpread}
+          show={!displayFee}
           showDismissButton={true}
           updateLoginAccountSettings={updateLoginAccountSettings}
           settings={{
@@ -362,7 +349,7 @@ export default class MarketsView extends Component<
           }}
           content={
             <span>
-              {feesLiquidityMessage}{' '}
+              {'The “Fee” filter is set to “All”. This puts you at risk of trading on invalid markets. '}
               <a href={HELP_CENTER_INVALID_MARKETS} target="_blank" rel="noopener noreferrer">
                 Learn more
               </a>


### PR DESCRIPTION
When filtering by all liquidity spreads, user should not see banner for potential invalid #7481