### PR TITLE
check to see if account has token approval before trying to swap

### DIFF
--- a/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
+++ b/packages/augur-ui/src/modules/contracts/actions/contractCalls.ts
@@ -348,14 +348,28 @@ export async function addLiquidityRepDai(dai: BigNumber, rep: BigNumber): Promis
   uniswap.addLiquidity(contracts.reputationToken.address, contracts.cash.address, repAmount, cashAmount, new BigNumber(0), new BigNumber(0));
 }
 
+export async function checkSetApprovalAmount(account, contract): Promise<void> {
+  const { contracts } = augurSdk.get();
+  try {
+    const APPROVAL_AMOUNT = new BigNumber(2**255);
+    const currentAllowance = await contract.allowance_(account, contracts.uniswap.address);
+    if (currentAllowance.toNumber() <= 0) {
+      await contract.approve(contracts.uniswap.address, APPROVAL_AMOUNT);
+    }
+  }
+  catch(error) {
+    throw error;
+  }
+}
+
 export async function uniswapDaiForRep(dai: BigNumber, rep: BigNumber, tradeSpread: number): Promise<void> {
   const { contracts, uniswap } = augurSdk.get();
 
   const exactDai = dai.multipliedBy(10**18);
-  const minRep = rep.minus(rep.multipliedBy(tradeSpread - 1)).multipliedBy(10**18);
+  const minRep = rep.minus(rep.multipliedBy(createBigNumber(tradeSpread).minus(1))).multipliedBy(10**18);
 
   try {
-    await uniswap.swapExactTokensForTokens(contracts.cash.address, contracts.reputationToken.address, exactDai, minRep);
+    await uniswap.swapExactTokensForTokens(contracts.cash.address, contracts.reputationToken.address, exactDai, createBigNumber(minRep.toNumber()));
   }
   catch(error) {
     console.error('uniswapDaiForRep', error);
@@ -367,10 +381,10 @@ export async function uniswapRepForDai(rep: BigNumber, dai: BigNumber, tradeSpre
   const { contracts, uniswap } = augurSdk.get();
 
   const exactRep = rep.multipliedBy(10**18);
-  const minDai = dai.minus(dai.multipliedBy(tradeSpread - 1)).multipliedBy(10**18);
+  const minDai = dai.minus(dai.multipliedBy(createBigNumber(tradeSpread).minus(1))).multipliedBy(10**18);
 
   try {
-    await uniswap.swapExactTokensForTokens(contracts.reputationToken.address, contracts.cash.address, exactRep, minDai);
+    await uniswap.swapExactTokensForTokens(contracts.reputationToken.address, contracts.cash.address, exactRep, createBigNumber(minDai.toNumber()));
   }
   catch(error) {
     console.error('uniswapRepForDai', error);

--- a/packages/augur-ui/src/modules/modal/add-funds.tsx
+++ b/packages/augur-ui/src/modules/modal/add-funds.tsx
@@ -238,6 +238,7 @@ export const AddFunds = ({
 
               {swapSelected && (
                 <Swap
+                  address={loginAccount.address}
                   balances={loginAccount.balances}
                   toToken={fundTypeToUse === REP ? REP : DAI}
                   fromToken={fundTypeToUse === REP ? DAI : REP}


### PR DESCRIPTION
- added `checkSetApprovalAmount` to check to make sure users have token allowance before making a swap