### PR TITLE
have one field for all the market properties that need to be full tex…

### DIFF
--- a/packages/augur-sdk/src/state/getter/Markets.ts
+++ b/packages/augur-sdk/src/state/getter/Markets.ts
@@ -531,7 +531,7 @@ export class Markets {
       params.userPortfolioAddress;
     let useCreator = false;
 
-    if (params.search || params.categories) {
+    if (params.search || (params.categories && params.categories.length > 0)) {
       const marketsFTSResults = await getMarketsSearchResults(
         params.universe,
         params.search || '',
@@ -1574,7 +1574,7 @@ async function getMarketsSearchResults(
 ): Promise<Array<SearchResults<MarketFields>>> {
   const whereObj = { universe };
   for (let i = 0; i < categories.length; i++) {
-    whereObj['category' + (i + 1)] = categories[i];
+    whereObj[`category${i + 1}`] = categories[i];
   }
   if (query) {
     return augur.syncableFlexSearch.search(query, { where: whereObj });

--- a/packages/augur-ui/src/modules/markets/selectors/build-search-string.ts
+++ b/packages/augur-ui/src/modules/markets/selectors/build-search-string.ts
@@ -5,14 +5,8 @@ export const buildSearchString = (keywords, tags) => {
     { find: "details:", replace: "longDescription:" }
   ];
 
-  let keywordSearch =
+  const keywordSearch =
     keywords && keywords.length > MIN_KEYWORDS_LENGTH ? keywords : undefined;
-  if (
-    keywordSearch &&
-    (!keywordSearch.endsWith(" ") && !keywordSearch.endsWith('"'))
-  ) {
-    keywordSearch += "*";
-  }
 
   const terms = [];
   tags.forEach(i => {


### PR DESCRIPTION
…t searchable

1. noticed that flexsearch was searched even thought there was not `search` or `categories` passed into getMarkets. added a conditional
2. removed `*` appeneded to keyword search in UI.
3. re-organized fields in flexsearch, only a few fields needed to be indexed individually. The bulk of the market properties could be added to one field. 


https://github.com/AugurProject/augur/issues/7593