### PR TITLE
fix trade history

### DIFF
--- a/packages/augur-ui/src/modules/market/components/market-trade-history/market-trade-history.styles.less
+++ b/packages/augur-ui/src/modules/market/components/market-trade-history/market-trade-history.styles.less
@@ -13,7 +13,7 @@
   > div {
     display: block;
     overflow: overlay;
-    max-height: calc(50vh + 53px);
+    max-height: calc(50vh + @size-52);
 
     > span {
       .mono-10-medium;

--- a/packages/augur-ui/src/modules/market/components/market-trade-history/market-trade-history.styles.less
+++ b/packages/augur-ui/src/modules/market/components/market-trade-history/market-trade-history.styles.less
@@ -11,11 +11,9 @@
   }
 
   > div {
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
+    display: block;
     overflow: overlay;
-    max-height: 50vh;
+    max-height: calc(50vh + 53px);
 
     > span {
       .mono-10-medium;
@@ -37,13 +35,19 @@
   }
 }
 
-@supports (-moz-appearance:none) {    
-  .Container {   
+@supports (-moz-appearance:none) {
+  .TradeHistory {
+    > div {
+      overflow-y: auto;
+    }
+  }
+
+  .Container {
     > main {
-      // firefox doesn't support overlay. need auto     
-      overflow-y: auto; 
-    }    
-  } 
+      // firefox doesn't support overlay. need auto
+      overflow-y: auto;
+    }
+  }
 }
 
 .TradeHistoryTable {


### PR DESCRIPTION
Trade history getting cut off at bottom for desktop #7675
 
<img width="483" src="https://user-images.githubusercontent.com/1683736/81424213-98b36d00-9123-11ea-9bb1-6936b9b25f13.png">
