### PR TITLE
change tooltip in account dropdown, add eth reserve replenish notice…

### DIFF
--- a/packages/augur-ui/src/modules/app/actions/get-ethToDai-rate.ts
+++ b/packages/augur-ui/src/modules/app/actions/get-ethToDai-rate.ts
@@ -24,7 +24,7 @@ export const getEthToDaiRate = (
   }
 };
 
-export const ethToDai = (ethAmount: number, ethToDaiRate: BigNumber) => {
+export const ethToDai = (ethAmount: number, ethToDaiRate: BigNumber): FormattedNumber => {
   if (!ethToDaiRate) return formatDaiEstimate(0);
   return formatDaiEstimate(ethToDaiRate.times(ethAmount));
 };

--- a/packages/augur-ui/src/modules/auth/components/connect-dropdown/connect-dropdown.tsx
+++ b/packages/augur-ui/src/modules/auth/components/connect-dropdown/connect-dropdown.tsx
@@ -166,8 +166,10 @@ const ConnectDropdown = (props: ConnectDropdownProps) => {
       toolTip: renderToolTip(
         'tooltip--ethReserve',
         <div>
-          <p>Augur is a peer-to-peer system, and certain actions require paying a small fee to other users of the system. The cost of these fees will be included in the total fees displayed when taking that action. Trades, Creating Markets, and Reporting on the market outcome are examples of such actions.</p>
-          <p>Augur will reserve ${ethReserveInDai} of your funds in order to pay these fees. Your total balance can be cashed out at any time.</p>
+          <p>Augur runs on a peer-to-peer network, transaction fees are paid in ETH. These fees go entirely to the network. Augur doesn’t collect any of these fees.</p>
+          <p>If your account balance exceeds $40, 0.04 ETH equivilant in DAI will be held in your ETH reserve to cover transaction fees, which results in cheaper transaction fees.</p>
+          <p>As long as your available account balance remains over $40 Dai, your ETH reserve will automatically be replenish.</p>
+          <p>Your ETH reserve can be easily cashed out at anytime using the withdraw button in the transactions section of your account summary.</p>
         </div>
       ),
       logo: EthIcon,

--- a/packages/augur-ui/src/modules/auth/selectors/get-eth-reserve.ts
+++ b/packages/augur-ui/src/modules/auth/selectors/get-eth-reserve.ts
@@ -8,7 +8,7 @@ import { selectEnvState } from 'appStore/select-state';
 export const getEthReserve = createSelector(
   selectLoginAccount,
   selectEnvState,
-  (loginAccount, env) => {
+  (loginAccount, env): FormattedNumber => {
     const { balances } = loginAccount;
     const ethNonSafeBN = createBigNumber(balances.ethNonSafe);
     let desiredSignerEthBalance = createBigNumber(

--- a/packages/augur-ui/src/modules/common/labels.styles.less
+++ b/packages/augur-ui/src/modules/common/labels.styles.less
@@ -1089,3 +1089,11 @@ span.PendingLabel {
     }
   }
 }
+
+.EthReserveNotice {
+  margin: @size-8 @size-12;
+
+  > div {
+    padding: @size-5;
+  }
+}

--- a/packages/augur-ui/src/modules/common/labels.tsx
+++ b/packages/augur-ui/src/modules/common/labels.tsx
@@ -1473,6 +1473,13 @@ export const InitializeWalletModalNotice = connect(
 
 const mapStateToPropsEthReserve = (state: AppState, ownProps) => {
   const gasLimit = ownProps.gasLimit;
+  const aboveCutoff = createBigNumber(state.loginAccount.balances.dai).isGreaterThan(createBigNumber(state.env.config.gsn.minDaiForSignerETHBalanceInDAI * 10**18))
+  if (!aboveCutoff) {
+    return {
+      show: false
+    }
+  }
+
   const ethInReserve = getEthReserve(state);
   const gasPrice =
     state.gasPriceInfo.userDefinedGasPrice || state.gasPriceInfo.average;

--- a/packages/augur-ui/src/modules/common/labels.tsx
+++ b/packages/augur-ui/src/modules/common/labels.tsx
@@ -1473,7 +1473,7 @@ export const InitializeWalletModalNotice = connect(
 
 const mapStateToPropsEthReserve = (state: AppState, ownProps) => {
   const gasLimit = ownProps.gasLimit;
-  const aboveCutoff = createBigNumber(state.loginAccount.balances.dai).isGreaterThan(createBigNumber(state.env.config.gsn.minDaiForSignerETHBalanceInDAI * 10**18))
+  const aboveCutoff = createBigNumber(state.loginAccount.balances.dai).isGreaterThan(createBigNumber(state.env.gsn.minDaiForSignerETHBalanceInDAI * 10**18))
   if (!aboveCutoff) {
     return {
       show: false

--- a/packages/augur-ui/src/modules/common/labels.tsx
+++ b/packages/augur-ui/src/modules/common/labels.tsx
@@ -19,7 +19,7 @@ import {
 } from 'modules/common/icons';
 import ReactTooltip from 'react-tooltip';
 import TooltipStyles from 'modules/common/tooltip.styles.less';
-import { createBigNumber } from 'utils/create-big-number';
+import { createBigNumber, BigNumber } from 'utils/create-big-number';
 import {
   SELL,
   BOUGHT,
@@ -35,9 +35,10 @@ import {
   DISCORD_LINK,
   ACCOUNT_TYPES,
   CLOSED_SHORT,
+  GWEI_CONVERSION,
 } from 'modules/common/constants';
 import { ViewTransactionDetailsButton } from 'modules/common/buttons';
-import { formatNumber } from 'utils/format-number';
+import { formatNumber, formatBlank, formatGasCostToEther, formatAttoEth } from 'utils/format-number';
 import { DateFormattedObject, FormattedNumber, SizeTypes, MarketData } from 'modules/types';
 import { Getters, TXEventName } from '@augurproject/sdk';
 import {
@@ -53,6 +54,9 @@ import { useTimer } from 'modules/common/progress';
 import { isGSNUnavailable } from 'modules/app/selectors/is-gsn-unavailable';
 import { AppState } from 'appStore';
 import { Ox_STATUS } from 'modules/app/actions/update-app-status';
+import { ethToDai } from 'modules/app/actions/get-ethToDai-rate';
+import { getEthForDaiRate } from 'modules/contracts/actions/contractCalls';
+import { getEthReserve } from 'modules/auth/selectors/get-eth-reserve';
 
 export interface MarketTypeProps {
   marketType: string;
@@ -1465,6 +1469,64 @@ const InitializeWalletModalNoticeCmp = ({ gsnUnavailable }) => (
 export const InitializeWalletModalNotice = connect(
   mapStateToPropsInitWalletModal
 )(InitializeWalletModalNoticeCmp);
+
+
+const mapStateToPropsEthReserve = (state: AppState, ownProps) => {
+  const gasLimit = ownProps.gasLimit;
+  const ethInReserve = getEthReserve(state);
+  const gasPrice =
+    state.gasPriceInfo.userDefinedGasPrice || state.gasPriceInfo.average;
+  const estTransactionFee = createBigNumber(
+    formatGasCostToEther(
+      gasLimit,
+      { decimalsRounded: 4 },
+      createBigNumber(GWEI_CONVERSION).multipliedBy(gasPrice)
+    )
+  );
+
+  const show = createBigNumber(estTransactionFee)
+    .minus(createBigNumber(ethInReserve.value))
+    .gt(0);
+
+  let reserve = formatBlank();
+  if (show) {
+    const attoEthToDaiRate: BigNumber = getEthForDaiRate();
+    const attoEthReserve = formatAttoEth(
+      state.env.gsn.desiredSignerBalanceInETH
+    ).value;
+    const diffReserve = createBigNumber(attoEthReserve).minus(createBigNumber(ethInReserve.value).div(10 ** 18));
+    reserve = ethToDai(diffReserve, createBigNumber(attoEthToDaiRate || 0));
+  }
+  return {
+    show,
+    reserve,
+  };
+};
+
+interface EthReseveProps {
+  show: boolean,
+  reserve: FormattedNumber,
+}
+
+const EthReserveNoticeCmp = ({ show, reserve }: EthReseveProps) => (
+  <>
+    {show && (
+      <div className={classNames(Styles.EthReserveNotice)}>
+        <DismissableNotice
+          show
+          buttonType={DISMISSABLE_NOTICE_BUTTON_TYPES.NONE}
+          title={`Replenish ETH Reserves`}
+          description={`$${reserve.formatted} DAI will be added to your ETH reserves`}
+        />
+      </div>
+    )}
+  </>
+);
+
+export const EthReserveNotice = connect(
+  mapStateToPropsEthReserve
+)(EthReserveNoticeCmp);
+
 
 export const AutoCancelOrdersNotice = () => (
     <div className={classNames(Styles.ModalMessageAutoCancel)}>

--- a/packages/augur-ui/src/modules/trades/helpers/generate-trade.ts
+++ b/packages/augur-ui/src/modules/trades/helpers/generate-trade.ts
@@ -7,6 +7,8 @@ import {
   calculateTotalOrderValue,
 } from "modules/trades/helpers/calc-order-profit-loss-percents";
 import * as constants from "modules/common/constants";
+import { MAX_FILLS_PER_TX } from '@augurproject/sdk';
+
 
 export const generateTrade = memoize(
   (market, outcomeTradeInProgress) => {
@@ -88,7 +90,7 @@ export const generateTrade = memoize(
       sharesFilled: formatMarketShares(marketType, sharesFilled),
       selfTrade: !!outcomeTradeInProgress.selfTrade,
       numFills: outcomeTradeInProgress.numFills ? outcomeTradeInProgress.numFills.toNumber() : 0,
-      loopLimit: outcomeTradeInProgress.loopLimit ? outcomeTradeInProgress.loopLimit.toNumber() : 0,
+      loopLimit: outcomeTradeInProgress.loopLimit ? outcomeTradeInProgress.loopLimit.toNumber() : MAX_FILLS_PER_TX.toNumber(),
       totalOrderValue: totalOrderValue
         ? formatDaiValue(totalOrderValue)
         : null,

--- a/packages/augur-ui/src/modules/trading/components/confirm.tsx
+++ b/packages/augur-ui/src/modules/trading/components/confirm.tsx
@@ -33,7 +33,7 @@ import {
   formatShares,
 } from 'utils/format-number';
 import { BigNumber, createBigNumber } from 'utils/create-big-number';
-import { LinearPropertyLabel } from 'modules/common/labels';
+import { LinearPropertyLabel, EthReserveNotice } from 'modules/common/labels';
 import { Trade } from 'modules/types';
 import { ExternalLinkButton, ProcessingButton } from 'modules/common/buttons';
 import { getGasInDai } from 'modules/app/actions/get-ethToDai-rate';
@@ -506,6 +506,7 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
             )}
           </div>
         )}
+        <EthReserveNotice gasLimit={gasLimit} />
       </section>
     );
   }


### PR DESCRIPTION
… in order form

Screenshots are 
1) before replenishment
2) notice to tell user they will replenish eth reserve
3) after replenishment


![Screen Shot 2020-05-13 at 4 18 07 PM](https://user-images.githubusercontent.com/3970376/81867124-d7875f80-9535-11ea-84fc-f2df2ae6d9e1.png)


![Screen Shot 2020-05-13 at 4 19 09 PM](https://user-images.githubusercontent.com/3970376/81867135-da825000-9535-11ea-983c-fc0476e88d7c.png)



ETH reserve was added to
![Screen Shot 2020-05-13 at 4 20 30 PM](https://user-images.githubusercontent.com/3970376/81867115-d35b4200-9535-11ea-89a5-d9bbb9f365e3.png)


Changed tooltip in account dropdown
![image](https://user-images.githubusercontent.com/3970376/81867703-bffca680-9536-11ea-8188-62491c0fca21.png)


Also fixed issue where numFills was used for number of transactions to take all orders. transaction can take 3 orders in one transaction. 