### PR TITLE
Switched to percentage because of double scrolling bug

### DIFF
--- a/packages/augur-ui/src/modules/app/components/app.styles.less
+++ b/packages/augur-ui/src/modules/app/components/app.styles.less
@@ -156,7 +156,7 @@ h6 {
   overflow-y: auto;
 
   @media @breakpoint-mobile {
-    height: 100vh;
+    height: 100%;
     width: 100vw;
     padding-bottom: @size-16;
 


### PR DESCRIPTION
#7765
I fixed the screen being cut, but there is something weird when scrolling using `100vh`.

Double scrolling bug:
It seems that using `100vh` instead of `100%` makes the height calculation slower than percentage, making the user have to scroll all the way to the bottom or top twice on a mobile device. Like... pull once and pull again, otherwise the top or bottom of the screen will be just slightly cut.

![Animated GIF-downsized_large](https://user-images.githubusercontent.com/10351013/82282007-30595c80-9969-11ea-8b8d-73ec6e78b075.gif)

