### PR TITLE
set time and unit based on market endTime. there was a bug if market …

### DIFF
--- a/packages/augur-ui/src/utils/format-date.ts
+++ b/packages/augur-ui/src/utils/format-date.ts
@@ -392,11 +392,29 @@ export function calcOrderExpirationTime(endTime: number, currentTime: number) {
   return endTime;
 }
 
-export function calcOrderExpirationDaysRemaining(
+export enum EXPIRATION_DATE_OPTIONS {
+  DAYS = 'day',
+  CUSTOM = '1',
+  HOURS = 'hours',
+  MINUTES = 'minutes',
+}
+
+export interface TimeRemaining {
+  time: number;
+  unit: EXPIRATION_DATE_OPTIONS;
+}
+
+export function calcOrderExpirationTimeRemaining(
   endTime: number,
   currentTime: number
-) {
-  const remaining = getDaysRemaining(endTime, currentTime);
-  if (remaining <= 0) return DAYS_AFTER_END_TIME_ORDER_EXPIRATION;
-  return remaining;
+): TimeRemaining {
+  const fallback = { time: DAYS_AFTER_END_TIME_ORDER_EXPIRATION, unit: EXPIRATION_DATE_OPTIONS.DAYS};
+  if (endTime < currentTime) return fallback;
+  let remaining = getDaysRemaining(endTime, currentTime);
+  if (remaining > 0) return { time: remaining, unit: EXPIRATION_DATE_OPTIONS.DAYS};
+  remaining = getHoursRemaining(endTime, currentTime);
+  if (remaining > 0) return {time: remaining, unit: EXPIRATION_DATE_OPTIONS.HOURS}
+  remaining = getMinutesRemaining(endTime, currentTime);
+  if (remaining > 0) return {time: remaining, unit: EXPIRATION_DATE_OPTIONS.MINUTES}
+  return fallback;
 }


### PR DESCRIPTION
… expires within a day, order expiration would say 7 days. Needed to set order expiration based on market endTime using time units, days, hours, minutes. 

![Screen Shot 2020-05-26 at 11 25 28 AM](https://user-images.githubusercontent.com/3970376/82925903-0218e580-9f44-11ea-8242-1631a7d34c8e.png)



![Screen Shot 2020-05-26 at 11 27 43 AM](https://user-images.githubusercontent.com/3970376/82925931-0ba24d80-9f44-11ea-8dae-46786ccc5b7f.png)
