### PR TITLE
remove estimated from label for est. tx fee, added tooltip in order f…

### DIFF
--- a/packages/augur-ui/src/modules/app/actions/get-ethToDai-rate.ts
+++ b/packages/augur-ui/src/modules/app/actions/get-ethToDai-rate.ts
@@ -8,7 +8,7 @@ import {
 } from 'modules/app/actions/update-app-status';
 import { NodeStyleCallback, FormattedNumber } from 'modules/types';
 import logError from 'utils/log-error';
-import { formatDaiEstimate, formatAttoDai } from 'utils/format-number';
+import { formatAttoDai, formatDai } from 'utils/format-number';
 import { augurSdk } from 'services/augursdk';
 import { BigNumber, createBigNumber } from 'utils/create-big-number';
 
@@ -30,14 +30,14 @@ export const ethToDaiFromAttoRate = (ethAmount: number): FormattedNumber => {
 };
 
 export const ethToDai = (ethAmount: number, ethToDaiRate: BigNumber): FormattedNumber => {
-  if (!ethToDaiRate) return formatDaiEstimate(0);
-  return formatDaiEstimate(ethToDaiRate.times(ethAmount));
+  if (!ethToDaiRate) return formatDai(0);
+  return formatDai(ethToDaiRate.times(ethAmount));
 };
 
 export const getGasInDai = (amount: BigNumber, manualGasPrice?: number): FormattedNumber => {
   const augur = augurSdk.get();
   const gasInAttoDai = augur.convertGasEstimateToDaiCost(amount, manualGasPrice);
-  return formatDaiEstimate(gasInAttoDai.dividedBy(10 ** 18));
+  return formatDai(gasInAttoDai.dividedBy(10 ** 18));
 }
 
 export const displayGasInDai = (amount: BigNumber, manualGasPrice?: number): string => {

--- a/packages/augur-ui/src/modules/auth/selectors/get-gas-price.ts
+++ b/packages/augur-ui/src/modules/auth/selectors/get-gas-price.ts
@@ -3,7 +3,7 @@ import { selectGasPriceInfo, selectEnvState } from "appStore/select-state";
 import { createBigNumber } from "utils/create-big-number";
 import store from "appStore";
 import { GWEI_CONVERSION, USE_ETH_RESERVE, NOT_USE_ETH_RESERVE } from 'modules/common/constants';
-import loginAccount, { selectLoginAccount } from "./login-account";
+import { selectLoginAccount } from "./login-account";
 
 export default function() {
   return getGasPrice(store.getState());

--- a/packages/augur-ui/src/modules/common/labels.styles.less
+++ b/packages/augur-ui/src/modules/common/labels.styles.less
@@ -317,6 +317,9 @@
     &.isAccented {
       color: @color-error;
     }
+    &.isHighlighted {
+      color: @color-reporting;
+    }
   }
 
   &.HighlightAlternateBolded {

--- a/packages/augur-ui/src/modules/common/labels.styles.less
+++ b/packages/augur-ui/src/modules/common/labels.styles.less
@@ -314,11 +314,11 @@
     color: @color-primary-text;
     padding-left: @size-8;
 
-    &.isAccented {
-      color: @color-error;
-    }
     &.isHighlighted {
       color: @color-reporting;
+    }
+    &.isAccented {
+      color: @color-error;
     }
   }
 

--- a/packages/augur-ui/src/modules/common/labels.tsx
+++ b/packages/augur-ui/src/modules/common/labels.tsx
@@ -36,8 +36,6 @@ import {
   ACCOUNT_TYPES,
   CLOSED_SHORT,
   GWEI_CONVERSION,
-  USE_ETH_RESERVE,
-  NOT_USE_ETH_RESERVE,
 } from 'modules/common/constants';
 import { ViewTransactionDetailsButton } from 'modules/common/buttons';
 import { formatNumber, formatBlank, formatGasCostToEther, formatAttoEth } from 'utils/format-number';
@@ -811,6 +809,7 @@ export const PropertyLabel = (props: PropertyLabelProps) => (
 interface TransactionFeeLabelProps {
   label: string;
   gasCostDai: FormattedNumber;
+  isError: boolean;
 }
 
 const mapStateToPropsTransactionFeeLabel = (state: AppState) => ({
@@ -819,19 +818,38 @@ const mapStateToPropsTransactionFeeLabel = (state: AppState) => ({
 
 export const TransactionFeeLabelCmp = ({
   label,
-  gasCostDai
+  gasCostDai,
 }: TransactionFeeLabelProps) => (
-    <LinearPropertyLabel
+  <LinearPropertyLabel
     label={label}
     value={gasCostDai}
     showDenomination={true}
   />
-)
+);
 
+export const TransactionFeeLabelToolTipCmp = ({
+  label,
+  isError,
+  gasCostDai
+}: TransactionFeeLabelProps) => (
+    <LinearPropertyLabelUnderlineTooltip
+      label={label}
+      value={gasCostDai}
+      showDenomination={true}
+      highlight
+      accentValue={isError}
+      id={'totalFunds'}
+      tipText={`Est. TX Fee is not included in profit and loss`}
+    />
+)
 
 export const TransactionFeeLabel = connect(
   mapStateToPropsTransactionFeeLabel
 )(TransactionFeeLabelCmp);
+
+export const TransactionFeeLabelToolTip = connect(
+  mapStateToPropsTransactionFeeLabel
+)(TransactionFeeLabelToolTipCmp);
 
 export const LinearPropertyLabel = ({
   highlight,
@@ -1358,6 +1376,7 @@ export const LinearPropertyLabelUnderlineTooltip = ({
   id,
   label,
   accentValue,
+  highlight,
   showDenomination,
   useFull,
 }: LinearPropertyLabelUnderlineTooltipProps) => (
@@ -1368,6 +1387,7 @@ export const LinearPropertyLabelUnderlineTooltip = ({
       className={classNames({
         [Styles.TEXT]: !!tipText,
         [Styles.isAccented]: accentValue,
+        [Styles.isHighlighted]: highlight,
       })}
       data-tip
       data-for={`underlinetooltip-${id}`}

--- a/packages/augur-ui/src/modules/create-market/components/review.tsx
+++ b/packages/augur-ui/src/modules/create-market/components/review.tsx
@@ -15,7 +15,7 @@ import {
   DateTimeHeaders,
   PreviewMarketTitleHeader
 } from "modules/create-market/components/common";
-import { LinearPropertyLabel, LinearPropertyLabelTooltip, TransactionFeeLabel } from "modules/common/labels";
+import { LinearPropertyLabel, TransactionFeeLabel } from "modules/common/labels";
 import {
   SCALAR,
   CATEGORICAL,

--- a/packages/augur-ui/src/modules/trading/components/confirm.tsx
+++ b/packages/augur-ui/src/modules/trading/components/confirm.tsx
@@ -34,10 +34,10 @@ import {
   formatNumber,
 } from 'utils/format-number';
 import { BigNumber, createBigNumber } from 'utils/create-big-number';
-import { LinearPropertyLabel, EthReserveNotice, TransactionFeeLabel } from 'modules/common/labels';
+import { LinearPropertyLabel, EthReserveNotice, TransactionFeeLabelToolTip } from 'modules/common/labels';
 import { Trade } from 'modules/types';
 import { ExternalLinkButton, ProcessingButton } from 'modules/common/buttons';
-import { getGasInDai, ethToDaiFromAttoRate } from 'modules/app/actions/get-ethToDai-rate';
+import { ethToDaiFromAttoRate } from 'modules/app/actions/get-ethToDai-rate';
 import { TXEventName } from '@augurproject/sdk/src';
 
 interface MessageButton {
@@ -163,6 +163,7 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
       potentialDaiLoss,
       numFills,
       loopLimit,
+      potentialDaiProfit,
     } = trade;
 
     let numTrades = loopLimit ? Math.ceil(numFills / loopLimit) : numFills;
@@ -231,6 +232,18 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
         header: 'Insufficient DAI',
         type: ERROR,
         message: `You do not have enough funds to place this order. ${gasCostDai} DAI required for gas.`,
+      };
+    }
+
+    if (
+      !isNaN(numTrades) && numTrades > 0 &&
+      createBigNumber(gasCostDai).gt(potentialDaiProfit.value) &&
+      !tradingTutorial
+    ) {
+      messages = {
+        header: 'UNPROFITABLE TRADE',
+        type: WARNING,
+        message: `Est. TX Fee is higher than profit`,
       };
     }
 
@@ -402,7 +415,7 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
             />
             {gasCostDai.roundedValue.gt(0) > 0 &&
               numFills > 0 && (
-              <TransactionFeeLabel
+              <TransactionFeeLabelToolTip
                 gasCostDai={gasCostDai}
               />
             )}
@@ -467,7 +480,8 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
             />
             {gasCostDai.roundedValue.gt(0) > 0 &&
               numFills > 0 && (
-              <TransactionFeeLabel
+              <TransactionFeeLabelToolTip
+                isError={createBigNumber(gasCostDai.value).gt(createBigNumber(potentialDaiProfit.value))}
                 gasCostDai={gasCostDai}
               />
               )}

--- a/packages/augur-ui/src/modules/trading/components/confirm.tsx
+++ b/packages/augur-ui/src/modules/trading/components/confirm.tsx
@@ -416,7 +416,7 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
             {gasCostDai.roundedValue.gt(0) > 0 &&
               numFills > 0 && (
               <TransactionFeeLabelToolTip
-                isError={createBigNumber(gasCostDai.value).gt(createBigNumber(potentialDaiProfit.value))}
+                isError={createBigNumber(gasCostDai.value).gt(createBigNumber(orderShareProfit.value))}
                 gasCostDai={gasCostDai}
               />
             )}

--- a/packages/augur-ui/src/modules/trading/components/confirm.tsx
+++ b/packages/augur-ui/src/modules/trading/components/confirm.tsx
@@ -416,6 +416,7 @@ class Confirm extends Component<ConfirmProps, ConfirmState> {
             {gasCostDai.roundedValue.gt(0) > 0 &&
               numFills > 0 && (
               <TransactionFeeLabelToolTip
+                isError={createBigNumber(gasCostDai.value).gt(createBigNumber(potentialDaiProfit.value))}
                 gasCostDai={gasCostDai}
               />
             )}

--- a/packages/augur-ui/src/utils/format-number.ts
+++ b/packages/augur-ui/src/utils/format-number.ts
@@ -96,27 +96,6 @@ export function formatEtherEstimate(
   });
 }
 
-export function formatDaiEstimate(
-  num: NumStrBigNumber,
-  opts: FormattedNumberOptions = {}
-): FormattedNumber {
-  return formatNumber(num, {
-    decimals: 2,
-    decimalsRounded: 2,
-
-    denomination: v => {
-      const isNegative = Number(v) < 0;
-      const val = isNegative ? createBigNumber(v).abs().toFixed(2) : v;
-      return `${isNegative ? '-' : ''}$${val} (estimated)`;
-    },
-    positiveSign: false,
-    zeroStyled: false,
-    blankZero: false,
-    bigUnitPostfix: false,
-    ...opts,
-  });
-}
-
 export function formatPercent(
   num: NumStrBigNumber,
   opts: FormattedNumberOptions = {}


### PR DESCRIPTION
…orm, added tooltip colorized value for est. tx fee
<https://github.com/AugurProject/augur/issues/7839>

ignore eth reserve replenishment

![Screen Shot 2020-05-26 at 2 30 48 PM](https://user-images.githubusercontent.com/3970376/82942558-c0953400-9f5d-11ea-8915-0ba11058918d.png)
![Screen Shot 2020-05-26 at 2 25 08 PM](https://user-images.githubusercontent.com/3970376/82942566-c25ef780-9f5d-11ea-9b7f-1cd596114697.png)

