### PR TITLE
Firefox will bug when there's position fixed and transition happening

### DIFF
--- a/packages/augur-ui/src/modules/app/components/app.styles.less
+++ b/packages/augur-ui/src/modules/app/components/app.styles.less
@@ -210,16 +210,20 @@ h6 {
   background: @color-module-background;
   border-right: @size-1 solid @color-dark-grey;
 
-  @media @breakpoint-mobile {
-    padding-top: 0;
-  }
-
   > div:first-of-type {
-    left: 0px;
+    left: 0;
     position: absolute;
-    right: 0px;
+    right: 0;
     width: 100%;
     z-index: @mask-toast;
+  }
+
+  @media @breakpoint-mobile {
+    padding-top: 0;
+
+    > div:first-of-type {
+      z-index: @above-all-content;
+    }
   }
 }
 

--- a/packages/augur-ui/src/modules/app/components/inner-nav/category-filters.styles.less
+++ b/packages/augur-ui/src/modules/app/components/inner-nav/category-filters.styles.less
@@ -28,7 +28,7 @@
   }
 
   @media @breakpoint-mobile {
-    margin: @size-64 0 @size-16;
+    margin: @size-10 0 @size-16;
   }
 }
 
@@ -124,9 +124,9 @@
         transform: translateY(@size-3);
       }
     }
-  
+
     @media @breakpoint-mobile {
-      .text-14-bold;  
+      .text-14-bold;
     }
 
     &:hover {

--- a/packages/augur-ui/src/modules/app/components/inner-nav/inner-nav.styles.less
+++ b/packages/augur-ui/src/modules/app/components/inner-nav/inner-nav.styles.less
@@ -140,8 +140,8 @@
         height: 50px;
         padding: @size-16;
         width: 100%;
-        z-index: @mask-above;
-        position: fixed;
+        z-index: unset;
+        position: initial;
 
         > span {
           padding-left: @size-25;


### PR DESCRIPTION
#7840 

This was a tricky one. Explanation below:

We have a transition when the Filter and Categories' menu is being open on mobile and we also have that inner header ("Categories & Filters") set to `position: fixed`, which causes the animation to lose itself and kinda crash. Sometimes it works a bit choppy,  sometimes it simply vanishes, which is when the user has to use the "back" button on Android to get unstuck or refresh the page.

I've tested that on desktop, in an old mozilla browser (version 68, which seems to be the same-ish version as mobile's version) and the bug is there as well.

The fix I've found is to use a `position: initial` header, which makes the header not follow the user's scroll but will provide a much better user experience, given that the user won't get stuck every time they open the Filter and Categories' menu.

### **Important to note!**
This fix can be only temporary. I've downloaded Firefox Beta on my phone and they seem to have fixed that animation bug. I imagine we can reverse this changes in a few months, when almost everyone has the newer version of the Browser.