### PR TITLE
Added height and width on rect element for firefox support

### DIFF
--- a/packages/augur-ui/src/modules/common/icons.tsx
+++ b/packages/augur-ui/src/modules/common/icons.tsx
@@ -139,7 +139,7 @@ export const CopyIcon = (
 
 export const ScalarIcon = (
   <svg viewBox="0 0 20 6">
-    <rect y="2" rx="0.75" />
+    <rect y="2" rx="0.75" height="1.5" width="20" />
     <path
       fillRule="evenodd"
       clipRule="evenodd"


### PR DESCRIPTION
#7892 

Problem: Chrome supports SVG 2, which allows CSS height and width configurations, but Firefox doesn't support that yet.

Tried using `@supports (-moz-appearance:none)` as suggested by @JohnDanz but was unable to make it work, so I just hardcoded the values in the SVG's rect element. 