### PR TITLE
Possible fix for weird glitches involving chrome's address bar

### DIFF
--- a/packages/augur-ui/src/assets/styles/_misc_redesign.less
+++ b/packages/augur-ui/src/assets/styles/_misc_redesign.less
@@ -31,6 +31,8 @@
 @multi-top-bar-height-mobile: 6rem;
 @multi-top-bar-height: 90px;
 @tutorial-banner-height: 2rem;
+// android chrome specific
+@chrome-address-bar: 6.5rem;
 
 @add-funds-height: 492px;
 

--- a/packages/augur-ui/src/modules/app/components/inner-nav/inner-nav.styles.less
+++ b/packages/augur-ui/src/modules/app/components/inner-nav/inner-nav.styles.less
@@ -122,6 +122,8 @@
     position: fixed;
     height: 100%;
     bottom: 0;
+    padding-bottom: @chrome-address-bar;
+    min-height: calc(100% + @chrome-address-bar);
 
     &.mobileShow {
       left: 0;


### PR DESCRIPTION
#6629

Bug happening on Android phones using Chrome. When the address bar was being hidden, some content would get cut or turn transparent at the bottom of the screen.

I think I found a fix. Tested on my Galaxy S9+ and it's not getting cut anymore.

Most common area where this was happening: scrolling down when inside "Categories & Filters" menu would show a gray bar at the bottom. If you had clicked something and the "Apply" button was showing, that button was getting cut. See screenshot bellow for the error. That has been fixed. Have to test on different devices.

![Cut Apply Button](https://images.zenhubusercontent.com/5c07af47035895308911c4c5/356de118-2c94-4815-9f6f-6d349ba19690)
