### PR TITLE
standardize invalid market label and create a comparison constant to …

### DIFF
--- a/packages/augur-ui/src/modules/app/components/inner-nav/markets-list-filters.tsx
+++ b/packages/augur-ui/src/modules/app/components/inner-nav/markets-list-filters.tsx
@@ -9,6 +9,7 @@ import {
   spreadFilters,
   TEMPLATE_FILTER,
   templateFilterValues,
+  INVALID_OUTCOME_LABEL,
 } from 'modules/common/constants';
 import Styles from 'modules/app/components/inner-nav/markets-list-filters.styles.less';
 import { FilterIcon, helpIcon } from 'modules/common/icons';
@@ -186,7 +187,7 @@ const MarketsListFilters = ({
               <span>Invalid Markets</span>
               {generateTooltip(
                 'Filters markets where the current best bid/offer would profit as a result of a market resolving as invalid',
-                'invalid'
+                INVALID_OUTCOME_LABEL
               )}
             </div>
 

--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -394,7 +394,8 @@ export const MARKET_FULLY_LOADED = 'MARKET_FULLY_LOADED';
 
 // # Market Outcome Constants
 export const INVALID_OUTCOME_ID = 0;
-export const INVALID_OUTCOME_NAME = 'Invalid';
+export const INVALID_OUTCOME_COMPARE = 'Invalid';
+export const INVALID_OUTCOME_LABEL = 'Invalid Market';
 export const YES_NO_NO_ID = 1;
 export const YES_NO_NO_OUTCOME_NAME = 'No';
 export const YES_NO_YES_ID = 2;
@@ -987,7 +988,7 @@ export const NON_EXISTENT = 'N/A';
 export const YES_NO_OUTCOMES = [
   {
     id: 0,
-    description: 'Invalid',
+    description: INVALID_OUTCOME_LABEL,
     isTradeable: true,
   },
   {
@@ -1005,7 +1006,7 @@ export const YES_NO_OUTCOMES = [
 export const SCALAR_OUTCOMES = [
   {
     id: 0,
-    description: 'Invalid',
+    description: INVALID_OUTCOME_LABEL,
     isTradeable: true,
   },
   {
@@ -1218,7 +1219,7 @@ export const TUTORIAL_PRICE = 0.4;
 export const TRADING_TUTORIAL_OUTCOMES = [
   {
     id: 0,
-    description: 'Invalid',
+    description: INVALID_OUTCOME_LABEL,
     isTradeable: true,
   },
   {

--- a/packages/augur-ui/src/modules/common/form.tsx
+++ b/packages/augur-ui/src/modules/common/form.tsx
@@ -23,7 +23,7 @@ import {
   LoadingEllipse,
 } from 'modules/common/icons';
 import debounce from 'utils/debounce';
-import { CUSTOM, SCALAR, ZERO, CATEGORY_PARAM_NAME } from 'modules/common/constants';
+import { CUSTOM, SCALAR, ZERO, CATEGORY_PARAM_NAME, INVALID_OUTCOME_LABEL } from 'modules/common/constants';
 import { ExclamationCircle } from 'modules/common/icons';
 import { Subheaders, DisputingButtonView } from 'modules/reporting/common';
 import { formatAttoRep, formatNumber } from 'utils/format-number';
@@ -1015,7 +1015,7 @@ export class ReportingRadioBar extends Component<ReportingRadioBarProps, {}> {
         }}
       >
         {checked ? FilledRadio : EmptyRadio}
-        <h5>{header}</h5>
+        <h5>{isInvalid ? INVALID_OUTCOME_LABEL : header}</h5>
         <div onClick={e => e.stopPropagation()}>
           {isDisputing && ( // for disputing or for scalar
             <>

--- a/packages/augur-ui/src/modules/common/labels.tsx
+++ b/packages/augur-ui/src/modules/common/labels.tsx
@@ -742,7 +742,7 @@ export const InvalidLabel = ({
 
   return (
     <span className={Styles.InvalidLabel}>
-      {text}
+      {constants.INVALID_OUTCOME_LABEL}
       <label
         data-tip
         data-for={`${keyId}-${text ? text.replace(/\s+/g, '-') : ''}`}

--- a/packages/augur-ui/src/modules/common/validations.ts
+++ b/packages/augur-ui/src/modules/common/validations.ts
@@ -1,12 +1,11 @@
 import {
-  INVALID_OUTCOME,
   OUTCOME_MAX_LENGTH,
   SATURDAY_DAY_OF_WEEK,
   SUNDAY_DAY_OF_WEEK,
 } from 'modules/create-market/constants';
 import isAddress from 'modules/auth/helpers/is-address';
 import { createBigNumber } from 'utils/create-big-number';
-import { ZERO } from './constants';
+import { ZERO, INVALID_OUTCOME_COMPARE } from './constants';
 import { NewMarketPropertiesValidations } from 'modules/types';
 import {
   ValidationType,
@@ -157,7 +156,7 @@ export function checkOutcomesArray(value) {
     const invalid = value.findIndex(
       outcome =>
         outcome &&
-        outcome.trim().toLowerCase() === INVALID_OUTCOME.toLowerCase()
+        outcome.trim().toLowerCase() === INVALID_OUTCOME_COMPARE.toLowerCase()
     );
     if (invalid !== -1)
       errors[invalid] = ['Can\'t enter "Market is Invalid" as an outcome'];

--- a/packages/augur-ui/src/modules/create-market/constants.ts
+++ b/packages/augur-ui/src/modules/create-market/constants.ts
@@ -48,7 +48,6 @@ import {
   SOCIAL_MEDIA,
 } from '@augurproject/artifacts';
 
-export const INVALID_OUTCOME = 'Invalid';
 
 // Button Types
 export const BACK = 'back';

--- a/packages/augur-ui/src/modules/create-market/get-template.ts
+++ b/packages/augur-ui/src/modules/create-market/get-template.ts
@@ -23,7 +23,7 @@ import {
   TimeOffset,
 } from '@augurproject/artifacts';
 import { YesNoMarketIcon, CategoricalMarketIcon, ScalarMarketIcon } from 'modules/common/icons';
-import { YES_NO, CATEGORICAL, SCALAR, YES_NO_OUTCOMES, SCALAR_OUTCOMES } from 'modules/common/constants';
+import { YES_NO, CATEGORICAL, SCALAR, YES_NO_OUTCOMES, SCALAR_OUTCOMES, INVALID_OUTCOME_LABEL } from 'modules/common/constants';
 import { NameValuePair } from 'modules/common/selection';
 import { OutcomeFormatted, DateTimeComponents } from 'modules/types';
 import { timestampComponents } from 'utils/format-date';
@@ -305,7 +305,7 @@ export const getFormattedOutcomes = (
     }));
     outcomesFormatted.unshift({
       id: 0,
-      description: 'Invalid',
+      description: INVALID_OUTCOME_LABEL,
       isTradeable: true,
     });
   } else if (marketType === SCALAR) {

--- a/packages/augur-ui/src/modules/market-cards/common.tsx
+++ b/packages/augur-ui/src/modules/market-cards/common.tsx
@@ -8,7 +8,7 @@ import {
   SCALAR_UP_ID,
   YES_NO,
   ZERO,
-  INVALID_OUTCOME_NAME,
+  INVALID_OUTCOME_LABEL,
   SUBMIT_DISPUTE,
   SCALAR_DOWN_ID,
   SCALAR_INVALID_BEST_BID_ALERT_VALUE as INVALID_ALERT_PERCENTAGE,
@@ -135,7 +135,7 @@ export const DisputeOutcome = (props: DisputeOutcomeProps) => {
       <span>
         {props.isWarpSync && !props.invalid
           ? props.stake.warpSyncHash
-          : props.description}
+          : props.invalid ? INVALID_OUTCOME_LABEL : props.description}
       </span>
       {!props.forkingMarket && (
         <>
@@ -494,7 +494,7 @@ export const ResolvedOutcomes = (props: ResolvedOutcomesProps) => {
       <span>Winning Outcome {CheckCircleIcon} </span>
       <span>
         {props.consensusFormatted.invalid
-          ? INVALID_OUTCOME_NAME
+          ? INVALID_OUTCOME_LABEL
           : props.consensusFormatted.outcomeName}
       </span>
       {props.expanded && (
@@ -532,7 +532,7 @@ export const TentativeWinner = (props: TentativeWinnerProps) => {
           <span>Tentative Winner</span>
           <span>
             {props.tentativeWinner.isInvalidOutcome
-              ? INVALID_OUTCOME_NAME
+              ? INVALID_OUTCOME_LABEL
               : getOutcomeNameWithOutcome(
                   props.market,
                   props.tentativeWinner.outcome,

--- a/packages/augur-ui/src/modules/market/components/market-header/market-header-reporting.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-header/market-header-reporting.tsx
@@ -4,7 +4,7 @@ import Styles from 'modules/market/components/market-header/market-header-report
 import {
   REPORTING_STATE,
   SCALAR,
-  INVALID_OUTCOME_NAME,
+  INVALID_OUTCOME_LABEL,
   SUBMIT_REPORT,
   SUBMIT_DISPUTE,
   PROCEEDS_TO_CLAIM_TITLE,
@@ -57,7 +57,7 @@ export const MarketHeaderReporting = ({
           <span>Winning Outcome</span>
           <span>
             {consensusFormatted.invalid
-              ? INVALID_OUTCOME_NAME
+              ? INVALID_OUTCOME_LABEL
               : consensusFormatted.outcomeName}
           </span>
         </div>
@@ -96,7 +96,7 @@ export const MarketHeaderReporting = ({
               <span>
                 {tentativeWinner &&
                   (tentativeWinner.isInvalidOutcome
-                    ? 'Invalid'
+                    ? INVALID_OUTCOME_LABEL
                     : market.marketType === SCALAR
                     ? tentativeWinner.outcome
                     : getOutcomeNameWithOutcome(

--- a/packages/augur-ui/src/modules/modal/reporting.tsx
+++ b/packages/augur-ui/src/modules/modal/reporting.tsx
@@ -18,7 +18,7 @@ import {
 import {
   SCALAR,
   REPORTING_STATE,
-  INVALID_OUTCOME_NAME,
+  INVALID_OUTCOME_LABEL,
   SUBMIT_REPORT,
   SUBMIT_DISPUTE,
   MARKETMIGRATED,
@@ -40,7 +40,7 @@ import Styles from 'modules/modal/modal.styles.less';
 import { Getters, TXEventName } from '@augurproject/sdk';
 import { loadAccountCurrentDisputeHistory } from 'modules/auth/actions/load-account-reporting';
 import ReleasableRepNotice from 'modules/reporting/containers/releasable-rep-notice';
-import { ExplainerBlock, MultipleExplainerBlock } from 'modules/create-market/components/common';
+import { MultipleExplainerBlock } from 'modules/create-market/components/common';
 import {
   AugurMarketsContent,
   EventDetailsContent,
@@ -212,7 +212,7 @@ export default class ModalReporting extends Component<
       const denomination = market.scalarDenomination;
       disputeInfo.stakes.forEach(stake => {
         const populatedHeader = stake.isInvalidOutcome
-          ? INVALID_OUTCOME_NAME
+          ? INVALID_OUTCOME_LABEL
           : `${stake.outcome} ${denomination}`;
         radioButtons.push({
           id: String(stake.outcome),

--- a/packages/augur-ui/src/modules/portfolio/containers/filled-order.ts
+++ b/packages/augur-ui/src/modules/portfolio/containers/filled-order.ts
@@ -5,7 +5,7 @@ import { formatDai, calcPercentageFromPrice, formatMarketShares } from 'utils/fo
 import {
   COLUMN_TYPES,
   SCALAR,
-  INVALID_OUTCOME_NAME,
+  INVALID_OUTCOME_COMPARE,
 } from 'modules/common/constants';
 
 import Row from 'modules/common/row';
@@ -25,7 +25,7 @@ const mergeProps = (sP: any, dP: any, oP: any) => {
   const orderType = filledOrder.type;
 
   const originalQuantity = formatMarketShares(filledOrder.marketType, filledOrder.originalQuantity);
-  const usePercent = filledOrder.outcome === INVALID_OUTCOME_NAME && filledOrder.marketType === SCALAR;
+  const usePercent = filledOrder.outcome === INVALID_OUTCOME_COMPARE && filledOrder.marketType === SCALAR;
   if (usePercent) {
     const market = sP.marketInfos[filledOrder.marketId];
     const orderPricePercent = calcPercentageFromPrice(

--- a/packages/augur-ui/src/modules/trading/components/form.tsx
+++ b/packages/augur-ui/src/modules/trading/components/form.tsx
@@ -12,6 +12,8 @@ import {
   SMALL_MOBILE,
   MIN_ORDER_LIFESPAN,
   MIN_QUANTITY,
+  INVALID_OUTCOME_COMPARE,
+  INVALID_OUTCOME_LABEL,
 } from 'modules/common/constants';
 import FormStyles from 'modules/common/form-styles.less';
 import Styles from 'modules/trading/components/form.styles.less';
@@ -871,7 +873,7 @@ class Form extends Component<FromProps, FormState> {
             options={sortedOutcomes
               .filter(outcome => outcome.isTradeable)
               .map(outcome => ({
-                label: outcome.description,
+                label: outcome.description === INVALID_OUTCOME_COMPARE ? INVALID_OUTCOME_LABEL : outcome.description,
                 value: outcome.id,
               }))}
             large

--- a/packages/augur-ui/src/utils/convert-marketInfo-marketData.ts
+++ b/packages/augur-ui/src/utils/convert-marketInfo-marketData.ts
@@ -11,6 +11,7 @@ import {
   INVALID_OUTCOME_ID,
   ARCHIVED_MARKET_LENGTH,
   SCALAR_UP_ID,
+  INVALID_OUTCOME_LABEL,
 } from 'modules/common/constants';
 import { convertUnixToFormattedDate, getDurationBetween } from './format-date';
 import {
@@ -25,7 +26,6 @@ import { keyBy } from './key-by';
 import { getOutcomeNameWithOutcome } from './get-outcome';
 import moment = require('moment');
 import deepClone from './deep-clone';
-import { INVALID_OUTCOME } from 'modules/create-market/constants';
 
 export function convertMarketInfoToMarketData(
   marketInfo: Getters.Markets.MarketInfo,
@@ -243,7 +243,7 @@ function processConsensus(
       ...market.consensus,
       winningOutcome: market.consensus.outcome,
       outcomeName: isScalar
-        ? market.consensus.invalid ? INVALID_OUTCOME : market.consensus.outcome
+        ? market.consensus.invalid ? INVALID_OUTCOME_LABEL : market.consensus.outcome
         : getOutcomeNameWithOutcome(
             market,
             market.consensus.outcome,
@@ -260,7 +260,7 @@ function processConsensus(
       ...winning,
       winningOutcome: winning.outcome,
       outcomeName: isScalar
-        ? winning.isInvalidOutcome ? INVALID_OUTCOME : winning.outcome
+        ? winning.isInvalidOutcome ? INVALID_OUTCOME_LABEL : winning.outcome
         : getOutcomeNameWithOutcome(
             market,
             winning.outcome,

--- a/packages/augur-ui/src/utils/get-outcome.ts
+++ b/packages/augur-ui/src/utils/get-outcome.ts
@@ -5,14 +5,14 @@ import {
   YES_NO_YES_ID,
   YES_NO_NO_OUTCOME_NAME,
   INVALID_OUTCOME_ID,
-  SCALAR
+  SCALAR,
+  INVALID_OUTCOME_LABEL
 } from 'modules/common/constants';
 import { MarketData } from 'modules/types';
-import { INVALID_OUTCOME } from 'modules/create-market/constants';
-import { MarketInfo } from '@augurproject/sdk/src/state/getter/Markets';
+import { Getters } from '@augurproject/sdk';
 
 const getOutcomeName = (
-  market: MarketData | MarketInfo,
+  market: MarketData | Getters.Markets.MarketInfo,
   outcomeId: number,
   isInvalid: boolean = false,
   showScalarOutcome: boolean = false
@@ -23,7 +23,7 @@ const getOutcomeName = (
   // default to handle app loading
   if (!marketType) return YES_NO_YES_OUTCOME_NAME;
 
-  if ((marketType !== SCALAR && outcomeId === INVALID_OUTCOME_ID) || isInvalid) return INVALID_OUTCOME;
+  if ((marketType !== SCALAR && outcomeId === INVALID_OUTCOME_ID) || isInvalid) return INVALID_OUTCOME_LABEL;
 
   switch (marketType) {
     case YES_NO: {


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/8014

replace 'Invalid' text to use  constant. standardized to Invalid Market. There are a few places where outcome description is compared now using constant

![image](https://user-images.githubusercontent.com/3970376/84413814-bf5b3c80-abd6-11ea-9cbb-9b422555f412.png)

![image](https://user-images.githubusercontent.com/3970376/84413843-c8e4a480-abd6-11ea-8ef2-871241725cd5.png)


![image](https://user-images.githubusercontent.com/3970376/84413867-d13cdf80-abd6-11ea-8aed-3b07f711bcee.png)

![image](https://user-images.githubusercontent.com/3970376/84413891-da2db100-abd6-11ea-95db-5b69917931fa.png)

![image](https://user-images.githubusercontent.com/3970376/84415176-fed65880-abd7-11ea-931c-c1a535c830d6.png)
