### PR TITLE
Add best offer getter

### DIFF
--- a/packages/augur-sdk/src/Augur.ts
+++ b/packages/augur-sdk/src/Augur.ts
@@ -28,6 +28,11 @@ import {
   CreateYesNoMarketParams,
   Market,
 } from './api/Market';
+import {
+  BestOffer,
+  GetBestOffersParams,
+  BestOffersOrders
+} from './api/BestOffer';
 import { OnChainTrade } from './api/OnChainTrade';
 import { PlaceTradeDisplayParams, SimulateTradeData, Trade } from './api/Trade';
 import { Uniswap } from './api/Uniswap';
@@ -76,6 +81,7 @@ export class Augur<TProvider extends Provider = Provider> {
   readonly universe: Universe;
   readonly liquidity: Liquidity;
   readonly hotLoading: HotLoading;
+  readonly bestOffer: BestOffer;
   readonly events: Subscriptions;
 
   private _sdkReady = false;
@@ -139,6 +145,7 @@ export class Augur<TProvider extends Provider = Provider> {
       );
     this.warpSync = new WarpSync(this);
     this.hotLoading = new HotLoading(this);
+    this.bestOffer = new BestOffer(this);
     this.onChainTrade = new OnChainTrade(this);
     this.trade = new Trade(this);
     if (enableFlexSearch && !this.syncableFlexSearch) {
@@ -536,6 +543,10 @@ export class Augur<TProvider extends Provider = Provider> {
 
   async getDisputeWindow(params: GetDisputeWindowParams): Promise<DisputeWindow> {
     return this.hotLoading.getCurrentDisputeWindowData(params);
+  }
+
+  async getBestOffers(params: GetBestOffersParams): Promise<BestOffersOrders> {
+    return this.bestOffer.getBestOffers(params);
   }
 
   async simulateTrade(

--- a/packages/augur-sdk/src/Augur.ts
+++ b/packages/augur-sdk/src/Augur.ts
@@ -65,6 +65,7 @@ import { Users } from './state/getter/Users';
 import { WarpSyncGetter } from './state/getter/WarpSyncGetter';
 import { ZeroXOrdersGetters } from './state/getter/ZeroXOrdersGetters';
 import { Subscriptions } from './subscriptions';
+import { LiquidityPool } from './state/getter/LiquidityPool';
 
 export class Augur<TProvider extends Provider = Provider> {
   syncableFlexSearch: SyncableFlexSearch;
@@ -545,9 +546,11 @@ export class Augur<TProvider extends Provider = Provider> {
     return this.hotLoading.getCurrentDisputeWindowData(params);
   }
 
-  async getBestOffers(params: GetBestOffersParams): Promise<BestOffersOrders> {
-    return this.bestOffer.getBestOffers(params);
-  }
+  getMarketOutcomeBestOffer = (
+    params: Parameters<typeof LiquidityPool.getMarketOutcomeBestOffer>[2]
+  ): ReturnType<typeof LiquidityPool.getMarketOutcomeBestOffer> => {
+    return this.bindTo(LiquidityPool.getMarketOutcomeBestOffer)(params);
+  };
 
   async simulateTrade(
     params: PlaceTradeDisplayParams

--- a/packages/augur-sdk/src/api/BestOffer.ts
+++ b/packages/augur-sdk/src/api/BestOffer.ts
@@ -1,6 +1,23 @@
 import { Augur } from '../Augur';
+import { BigNumber } from 'bignumber.js';
 import { SubscriptionEventName } from '../constants';
 import { Logs } from '../state';
+import { OrderTypeHex } from '../state/logs/types';
+import * as _ from 'lodash';
+import { MarketLiquidityPool } from '../state/getter/LiquidityPool';
+import {
+  convertOnChainPriceToDisplayPrice,
+  convertOnChainAmountToDisplayAmount,
+} from '../index';
+
+export interface LiquidityPoolUpdated {
+  [liquidityPoolId: string]: {
+    [outcome: number]: {
+      price: string;
+      shares: string;
+    }[];
+  };
+}
 
 export interface BestOfferOrder {
   price: string;
@@ -14,6 +31,8 @@ export interface BestOffersOrders {
 export interface GetBestOffersParams {
   liquidityPools: string[];
 }
+const CAT_TICK_SIZE = new BigNumber(0.01);
+const CAT_MIN_PRICE = new BigNumber(0);
 export class BestOffer {
   private readonly augur: Augur;
 
@@ -22,23 +41,114 @@ export class BestOffer {
 
     this.augur.events.subscribe(
       SubscriptionEventName.BulkOrderEvent,
-      orderEvents => this.determinBestOfferForLiquidityPool(orderEvents)
+      orderEvents => this.determineBestOfferForLiquidityPool(orderEvents)
     );
   }
 
-  determinBestOfferForLiquidityPool(orders: Logs.ParsedOrderEventLog[]) {
-    console.log(orders);
+  determineBestOfferForLiquidityPool(orders: {
+    logs: Logs.ParsedOrderEventLog[];
+  }) {
+    console.log('order events', orders);
+    const onlyOffers = orders.logs.filter(
+      o => String(o.orderType) === OrderTypeHex.Ask
+    );
+    const bestBulkOrders = this.getBestPricePerOutcomeInMarket(onlyOffers);
+    const flatten: Logs.ParsedOrderEventLog[] = [];
+    _.forOwn(bestBulkOrders, market => {
+      _.forOwn(market, outcome => {
+        flatten.push(outcome);
+      });
+    });
+    Promise.all(
+      _.map(flatten, async order => {
+        const poolBestPrice = await this.augur.getMarketOutcomeBestOffer({
+          marketId: order.market,
+          outcome: order.outcome,
+        });
+        if (
+          poolBestPrice &&
+          new BigNumber(
+            poolBestPrice[_.first(_.keys(poolBestPrice))][order.outcome].price
+          ).eq(new BigNumber(order.price))
+        ) {
+          return poolBestPrice;
+        }
+        return null;
+      })
+    ).then(updates => {
+      const liquiditPoolsUpdated = _.reduce(
+        updates,
+        (p, liq) => (liq ? { ...p, ...this.convertToDisplayvalues(liq) } : p),
+        {}
+      );
+
+      this.augur.events.emit(
+        SubscriptionEventName.LiquidityPoolUpdated,
+        liquiditPoolsUpdated
+      );
+      console.log('best offer', liquiditPoolsUpdated);
+    });
   }
 
-  async getBestOffers(params: GetBestOffersParams): Promise<BestOffersOrders> {
-    console.log(params);
-    return {
-      '0x333': {
-        1: {
-          price: '0.3',
-          shares: '100'
-        }
-      }
-    };
-  }
+  convertToDisplayvalues = (liq: MarketLiquidityPool): any => {
+    return _.keys(liq).reduce((pools, pool) => {
+      const outcomes = _.keys(liq[pool]).reduce(
+        (outcomes, outcome) => ({
+          ...outcomes,
+          [Number(new BigNumber(outcome))]: this.convertOrderToDisplayValues(
+            liq[pool][outcome]
+          ),
+        }),
+        {}
+      );
+      return { ...pools, [pool]: outcomes };
+    }, {});
+  };
+
+  convertOrderToDisplayValues = order => ({
+    ...order,
+    price: String(
+      convertOnChainPriceToDisplayPrice(
+        new BigNumber(order.price),
+        CAT_MIN_PRICE,
+        CAT_TICK_SIZE
+      ).toFixed()
+    ),
+    shares: String(
+      convertOnChainAmountToDisplayAmount(
+        new BigNumber(order.shares),
+        CAT_TICK_SIZE
+      ).toFixed()
+    ),
+  });
+
+  getBestPricePerOutcomeInMarket = (onlyOffers: Logs.ParsedOrderEventLog[]) => {
+    const marketIds: _.Dictionary<Logs.ParsedOrderEventLog[]> = _.groupBy(
+      onlyOffers,
+      'market'
+    );
+    return _.reduce(
+      _.keys(marketIds),
+      (agg, marketId) => {
+        const outcomeOrders = _.groupBy(marketIds[marketId], 'outcome');
+        const outcomeBestOffer = _.reduce(
+          _.keys(outcomeOrders),
+          (p, outcome) => {
+            const offers = outcomeOrders[outcome];
+            const bestOffer = offers.reduce(
+              (lowerAsk, order) =>
+                new BigNumber(order.price).lte(new BigNumber(lowerAsk.price))
+                  ? lowerAsk
+                  : order,
+              _.first(offers)
+            );
+            return { ...p, [outcome]: bestOffer };
+          },
+          {}
+        );
+        return { ...agg, [marketId]: outcomeBestOffer };
+      },
+      {}
+    );
+  };
 }

--- a/packages/augur-sdk/src/api/BestOffer.ts
+++ b/packages/augur-sdk/src/api/BestOffer.ts
@@ -1,0 +1,20 @@
+import { Augur } from '../Augur';
+import { SubscriptionEventName } from '../constants';
+import { Logs } from '../state';
+
+export class BestOffer {
+  private readonly augur: Augur;
+
+  constructor(augur: Augur) {
+    this.augur = augur;
+
+    this.augur.events.subscribe(
+      SubscriptionEventName.BulkOrderEvent,
+      orderEvents => this.getBestOfferForMarketOrders(orderEvents)
+    );
+  }
+
+  getBestOfferForMarketOrders(orders: Logs.ParsedOrderEventLog[]) {
+    console.log(orders);
+  }
+}

--- a/packages/augur-sdk/src/api/BestOffer.ts
+++ b/packages/augur-sdk/src/api/BestOffer.ts
@@ -2,6 +2,18 @@ import { Augur } from '../Augur';
 import { SubscriptionEventName } from '../constants';
 import { Logs } from '../state';
 
+export interface BestOfferOrder {
+  price: string;
+  shares: string;
+}
+export interface BestOffersOrders {
+  [liquityPoolId: string]: {
+    [outcome: number]: BestOfferOrder;
+  };
+}
+export interface GetBestOffersParams {
+  liquidityPools: string[];
+}
 export class BestOffer {
   private readonly augur: Augur;
 
@@ -10,11 +22,23 @@ export class BestOffer {
 
     this.augur.events.subscribe(
       SubscriptionEventName.BulkOrderEvent,
-      orderEvents => this.getBestOfferForMarketOrders(orderEvents)
+      orderEvents => this.determinBestOfferForLiquidityPool(orderEvents)
     );
   }
 
-  getBestOfferForMarketOrders(orders: Logs.ParsedOrderEventLog[]) {
+  determinBestOfferForLiquidityPool(orders: Logs.ParsedOrderEventLog[]) {
     console.log(orders);
+  }
+
+  async getBestOffers(params: GetBestOffersParams): Promise<BestOffersOrders> {
+    console.log(params);
+    return {
+      '0x333': {
+        1: {
+          price: '0.3',
+          shares: '100'
+        }
+      }
+    };
   }
 }

--- a/packages/augur-sdk/src/api/BestOffer.ts
+++ b/packages/augur-sdk/src/api/BestOffer.ts
@@ -65,7 +65,7 @@ export class BestOffer {
           outcome: order.outcome,
         });
         if (
-          poolBestPrice &&
+          poolBestPrice && _.keys(poolBestPrice).length > 0 &&
           new BigNumber(
             poolBestPrice[_.first(_.keys(poolBestPrice))][order.outcome].price
           ).eq(new BigNumber(order.price))

--- a/packages/augur-sdk/src/api/BestOffer.ts
+++ b/packages/augur-sdk/src/api/BestOffer.ts
@@ -48,7 +48,6 @@ export class BestOffer {
   determineBestOfferForLiquidityPool(orders: {
     logs: Logs.ParsedOrderEventLog[];
   }) {
-    console.log('order events', orders);
     const onlyOffers = orders.logs.filter(
       o => String(o.orderType) === OrderTypeHex.Ask
     );
@@ -82,11 +81,12 @@ export class BestOffer {
         {}
       );
 
-      this.augur.events.emit(
-        SubscriptionEventName.LiquidityPoolUpdated,
-        liquiditPoolsUpdated
-      );
-      console.log('best offer', liquiditPoolsUpdated);
+      if (_.keys(liquiditPoolsUpdated).length > 0) {
+        this.augur.events.emit(
+          SubscriptionEventName.LiquidityPoolUpdated,
+          liquiditPoolsUpdated
+        );
+      }
     });
   }
 

--- a/packages/augur-sdk/src/constants.ts
+++ b/packages/augur-sdk/src/constants.ts
@@ -60,6 +60,7 @@ export enum SubscriptionEventName {
   ZeroXStatusRestarting = 'ZeroX:Status:Restarting',
   ZeroXStatusError = 'ZeroX:Status:Error',
   WarpSyncHashUpdated = 'WarpSyncHashUpdated',
+  LiquidityPoolUpdated = 'LiquidityPoolUpdated',
 }
 
 export enum TXEventName {

--- a/packages/augur-sdk/src/state/db/DB.ts
+++ b/packages/augur-sdk/src/state/db/DB.ts
@@ -338,7 +338,7 @@ export class DB {
       schemas[genericEventDBDescription.EventName] = fields.join(',');
     }
     schemas['Markets'] =
-      'market,reportingState,universe,marketCreator,timestamp,finalized,blockNumber';
+      'market,reportingState,universe,marketCreator,timestamp,finalized,blockNumber,groupHash,liquidityPool';
     schemas['CurrentOrders'] =
       'orderId,[market+open],[market+outcome+orderType],orderCreator,orderFiller,blockNumber';
     schemas['Dispute'] = '[market+payoutNumerators],market,blockNumber';

--- a/packages/augur-sdk/src/state/db/MarketDB.ts
+++ b/packages/augur-sdk/src/state/db/MarketDB.ts
@@ -552,13 +552,13 @@ export class MarketDB extends DerivedDB {
             canPoolLiquidity, liquidityPoolId } = getGroupHashInfo(
             log['extraInfo'].template
           );
-          log['templateGroupHash'] = hashKeyInputValues;
-          log['templateGroupType'] = groupType;
-          log['templateGroupLine'] = groupLine;
-          log['templateGroupHeader'] = header;
-          log['templateGroupTitle'] = title;
-          log['templateGroupEst'] = estTimestamp;
-          log['templateLiquidityPool'] = canPoolLiquidity ? liquidityPoolId : log['market'];
+          log['groupHash'] = hashKeyInputValues;
+          log['groupType'] = groupType;
+          log['groupLine'] = groupLine;
+          log['groupHeader'] = header;
+          log['groupTitle'] = title;
+          log['groupEstDatetime'] = estTimestamp;
+          log['liquidityPool'] = canPoolLiquidity ? liquidityPoolId : log['market'];
         }
       }
     } catch (err) {

--- a/packages/augur-sdk/src/state/getter/LiquidityPool.ts
+++ b/packages/augur-sdk/src/state/getter/LiquidityPool.ts
@@ -1,0 +1,131 @@
+import { DB } from '../db/DB';
+import * as _ from 'lodash';
+import { Augur } from '../../index';
+import { BigNumber } from 'bignumber.js';
+import { Getter } from './Router';
+import { getMarkets, Order, OrderState } from './OnChainTrading';
+import { StoredOrder } from '../db/ZeroXOrders';
+import Dexie from 'dexie';
+import * as t from 'io-ts';
+import { MarketData, OrderType, OrderTypeHex } from '../logs/types';
+import { ZeroXOrdersGetters } from './ZeroXOrdersGetters';
+
+export interface BestOfferOrder {
+  price: string;
+  shares: string;
+}
+export interface MarketLiquidityPool {
+  [liquityPoolId: string]: {
+    [outcome: number]: BestOfferOrder;
+  };
+}
+
+export const MarketPoolBestOfferParam = t.type({
+  marketIds: t.array(t.string),
+});
+
+export const MarketOutcomeBestOfferParam = t.type({
+  marketId: t.string,
+  outcome: t.string,
+});
+
+export class LiquidityPool {
+  static GetMarketPoolBestOfferParam = MarketPoolBestOfferParam;
+  static GetMarketOutcomeBestOfferParams = MarketOutcomeBestOfferParam;
+
+  //@Getter('GetMarketsLiquidityPoolParam')
+  static async getMarketsLiquidityPool(
+    augur: Augur,
+    db: DB,
+    params: t.TypeOf<typeof LiquidityPool.GetMarketPoolBestOfferParam>
+  ): Promise<MarketLiquidityPool> {
+    // get outcomes and build liquidity pool
+    const markets: MarketData[] = await db.Markets.where('market')
+      .anyOf(params.marketIds)
+      .toArray();
+    const groupHashes = _.uniq(_.keys(_.keyBy(markets, 'groupHash')));
+    const groupMarkets: MarketData[] = await db.Markets.where('groupHash')
+      .anyOf(groupHashes)
+      .toArray();
+    const totalMarkets = _.uniq(_.keys(_.keyBy(groupMarkets, 'market')));
+    const allMarketsInPools: MarketData[] = await db.Markets.where('market')
+      .anyOf(totalMarkets)
+      .toArray();
+    const allPools = _.uniq(
+      _.keys(_.keyBy(allMarketsInPools, 'liquidityPool'))
+    );
+    const getterParams = {};
+    // return ZeroXOrdersGetters.getZeroXOrders(augur, db, params);
+    return {
+      '0x333': {
+        1: {
+          price: '0.3',
+          shares: '100',
+        },
+      },
+    };
+  }
+
+  @Getter('GetMarketOutcomeBestOfferParams')
+  static async getMarketOutcomeBestOffer(
+    augur: Augur,
+    db: DB,
+    params: t.TypeOf<typeof LiquidityPool.GetMarketOutcomeBestOfferParams>
+  ): Promise<MarketLiquidityPool> {
+    const orderType = OrderTypeHex.Ask;
+    const outcome = params.outcome;
+    const liqPool = await LiquidityPool.getPoolsOfMarkets(db, [
+      params.marketId,
+    ]);
+    if (!liqPool) return null;
+
+    // market can only be in one liquidity pool
+    const liquidityPoolId = _.first(_.keys(liqPool));
+    const marketIds = _.map(_.first(_.values(liqPool)), 'market');
+
+    // when getting orders need to use outcome number not hex value
+    const unsortedOffers = await db.ZeroXOrders.where('market')
+      .anyOfIgnoreCase(marketIds)
+      .and(order => order.outcome === outcome && order.orderType === orderType)
+      .toArray();
+
+    const bucketsByPrice = _.groupBy(unsortedOffers, order => order.price);
+
+    const lastSortedOrder = Object.keys(bucketsByPrice).sort((a, b) =>
+      new BigNumber(b).minus(a).toNumber()
+    );
+
+    const sortedOrders = lastSortedOrder.map(k => bucketsByPrice[k]);
+    for (let i = 0, size = sortedOrders.length; i < size; i++) {
+      sortedOrders[i].sort((a, b) => parseFloat(b.amount) - parseFloat(a.amount));
+    }
+
+    const size = _.last(_.values(sortedOrders)).reduce(
+      (size, orders) => new BigNumber(orders.amount).plus(size),
+      new BigNumber(0)
+    );
+    const bestPrice = { price: _.last(lastSortedOrder), shares: String(size) };
+    return {
+      [liquidityPoolId]: {
+        [outcome]: bestPrice,
+      },
+    };
+  }
+
+  static async getPoolsOfMarkets(
+    db: DB,
+    marketIds: string[]
+  ): Promise<_.Dictionary<MarketData[]>> {
+    const markets: MarketData[] = await db.Markets.where('market')
+      .anyOf(marketIds)
+      .toArray();
+    const liquidityPools = _.uniq(_.keys(_.groupBy(markets, 'liquidityPool')));
+    const liquidityPoolsMarkets: MarketData[] = await db.Markets.where(
+      'liquidityPool'
+    )
+      .anyOf(liquidityPools)
+      .toArray();
+    const allPools = _.groupBy(liquidityPoolsMarkets, 'liquidityPool');
+    return allPools;
+  }
+}

--- a/packages/augur-sdk/src/state/getter/LiquidityPool.ts
+++ b/packages/augur-sdk/src/state/getter/LiquidityPool.ts
@@ -77,7 +77,7 @@ export class LiquidityPool {
     const liqPool = await LiquidityPool.getPoolsOfMarkets(db, [
       params.marketId,
     ]);
-    if (!liqPool) return null;
+    if (!liqPool || _.keys(liqPool).length === 0) return null;
 
     // market can only be in one liquidity pool
     const liquidityPoolId = _.first(_.keys(liqPool));

--- a/packages/augur-sdk/src/state/getter/Markets.ts
+++ b/packages/augur-sdk/src/state/getter/Markets.ts
@@ -693,7 +693,7 @@ export class Markets {
             return false;
           if (
               params.templateFilter === TemplateFilters.sportsBook &&
-              !market.templateGroupHash
+              !market.groupHash
             )
               return false;
         }
@@ -1458,13 +1458,13 @@ async function getMarketsInfo(
       isWarpSync: marketData.isWarpSync,
       passDefaultLiquiditySpread,
       sportsBook: {
-        groupId: marketData.templateGroupHash,
-        groupType: marketData.templateGroupType,
-        marketLine: marketData.templateGroupLine,
-        header: marketData.templateGroupHeader,
-        title: marketData.templateGroupTitle,
-        estTimestamp: marketData.templateGroupEst,
-        liquidityPool: marketData.templateLiquidityPool
+        groupId: marketData.groupHash,
+        groupType: marketData.groupType,
+        marketLine: marketData.groupLine,
+        header: marketData.groupHeader,
+        title: marketData.groupTitle,
+        estTimestamp: marketData.groupEstDatetime,
+        liquidityPool: marketData.liquidityPool
       }
     };
   });

--- a/packages/augur-sdk/src/state/logs/types.ts
+++ b/packages/augur-sdk/src/state/logs/types.ts
@@ -460,13 +460,13 @@ export interface MarketData extends Log {
   finalized: boolean;
   lastTradedTimestamp: UnixTimestamp;
   isWarpSync: boolean;
-  templateGroupHash?: string;
-  templateGroupType?: string;
-  templateGroupLine?: string;
-  templateGroupHeader?: string;
-  templateGroupTitle?: string;
-  templateGroupEst?: string;
-  templateLiquidityPool?: string;
+  groupHash?: string;
+  groupType?: string;
+  groupLine?: string;
+  groupHeader?: string;
+  groupTitle?: string;
+  groupEstDatetime?: string;
+  liquidityPool?: string;
 }
 
 export interface DisputeDoc extends Log {

--- a/packages/augur-tools/src/flash/create-orders.ts
+++ b/packages/augur-tools/src/flash/create-orders.ts
@@ -76,7 +76,7 @@ export async function createCatZeroXOrders(
   user: ContractAPI,
   market: string,
   skipFaucetApproval: boolean,
-  numOutcomes: number,
+  numOutcomes: number = 3,
 ) {
   if (!skipFaucetApproval) {
     await user.faucetCashUpTo(MILLION, MILLION);
@@ -131,7 +131,7 @@ export async function createCatZeroXOrders(
         direction: 0,
         market,
         numTicks: new BigNumber(100),
-        numOutcomes: 3,
+        numOutcomes: numOutcomes,
         outcome,
         tradeGroupId,
         fingerprint: formatBytes32String('11'),
@@ -168,6 +168,46 @@ export async function createCatZeroXOrders(
   await user.placeZeroXOrders(orders).catch(console.error);
 }
 
+export async function createSingleCatZeroXOrder(
+  user: ContractAPI,
+  market: string,
+  skipFaucetApproval: boolean,
+  numOutcomes: number,
+  direction: number,
+  price: string,
+  shares: string,
+  outcome: number,
+) {
+  if (!skipFaucetApproval) {
+    await user.faucetCashUpTo(MILLION, MILLION);
+    await user.approve();
+  }
+
+  const timestamp = await user.getTimestamp();
+  const tradeGroupId = String(Date.now());
+  const oneHundredDays = new BigNumber(8640000);
+  const expirationTime = new BigNumber(timestamp).plus(oneHundredDays);
+  const orders = [];
+  console.log(`creating ${direction} order, ${shares} @ ${price}`);
+  orders.push({
+    direction,
+    market,
+    numTicks: new BigNumber(100),
+    numOutcomes: numOutcomes,
+    outcome,
+    tradeGroupId,
+    fingerprint: formatBytes32String('11'),
+    doNotCreateOrders: false,
+    displayMinPrice: new BigNumber(0),
+    displayMaxPrice: new BigNumber(1),
+    displayAmount: new BigNumber(shares),
+    displayPrice: new BigNumber(price),
+    displayShares: new BigNumber(0),
+    expirationTime,
+  });
+
+  await user.placeZeroXOrders(orders).catch(console.error);
+}
 
 export async function createScalarZeroXOrders(
   user: ContractAPI,

--- a/packages/augur-tools/src/templates-source.ts
+++ b/packages/augur-tools/src/templates-source.ts
@@ -108,6 +108,7 @@ export const TEMPLATES = {
             question: `MMA: [0] vs. [1], Who will win?`,
             example: `MMA: Donald Cerrone vs. Conor McGregor, Who will win?\nEstimated schedule start time: Jan 18, 2020 8:20 pm EST`,
             header: `[0] vs. [1]`,
+            title: `Money Line`,
             groupName: groupTypes.MONEY_LINE,
             inputs: [
               {
@@ -483,6 +484,7 @@ export const TEMPLATES = {
             question: `Boxing: [0] vs. [1], Who will win?`,
             example: `Boxing: Robert Helenius vs. Adam Kownacki, Who will win?\nEstimated schedule start time: Feb 10, 2020 8:20 pm EST`,
             header: `[0] vs. [1]`,
+            title: `Money Line`,
             groupName: groupTypes.MONEY_LINE,
             inputs: [
               {
@@ -845,6 +847,7 @@ export const TEMPLATES = {
             question: `NASCAR [0] [1]: Winner?`,
             example: `NASCAR 2020 Daytona 500: Winner?\nEstimated schedule start time: Sept 19, 2020 1:00 pm EST`,
             header: `NASCAR [0] [1] winner`,
+            title: `Money Line`,
             groupName: groupTypes.MONEY_LINE,
             inputs: [
               {
@@ -2198,6 +2201,7 @@ export const TEMPLATES = {
                 question: `[0] Single Tennis: [1] [2] Match play winner: [3] vs. [4]?`,
                 example: `Men's Single Tennis: 2020 Wimbledon Match play winner between Roger Federer vs. Rafael Nadal?`,
                 header: `[3] vs. [4]`,
+                title: `Money Line`,
                 groupName: groupTypes.MONEY_LINE,
                 inputs: [
                   {
@@ -2557,6 +2561,7 @@ export const TEMPLATES = {
                 question: `[0] Doubles Tennis: [1] [2] Match play winner: [3] vs. [4]?`,
                 example: `Men's Doubles Tennis: 2020 Wimbledon Match play winner between Kevin Krawietz/Andreas Mies vs. Bob Bryan/Mike Bryan?`,
                 header: `[3] vs. [4]`,
+                title: `Money Line`,
                 groupName: groupTypes.MONEY_LINE,
                 inputs: [
                   {
@@ -2822,6 +2827,7 @@ export const TEMPLATES = {
                 question: `Men's [0]: Which team will win: [1] vs. [2]?`,
                 example: `Men's English Premier League: Which team will win: Manchester City vs. Manchester United?\nEstimated schedule start time: Sept 19, 2019 8:20 pm EST`,
                 header: `(Men's) [0] [1] vs. [2]`,
+                title: `Money Line`,
                 groupName: groupTypes.MONEY_LINE,
                 inputs: [
                   {
@@ -3129,6 +3135,7 @@ export const TEMPLATES = {
                 question: `[0] [1]: Which team will win: [2] vs. [3]?`,
                 example: `Men's World Cup: Which team will win: Real Madrid vs. Manchester United?\nEstimated schedule start time: Sept 19, 2019 8:20 pm EST`,
                 header: `([0]) [2] vs. [3]`,
+                title: `Money Line`,
                 groupName: groupTypes.MONEY_LINE,
                 inputs: [
                   {

--- a/packages/augur-ui/src/modules/events/actions/listen-to-updates.ts
+++ b/packages/augur-ui/src/modules/events/actions/listen-to-updates.ts
@@ -15,6 +15,7 @@ import {
   handleWarpSyncHashUpdatedLog,
   handleZeroStatusUpdated,
   handleBulkOrdersLog,
+  handleLiquidityPoolUpdatedLog,
 } from 'modules/events/actions/log-handlers';
 import { wrapLogHandler } from 'modules/events/actions/wrap-log-handler';
 import { ThunkDispatch } from 'redux-thunk';
@@ -43,6 +44,7 @@ const StartUpEvents = {
     () => handleZeroStatusUpdated(ZEROX_STATUSES.SYNCED)
   ),
   [SubscriptionEventName.BulkOrderEvent]: wrapLogHandler(handleBulkOrdersLog),
+  [SubscriptionEventName.LiquidityPoolUpdated]: wrapLogHandler(handleLiquidityPoolUpdatedLog),
 };
 
 const EVENTS = {

--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -405,6 +405,10 @@ export const handleBulkOrdersLog = (data: {
   }
 };
 
+export const handleLiquidityPoolUpdatedLog = (data: Logs.LiquidityPoolUpdated) => {
+  console.log('In log handler', data);
+}
+
 export const handleOrderLog = (log: any) =>
 (dispatch: ThunkDispatch<void, any, Action>) => {
   const type = log.eventType;

--- a/packages/augur-ui/src/modules/events/actions/log-handlers.ts
+++ b/packages/augur-ui/src/modules/events/actions/log-handlers.ts
@@ -406,7 +406,7 @@ export const handleBulkOrdersLog = (data: {
 };
 
 export const handleLiquidityPoolUpdatedLog = (data: Logs.LiquidityPoolUpdated) => {
-  console.log('In log handler', data);
+  console.log(data);
 }
 
 export const handleOrderLog = (log: any) =>


### PR DESCRIPTION
First cut at LiquidityPoolUpdated event to inform the UI liquidity pool has a better offer.

no event for non-sportsbook markets.
only emits if the new offer is the best or adds size to existing best offer.
added `new-offer` flash script to easily add an offer on the book. 