### PR TITLE
Clean up subscription handling

### DIFF
--- a/packages/augur-sdk-lite/src/constants.ts
+++ b/packages/augur-sdk-lite/src/constants.ts
@@ -137,7 +137,7 @@ export enum SubscriptionEventName {
   ZeroXStatusRestarting = 'ZeroX:Status:Restarting',
   ZeroXStatusError = 'ZeroX:Status:Error',
   ZeroXMeshOrderEvent = 'ZeroX:Mesh:OrderEvent',
-  ZeroXRPCOrderEvent = 'ZeroX:Mesh:OrderEvent',
+  ZeroXRPCOrderEvent = 'ZeroX:Rpc:OrderEvent',
   WarpSyncHashUpdated = 'WarpSyncHashUpdated',
   LiquidityPoolUpdated = 'LiquidityPoolUpdated',
   DBUpdatedZeroXOrders = 'DB:updated:ZeroXOrders',

--- a/packages/augur-sdk/src/Augur.ts
+++ b/packages/augur-sdk/src/Augur.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'events';
 import type { SDKConfiguration } from '@augurproject/utils';
 import { NetworkId } from '@augurproject/utils';
 import {
@@ -52,7 +53,7 @@ import {
   SingleThreadConnector,
 } from './connector';
 import { Provider } from './ethereum/Provider';
-import { augurEmitter, Callback, TXStatusCallback } from './events';
+import { EventNameEmitter, Callback, TXStatusCallback } from './events';
 import { ContractDependenciesGSN } from './lib/contract-deps';
 import { SyncableFlexSearch } from './state/db/SyncableFlexSearch';
 import { Accounts } from './state/getter/Accounts';
@@ -65,7 +66,6 @@ import { Universe } from './state/getter/Universe';
 import { Users } from './state/getter/Users';
 import { WarpSyncGetter } from './state/getter/WarpSyncGetter';
 import { ZeroXOrdersGetters } from './state/getter/ZeroXOrdersGetters';
-import { Subscriptions } from './subscriptions';
 import { LiquidityPool } from './state/getter/LiquidityPool';
 
 export class Augur<TProvider extends Provider = Provider> {
@@ -84,7 +84,7 @@ export class Augur<TProvider extends Provider = Provider> {
   readonly liquidity: Liquidity;
   readonly hotLoading: HotLoading;
   readonly bestOffer: BestOffer;
-  readonly events: Subscriptions;
+  readonly events: EventEmitter;
 
   private _sdkReady = false;
 
@@ -129,7 +129,8 @@ export class Augur<TProvider extends Provider = Provider> {
         `Augur config must include addresses. Config=${JSON.stringify(config)}`
       );
 
-    this.events = new Subscriptions(augurEmitter);
+    this.events = new EventNameEmitter();
+    this.events.setMaxListeners(0);
     this.events.on(SubscriptionEventName.SDKReady, () => {
       this._sdkReady = true;
       logger.info('SDK is ready');

--- a/packages/augur-sdk/src/api/BestOffer.ts
+++ b/packages/augur-sdk/src/api/BestOffer.ts
@@ -37,7 +37,7 @@ export class BestOffer {
   constructor(augur: Augur) {
     this.augur = augur;
 
-    this.augur.events.subscribe(
+    this.augur.events.on(
       SubscriptionEventName.BulkOrderEvent,
       orderEvents => this.determineBestOfferForLiquidityPool(orderEvents)
     );

--- a/packages/augur-sdk/src/events.ts
+++ b/packages/augur-sdk/src/events.ts
@@ -13,9 +13,5 @@ export class EventNameEmitter extends EventEmitter {
   }
 }
 
-export const augurEmitter: EventNameEmitter = new EventNameEmitter();
-
-// 0 because we need one per websocket client
-augurEmitter.setMaxListeners(0);
 export type Callback = (...args: SubscriptionType[]) => void;
 export type TXStatusCallback = (...args: TXStatus[]) => void;

--- a/packages/augur-sdk/src/state/WebsocketEndpoint.ts
+++ b/packages/augur-sdk/src/state/WebsocketEndpoint.ts
@@ -5,7 +5,6 @@ import http from 'http';
 import https from 'https';
 import WebSocket from 'ws';
 
-import { augurEmitter } from '../events';
 import { Subscriptions } from '../subscriptions';
 import { AddressFormatReviver } from './AddressFormatReviver';
 import { API } from './getter/API';
@@ -45,7 +44,7 @@ export function runWssServer(
 
 function setupServer(server: WebSocket.Server, api: API) {
   server.on('connection', (websocket: WebSocket): void => {
-    const subscriptions = api.augur.events;
+    const subscriptions = new Subscriptions(api.augur.events);
     const pingInterval = setInterval(() => safePing(websocket), 12000);
 
     websocket.on('message', (data: WebSocket.Data): void => {

--- a/packages/augur-sdk/src/state/db/BaseSyncableDB.ts
+++ b/packages/augur-sdk/src/state/db/BaseSyncableDB.ts
@@ -76,15 +76,12 @@ export class BaseSyncableDB extends RollbackTable {
       await this.saveDocuments(documents);
     }
     if (documents && (documents as any[]).length && !this.syncing) {
-      _.each(documents, (document: any) => {
-        this.augur.events.emitAfter(
-          SubscriptionEventName.NewBlock,
-          this.eventName,
-          {
-            eventName: this.eventName,
-            ...document,
-          }
-        );
+      this.augur.events.once(SubscriptionEventName.NewBlock, () => {
+        _.each(documents, (document: any) => {
+          this.augur.events.emit(this.eventName, {
+            eventName: this.eventName, ...document
+          });
+        });
       });
     }
 

--- a/packages/augur-sdk/src/state/db/DerivedDB.ts
+++ b/packages/augur-sdk/src/state/db/DerivedDB.ts
@@ -158,11 +158,9 @@ export class DerivedDB extends RollbackTable {
       syncing
     );
     if (logs.length > 0 && !this.syncing) {
-      this.augur.events.emitAfter(
-        SubscriptionEventName.NewBlock,
-        `DerivedDB:updated:${this.name}`,
-        { data: documentsByIdByTopic }
-      );
+      this.augur.events.once(SubscriptionEventName.NewBlock, () => {
+        this.augur.events.emit(`DerivedDB:updated:${this.name}`, { data: documentsByIdByTopic });
+      });
     }
 
     return blocknumber;

--- a/packages/augur-sdk/src/state/db/MarketDB.ts
+++ b/packages/augur-sdk/src/state/db/MarketDB.ts
@@ -80,14 +80,14 @@ export class MarketDB extends DerivedDB {
       MarketMigrated: this.processMarketMigrated,
     };
 
-    this.augur.events.subscribe(SubscriptionEventName.DBUpdatedZeroXOrders, orderEvents =>
+    this.augur.events.on(SubscriptionEventName.DBUpdatedZeroXOrders, orderEvents =>
       this.markMarketLiquidityAsDirty(orderEvents.market)
     );
-    this.augur.events.subscribe(
+    this.augur.events.on(
       SubscriptionEventName.NewBlock,
       this.processNewBlock
     );
-    this.augur.events.subscribe(
+    this.augur.events.on(
       SubscriptionEventName.TimestampSet,
       this.processTimestampSet
     );
@@ -691,11 +691,9 @@ export class MarketDB extends DerivedDB {
 
     if (updateDocs.length > 0) {
       await this.saveDocuments(updateDocs);
-      this.augur.events.emitAfter(
-        SubscriptionEventName.NewBlock,
-        SubscriptionEventName.ReportingStateChanged,
-        { data: updateDocs }
-      );
+      this.augur.events.once(SubscriptionEventName.NewBlock, () => {
+        this.augur.events.emit(SubscriptionEventName.ReportingStateChanged, { data: updateDocs });
+      })
     }
   }
 


### PR DESCRIPTION
The Subscription class was intended to be used for a server to multiplex events to multiple clients, so I've restored it to its original purposes for the WS server. Everywhere else the Augur#events emitter is used which is just an EventEmitter.

This also fixes a stupid bug where the constants for Mesh/RPC order events were using the same string and thus all events were being duplicated.