### PR TITLE
Removed one of the actions

### DIFF
--- a/packages/augur-ui/src/modules/modal/transactions.tsx
+++ b/packages/augur-ui/src/modules/modal/transactions.tsx
@@ -101,10 +101,6 @@ const actionOptions = [
     value: 'CANCEL',
   },
   {
-    label: 'Claim Market Creator Fees',
-    value: 'CLAIM_MARKET_CREATOR_FEES',
-  },
-  {
     label: 'Claim Participation Tokens',
     value: 'CLAIM_PARTICIPATION_TOKENS',
   },


### PR DESCRIPTION
#8128 

I talked to Alex and there is no call in the DB to get the Claimed Market Creator Fees and that is rather complicated to add. At this point of the game, we decided to remove that from the Transactions modal and add it post v2.