### PR TITLE
fix issue where removing all pre-liquidity orders still causes 'sign …

### DIFF
--- a/packages/augur-ui/src/modules/markets/reducers/new-market.ts
+++ b/packages/augur-ui/src/modules/markets/reducers/new-market.ts
@@ -102,7 +102,7 @@ export default function(
       const updatedOutcomeUpdatedShares = recalculateCumulativeShares(
         updatedOrders
       );
-      const orderBook = {
+      let orderBook = {
         ...newMarket.orderBook,
         [outcome]: updatedOutcomeUpdatedShares,
       };
@@ -110,7 +110,9 @@ export default function(
       const { initialLiquidityDai, initialLiquidityGas } = calculateLiquidity(
         orderBook
       );
-
+      if (initialLiquidityDai.eq(createBigNumber(0))) {
+        orderBook = {};
+      }
       return {
         ...newMarket,
         initialLiquidityDai,


### PR DESCRIPTION
…orders ...' link is shown after market is created when there is no orders to sign

https://github.com/AugurProject/augur/issues/8152