### PR TITLE
make frozen funds modal smaller on mobile so it is the same as other …

### DIFF
--- a/packages/augur-ui/src/modules/modal/components/modal-frozen-funds.tsx
+++ b/packages/augur-ui/src/modules/modal/components/modal-frozen-funds.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { Breakdown } from 'modules/modal/common';
-import { CloseButton, SecondaryButton } from 'modules/common/buttons';
+import { Breakdown, Title, ButtonsRow } from 'modules/modal/common';
 import Styles from 'modules/modal/modal.styles.less';
 import { formatDai } from 'utils/format-number';
 import type { Getters } from '@augurproject/sdk';
@@ -81,15 +80,7 @@ export const ModalFrozenFunds = ({
 
   return (
     <div className={Styles.FrozenFundsBreakdown}>
-      <header>
-        <div>
-          <CloseButton action={() => closeAction()} />
-        </div>
-        <div>
-          <h1>Frozen Funds</h1>
-        </div>
-      </header>
-
+      <Title title="Frozen Funds" closeAction={closeAction} />
       <main>
         <section>
           {breakdowns.map(bk => (
@@ -116,9 +107,14 @@ export const ModalFrozenFunds = ({
           />
         </section>
       </main>
-      <div className={Styles.ButtonsRow}>
-        <SecondaryButton text={'Cancel'} action={closeAction} />
-      </div>
+      <ButtonsRow
+        buttons={[
+          {
+            text: 'Cancel',
+            action: closeAction,
+          },
+        ]}
+      />
     </div>
   );
 };

--- a/packages/augur-ui/src/modules/modal/modal.styles.less
+++ b/packages/augur-ui/src/modules/modal/modal.styles.less
@@ -3832,30 +3832,6 @@ div.ButtonsRow:last-of-type {
   max-width: 432px;
   height: 565px;
 
-  > header {
-    margin: @size-32 @size-32 0;
-
-    > div:first-of-type {
-      > button {
-        position: absolute;
-        top: @size-24;
-        right: @size-24;
-      }
-    }
-
-    > div:last-of-type {
-      margin-bottom: @size-24;
-
-      > h1 {
-        .text-16-bold;
-
-        color: @color-primary-text;
-        text-transform: none;
-        margin: 0;
-      }
-    }
-  }
-
   > main {
     display: flex;
     flex-grow: 1;
@@ -3879,15 +3855,6 @@ div.ButtonsRow:last-of-type {
       > div:last-of-type {
         margin-bottom: @size-12;
       }
-    }
-  }
-
-  > div:last-of-type {
-    padding: 0;
-    margin: @size-24 @size-32 @size-32;
-
-    @media @breakpoint-mobile {
-      margin: @size-24;
     }
   }
 }

--- a/packages/augur-ui/src/modules/modal/modal.styles.less
+++ b/packages/augur-ui/src/modules/modal/modal.styles.less
@@ -3832,18 +3832,8 @@ div.ButtonsRow:last-of-type {
   max-width: 432px;
   height: 565px;
 
-  @media @breakpoint-mobile {
-    height: 100vh;
-    max-height: 100vh;
-    max-width: 100vw;
-  }
-
   > header {
     margin: @size-32 @size-32 0;
-
-    @media @breakpoint-mobile {
-      margin: @size-24 @size-24 0;
-    }
 
     > div:first-of-type {
       > button {
@@ -3874,9 +3864,6 @@ div.ButtonsRow:last-of-type {
     border: 1px solid @color-secondary-action;
     align-items: flex-start;
 
-    @media @breakpoint-mobile {
-      padding: 0 @size-24;
-    }
     > section {
       color: @color-primary-text;
 
@@ -3920,8 +3907,9 @@ div.ButtonsRow:last-of-type {
 
     > span > a {
       .text-12-bold;
-
+      .limit-lines(1);
     }
+
     > div:last-of-type {
       margin-top: @size-6;
     }


### PR DESCRIPTION
…info modals. only show one line of market title

https://github.com/AugurProject/augur/issues/8142

update to use more standard modal components.
![image](https://user-images.githubusercontent.com/3970376/85906523-3518f800-b7d4-11ea-92a2-eb7f40242d21.png)


