### PR TITLE
Render market list using warp sync data

### DIFF
--- a/packages/augur-sdk-lite/package.json
+++ b/packages/augur-sdk-lite/package.json
@@ -27,7 +27,8 @@
     "@augurproject/artifacts": "2.0.0-alpha.2",
     "@augurproject/utils": "2.0.0-alpha.2",
     "async": "3.1.0",
-    "ethers": "4.0.47"
+    "ethers": "4.0.47",
+    "lz-string": "1.4.4"
   },
   "devDependencies": {
     "@types/async": "3.0.1",

--- a/packages/augur-sdk-lite/src/AugurLite.ts
+++ b/packages/augur-sdk-lite/src/AugurLite.ts
@@ -1,34 +1,100 @@
 import { NetworkId } from '@augurproject/utils';
+import { BigNumber } from 'bignumber.js';
 import { ethers } from 'ethers';
+import LZString from 'lz-string';
 import { HotLoading, HotLoadMarketInfo } from './api/HotLoading';
+import { WarpSync } from './api/WarpSync';
+import { MarketReportingState } from './constants';
+import { MarketCreatedLog } from './logs';
+
+interface NamedMarketCreatedLog extends MarketCreatedLog {
+  name: string;
+}
+
+export interface CheckpointInterface {
+  startBlockNumber: number;
+  endBlockNumber: number;
+  logs: NamedMarketCreatedLog[];
+}
 
 export interface Addresses {
+  Universe: string;
   HotLoading: string;
   Augur: string;
   FillOrder: string;
   Orders: string;
+  WarpSync: string;
 }
 
+const FILE_FETCH_TIMEOUT = 10000; // 10 seconds
+
 export class AugurLite {
-    readonly hotLoading: HotLoading;
+  readonly hotLoading: HotLoading;
+  readonly warpSync: WarpSync;
 
-    constructor(
-      readonly provider: ethers.providers.Provider,
-      readonly addresses: Addresses,
-      readonly networkId: NetworkId
-    ) {
-      this.provider = provider;
-      this.hotLoading = new HotLoading(this.provider);
-      this.addresses = addresses;
-    }
+  constructor(
+    readonly provider: ethers.providers.Provider,
+    readonly addresses: Addresses,
+    readonly networkId: NetworkId
+  ) {
+    this.provider = provider;
+    this.hotLoading = new HotLoading(this.provider);
+    this.warpSync = new WarpSync(this.provider, addresses.WarpSync);
+    this.addresses = addresses;
+  }
 
-    async hotloadMarket(marketId: string): Promise<HotLoadMarketInfo> {
-        return this.hotLoading.getMarketData({
-          market: marketId,
-          hotLoadingAddress: this.addresses.HotLoading,
-          augurAddress: this.addresses.Augur,
-          fillOrderAddress: this.addresses.FillOrder,
-          ordersAddress: this.addresses.Orders,
-        });
-    }
+  async hotloadMarket(marketId: string): Promise<HotLoadMarketInfo> {
+    return this.hotLoading.getMarketData({
+      market: marketId,
+      hotLoadingAddress: this.addresses.HotLoading,
+      augurAddress: this.addresses.Augur,
+      fillOrderAddress: this.addresses.FillOrder,
+      ordersAddress: this.addresses.Orders,
+    });
+  }
+
+  async getIPFSFile(ipfsPath: string) {
+    const fileRetrievalFn = (ipfsPath: string) =>
+      fetch(`https://cloudflare-ipfs.com/ipfs/${ipfsPath}/index `)
+        .then((item) => item.arrayBuffer())
+        .then((item) => new Uint8Array(item));
+
+    return new Promise<CheckpointInterface>(async (resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('Request timed out'));
+      }, FILE_FETCH_TIMEOUT);
+      const fileResult = await fileRetrievalFn(ipfsPath);
+      clearTimeout(timeout);
+      const decompressedResult = await LZString.decompressFromUint8Array(
+        fileResult
+      );
+      resolve(JSON.parse(decompressedResult));
+    });
+  }
+
+  async getMarketCreatedLogs() {
+    const { warpSyncHash } = await this.warpSync.getLastWarpSyncData(this.addresses.Universe);
+    const { logs } = await this.getIPFSFile(warpSyncHash);
+
+    return logs.filter((log) => log.name === 'MarketCreated').map(({extraInfo, ...rest }) => ({
+      id: rest.market,
+      categories: [],
+      ...rest,
+      ...JSON.parse(extraInfo),
+      extraInfo: JSON.parse(extraInfo),
+      reportingState: MarketReportingState.Unknown,
+      disputeInfo: {
+        disputeRound: new BigNumber('0x0',
+          16
+        ).toFixed(),
+        disputeWindow: {
+          startTime: null,
+          endTime: rest.endTime,
+        },
+        stakes: [],
+      },
+      disputePacingOn: false,
+      stakes: []
+    }));
+  }
 }

--- a/packages/augur-sdk-lite/src/abi/WarpSyncAbi.ts
+++ b/packages/augur-sdk-lite/src/abi/WarpSyncAbi.ts
@@ -1,0 +1,212 @@
+export const WarpSyncAbi = [
+  {
+    constant: true,
+    inputs: [],
+    name: 'augur',
+    outputs: [
+      {
+        internalType: 'contract IAugur',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'data',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'warpSyncHash',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'timestamp',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'contract IUniverse',
+        name: '_universe',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256[]',
+        name: '_payoutNumerators',
+        type: 'uint256[]',
+      },
+      {
+        internalType: 'string',
+        name: '_description',
+        type: 'string',
+      },
+    ],
+    name: 'doInitialReport',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'contract IUniverse',
+        name: '_universe',
+        type: 'address',
+      },
+    ],
+    name: 'getCreationReward',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'contract IMarket',
+        name: '_market',
+        type: 'address',
+      },
+    ],
+    name: 'getFinalizationReward',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'getInitialized',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'contract IAugur',
+        name: '_augur',
+        type: 'address',
+      },
+    ],
+    name: 'initialize',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'contract IUniverse',
+        name: '_universe',
+        type: 'address',
+      },
+    ],
+    name: 'initializeUniverse',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'lastSweepTime',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'markets',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [],
+    name: 'notifyMarketFinalized',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+];

--- a/packages/augur-sdk-lite/src/api/WarpSync.ts
+++ b/packages/augur-sdk-lite/src/api/WarpSync.ts
@@ -1,0 +1,40 @@
+import { BigNumber } from 'bignumber.js';
+import * as bs58 from 'bs58';
+import { ethers } from 'ethers';
+import { WarpSyncAbi } from '../abi/WarpSyncAbi';
+
+const MAX_PAYOUT = new BigNumber(2).pow(256).minus(2);
+
+export interface WarpSyncData {
+  warpSyncHash: string;
+  timestamp: number;
+}
+
+export class WarpSync {
+  private readonly provider: ethers.providers.Provider;
+  private readonly contract: ethers.Contract;
+
+  constructor(provider: ethers.providers.Provider, address: string) {
+    this.contract = new ethers.Contract(address, WarpSyncAbi, provider);
+
+    this.provider = provider;
+  }
+
+  getWarpSyncHashFromPayout(payout: BigNumber): string {
+    // 0x12 == hashing function of sha2-256 0x20 is the size value. Both are constant and appended at the start of the ipfs hash
+    const hexHash = `1220${payout.toString(16).padStart(64, '0')}`;
+    const bytes = Buffer.from(hexHash, 'hex');
+    return bs58.encode(bytes);
+  }
+
+  async getLastWarpSyncData(universe: string): Promise<WarpSyncData> {
+    const [warpSyncHash, timestamp] = await this.contract.data(
+      universe
+    );
+
+    return {
+      warpSyncHash: this.getWarpSyncHashFromPayout(new BigNumber(warpSyncHash.toString())),
+      timestamp: timestamp.toNumber(),
+    };
+  }
+}

--- a/packages/augur-sdk-lite/src/constants.ts
+++ b/packages/augur-sdk-lite/src/constants.ts
@@ -49,6 +49,8 @@ export enum MarketReportingStateByNum {
 }
 
 export enum MarketReportingState {
+  // This only applies to hot loaded markets.
+  Unknown = 'Unknown',
   PreReporting = 'PreReporting',
   DesignatedReporting = 'DesignatedReporting',
   OpenReporting = 'OpenReporting',

--- a/packages/augur-sdk-lite/src/utils/hotloadKovanTest.ts
+++ b/packages/augur-sdk-lite/src/utils/hotloadKovanTest.ts
@@ -1,10 +1,13 @@
 import { NetworkId } from '@augurproject/utils';
 import { ethers } from 'ethers';
 import { AugurLite } from '../AugurLite';
+import { NULL_ADDRESS } from '../constants';
 
 async function doWork(): Promise<void> {
     const provider = new ethers.providers.JsonRpcProvider("https://kovan.augur.net/ethereum-http");
     const addresses = {
+        "Universe": NULL_ADDRESS,
+        "WarpSync": NULL_ADDRESS,
         "HotLoading": "0x208993149C873a2fCCD1c822E1300Fbb7189ede8",
         "Augur": "0x4045A51631181A63d4136b56e2C85552A2c87783",
         "FillOrder": "0x431A0376274dCb5612bBD96491946d55cA0215f1",

--- a/packages/augur-sdk/src/Augur.ts
+++ b/packages/augur-sdk/src/Augur.ts
@@ -1,6 +1,3 @@
-import { EventEmitter } from 'events';
-import type { SDKConfiguration } from '@augurproject/utils';
-import { NetworkId } from '@augurproject/utils';
 import {
   EthersSigner,
   TransactionStatus,
@@ -8,19 +5,22 @@ import {
 } from '@augurproject/contract-dependencies-ethers';
 import { ContractInterfaces } from '@augurproject/core';
 import {
-  NETWORK_IDS,
   isSubscriptionEventName,
+  NETWORK_IDS,
   NULL_ADDRESS,
   SubscriptionEventName,
   TXEventName,
   TXStatus,
 } from '@augurproject/sdk-lite';
-import { logger, LoggerLevels } from '@augurproject/utils';
+import type { SDKConfiguration } from '@augurproject/utils';
+import { logger, LoggerLevels, NetworkId } from '@augurproject/utils';
 import axios from 'axios';
 import { BigNumber } from 'bignumber.js';
 import { TransactionResponse } from 'ethers/providers';
 import { Arrayish } from 'ethers/utils';
 import { getAddress } from 'ethers/utils/address';
+import { EventEmitter } from 'events';
+import { BestOffer } from './api/BestOffer';
 import { ContractEvents } from './api/ContractEvents';
 import { Contracts } from './api/Contracts';
 import { GSN } from './api/GSN';
@@ -37,11 +37,6 @@ import {
   CreateYesNoMarketParams,
   Market,
 } from './api/Market';
-import {
-  BestOffer,
-  GetBestOffersParams,
-  BestOffersOrders
-} from './api/BestOffer';
 import { OnChainTrade } from './api/OnChainTrade';
 import { PlaceTradeDisplayParams, SimulateTradeData, Trade } from './api/Trade';
 import { Uniswap } from './api/Uniswap';
@@ -53,11 +48,12 @@ import {
   SingleThreadConnector,
 } from './connector';
 import { Provider } from './ethereum/Provider';
-import { EventNameEmitter, Callback, TXStatusCallback } from './events';
+import { Callback, EventNameEmitter, TXStatusCallback } from './events';
 import { ContractDependenciesGSN } from './lib/contract-deps';
 import { SyncableFlexSearch } from './state/db/SyncableFlexSearch';
 import { Accounts } from './state/getter/Accounts';
 import { Liquidity as LiquidityGetter } from './state/getter/Liquidity';
+import { LiquidityPool } from './state/getter/LiquidityPool';
 import { Markets } from './state/getter/Markets';
 import { OnChainTrading } from './state/getter/OnChainTrading';
 import { Platform } from './state/getter/Platform';
@@ -66,7 +62,7 @@ import { Universe } from './state/getter/Universe';
 import { Users } from './state/getter/Users';
 import { WarpSyncGetter } from './state/getter/WarpSyncGetter';
 import { ZeroXOrdersGetters } from './state/getter/ZeroXOrdersGetters';
-import { LiquidityPool } from './state/getter/LiquidityPool';
+import { WarpController } from './warp/WarpController';
 
 export class Augur<TProvider extends Provider = Provider> {
   syncableFlexSearch: SyncableFlexSearch;
@@ -94,6 +90,12 @@ export class Augur<TProvider extends Provider = Provider> {
   private txFeeTooLowCallback: TXStatusCallback;
   private txRelayerDownCallback: TXStatusCallback;
   private txSuccessCallbacks: TXStatusCallback[]; 
+
+  private _warpController: WarpController;
+
+  set warpController(_warpController: WarpController) {
+    this._warpController = _warpController;
+  }
 
   get zeroX(): ZeroX {
     return this._zeroX;
@@ -602,6 +604,10 @@ export class Augur<TProvider extends Provider = Provider> {
     params: PlaceTradeDisplayParams
   ): Promise<SimulateTradeData> {
     return this.trade.simulateTrade(params);
+  }
+
+  async pinHashByGatewayUrl(url:string) {
+    if(this._warpController) this._warpController.pinHashByGatewayUrl(url);
   }
 
   async placeTrade(params: PlaceTradeDisplayParams): Promise<boolean> {

--- a/packages/augur-sdk/src/state/create-api.ts
+++ b/packages/augur-sdk/src/state/create-api.ts
@@ -1,8 +1,7 @@
-import { SDKConfiguration } from '@augurproject/utils';
 import { EthersSigner } from '@augurproject/contract-dependencies-ethers';
 import { EthersProvider } from '@augurproject/ethersjs-provider';
 import { SubscriptionEventName } from '@augurproject/sdk-lite';
-import { logger, LoggerLevels } from '@augurproject/utils';
+import { logger, LoggerLevels, SDKConfiguration } from '@augurproject/utils';
 import { BigNumber } from 'bignumber.js';
 import { SupportedProvider } from 'ethereum-types';
 import { JsonRpcProvider } from 'ethers/providers';
@@ -39,6 +38,9 @@ export function buildSyncStrategies(client:Augur, db:Promise<DB>, provider: Ethe
     const currentBlock = await provider.getBlock('latest');
     const warpController = new WarpController((await db), client, provider,
       uploadBlockNumber);
+
+    client.warpController = warpController;
+
     const warpSyncStrategy = new WarpSyncStrategy(warpController,
       logFilterAggregator.onLogsAdded, await db, provider);
 

--- a/packages/augur-ui/src/modules/app/actions/init-augur.ts
+++ b/packages/augur-ui/src/modules/app/actions/init-augur.ts
@@ -228,8 +228,10 @@ export function connectAugur(
       config.addresses,
       config.networkId
     );
+
     dispatch(updateCanHotload(true)); // Hotload now!
-    // End init here for Googlebot 
+
+    // End init here for Googlebot
     // TODO: Market list do something with hotload
     if(isGoogleBot()) {
       callback(null);
@@ -293,6 +295,9 @@ export function connectAugur(
     dispatch(listenForStartUpEvents(Augur));
 
     await augurSdk.connect();
+
+    // IPFS pin the UI hash.
+    augurSdk.client.pinHashByGatewayUrl(windowApp.location.href);
     callback(null);
   };
 }

--- a/packages/augur-ui/src/modules/market-cards/common.tsx
+++ b/packages/augur-ui/src/modules/market-cards/common.tsx
@@ -1,9 +1,9 @@
 import type { Getters } from '@augurproject/sdk';
+import { MarketReportingState } from '@augurproject/sdk-lite';
 import classNames from 'classnames';
 import { ProcessingButton } from 'modules/common/buttons';
 import {
   INVALID_OUTCOME_ID,
-  INVALID_OUTCOME_NAME,
   INVALID_OUTCOME_LABEL,
   SCALAR,
   SCALAR_DOWN_ID,
@@ -363,7 +363,7 @@ export const OutcomeGroup = (props: OutcomeGroupProps) => {
           />
         </>
       )}
-      {(props.marketType !== SCALAR || inDispute) &&
+      {((props.marketType !== SCALAR || inDispute) && props.reportingState !== MarketReportingState.Unknown) &&
         outcomesShow.map(
           (outcome: OutcomeFormatted, index: number) =>
             ((!props.expanded && index < showOutcomeNumber) ||

--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -237,9 +237,17 @@ export default class MarketView extends Component<
       this.setState({ selectedOutcomeId: this.props.outcomeId });
     }
 
-    if (this.props.canHotload && prevProps.canHotload !== this.props.canHotload  && !tradingTutorial && marketId) {
+    if (
+      typeof this.props.marketId !== 'undefined' &&
+      typeof this.props.canHotload !== 'undefined' &&
+      !tradingTutorial &&
+      // We can hotload now.
+      (prevProps.canHotload === this.props.canHotload ||
+        // The market id changed.
+        prevProps.marketId !== this.props.marketId)
+    ) {
       // This will only be called once on the 'canHotLoad' prop change.
-      loadHotMarket(marketId);
+      loadHotMarket(this.props.marketId);
     }
 
     if (tradingTutorial) {
@@ -264,9 +272,9 @@ export default class MarketView extends Component<
     }
 
     if ((isConnected !== this.props.isConnected) && !!marketId && !tradingTutorial && !preview) {
-      this.props.loadMarketOrderBook(marketId);
+      this.props.loadMarketOrderBook(this.props.marketId);
       this.props.loadMarketsInfo(this.props.marketId);
-      this.props.loadMarketTradingHistory(marketId);
+      this.props.loadMarketTradingHistory(this.props.marketId);
     }
     if (!this.props.isMarketLoading) {
       if (closeMarketLoadingModalOnly) closeMarketLoadingModalOnly(this.props.modalShowing);

--- a/packages/augur-ui/src/modules/markets-list/components/markets-view.tsx
+++ b/packages/augur-ui/src/modules/markets-list/components/markets-view.tsx
@@ -59,6 +59,8 @@ interface MarketsViewProps {
   setMarketsListSearchInPlace: Function;
   marketListViewed: Function;
   marketsInReportingState: MarketData[];
+  hotLoadMarketList: Function;
+  canHotload: boolean;
 }
 
 interface MarketsViewState {
@@ -103,19 +105,21 @@ export default class MarketsView extends Component<
 
   componentDidUpdate(prevProps, prevState) {
     const {
+      canHotload,
       search,
       marketFilter,
       marketSort,
       maxFee,
       selectedCategories,
       maxLiquiditySpread,
+      hotLoadMarketList,
       includeInvalidMarkets,
       isConnected,
       isLogged,
       templateFilter,
       marketTypeFilter,
       marketListViewed,
-      marketsInReportingState
+      setLoadMarketsPending
     } = this.props;
     const { marketCount, offset } = this.state;
 
@@ -151,7 +155,18 @@ export default class MarketsView extends Component<
       return this.updateFilteredMarkets();
     }
 
-    const filtersHaveChanged = this.haveFiltersChanged({
+    if(!isConnected && canHotload !== prevProps.canHotload && canHotload ) {
+      hotLoadMarketList((marketsInfo) => {
+        this.setState({
+          filterSortedMarkets: marketsInfo.map((market) => market.id),
+          marketCount: marketsInfo.length,
+          limit: marketsInfo.length,
+        });
+        setLoadMarketsPending(false);
+      });
+    }
+
+      const filtersHaveChanged = this.haveFiltersChanged({
       search,
       marketFilter,
       marketSort,

--- a/packages/augur-ui/src/modules/markets/selectors/market.ts
+++ b/packages/augur-ui/src/modules/markets/selectors/market.ts
@@ -50,7 +50,8 @@ export const selectSortedMarketOutcomes = (marketType, outcomes: OutcomeFormatte
     return sortedOutcomes.reverse();
   }
   // Move invalid to the end
-  sortedOutcomes.push(sortedOutcomes.shift());
+  if(sortedOutcomes.length > 0) sortedOutcomes.push(sortedOutcomes.shift());
+
   return sortedOutcomes;
 };
 


### PR DESCRIPTION
This seems to work but is kinda ugly.

closes #8220 

- [x] Cache warp sync file

- [x] Pin UI on load

- [x] Hotload all markets.