### PR TITLE
Always hotload market info.

### DIFF
--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -238,7 +238,6 @@ export default class MarketView extends Component<
     }
 
     if (this.props.canHotload && !tradingTutorial && marketId) {
-      // This will only be called once on the 'canHotLoad' prop change.
       loadHotMarket(marketId);
     }
 

--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -237,7 +237,7 @@ export default class MarketView extends Component<
       this.setState({ selectedOutcomeId: this.props.outcomeId });
     }
 
-    if (this.props.canHotload && prevProps.canHotload !== this.props.canHotload  && !tradingTutorial && marketId) {
+    if (this.props.canHotload && !tradingTutorial && marketId) {
       // This will only be called once on the 'canHotLoad' prop change.
       loadHotMarket(marketId);
     }


### PR DESCRIPTION
This ensures that if the market info in the database is tampered with
externally the user is presented with the actual market details when
viewing the detail page.

Not 100% certain this is the right approach -- we could perhaps only do this on the first time the market details are loaded?