### PR TITLE
Fix custom end time formatting

### DIFF
--- a/packages/augur-ui/src/modules/market/components/common/PreviewMarketTitle.tsx
+++ b/packages/augur-ui/src/modules/market/components/common/PreviewMarketTitle.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { buildMarketDescription } from 'modules/create-market/get-template';
-import { convertUTCUnixToFormattedDate } from 'utils/format-date';
+import { convertUnixToFormattedDate } from 'utils/format-date';
 import type {
   TemplateInput,
   Template,
@@ -35,7 +35,7 @@ const MarketTemplateTitle: React.FC<MarketTemplateTitleProps> = ({
   const convertedInputs: TemplateInput[] = template.inputs.map(i => {
     let userInput = i.userInput;
     if (i.type === TemplateInputType.ESTDATETIME) {
-      userInput = convertUTCUnixToFormattedDate(Number(i.userInput))
+      userInput = convertUnixToFormattedDate(Number(i.userInput))
         .formattedLocalShortDateTimeWithTimezone;
     }
 

--- a/packages/augur-ui/src/modules/market/components/common/market-title.tsx
+++ b/packages/augur-ui/src/modules/market/components/common/market-title.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import MarketLink from 'modules/market/components/market-link/market-link';
 import { buildMarketDescription } from 'modules/create-market/get-template';
-import { convertUTCUnixToFormattedDate } from 'utils/format-date';
+import { convertUnixToFormattedDate } from 'utils/format-date';
 import type {
   TemplateInput,
   ExtraInfoTemplate,
@@ -61,7 +61,7 @@ const MarketTemplateTitle: React.FC<MarketTemplateTitleProps> = ({
     userInput:
       i.type === TemplateInputType.ESTDATETIME ||
       i.type === TemplateInputType.DATETIME
-        ? convertUTCUnixToFormattedDate(Number(i.timestamp))
+        ? convertUnixToFormattedDate(Number(i.timestamp))
             .formattedLocalShortDateTimeWithTimezone
         : i.value,
     id: i.id,

--- a/packages/augur-ui/src/utils/convert-marketInfo-marketData.ts
+++ b/packages/augur-ui/src/utils/convert-marketInfo-marketData.ts
@@ -19,7 +19,7 @@ import {
 } from 'modules/types';
 import { createBigNumber } from './create-big-number';
 import deepClone from './deep-clone';
-import { getDurationBetween, convertUTCUnixToFormattedDate } from './format-date';
+import { getDurationBetween, convertUnixToFormattedDate } from './format-date';
 import {
   formatAttoRep,
   formatDai,
@@ -45,12 +45,12 @@ export function convertMarketInfoToMarketData(
     maxPriceBigNumber: createBigNumber(marketInfo.maxPrice),
     outcomesFormatted: processOutcomes(marketInfo),
     marketStatus: getMarketStatus(marketInfo.reportingState),
-    endTimeFormatted: convertUTCUnixToFormattedDate(marketInfo.endTime),
-    creationTimeFormatted: convertUTCUnixToFormattedDate(marketInfo.creationTime),
+    endTimeFormatted: convertUnixToFormattedDate(marketInfo.endTime),
+    creationTimeFormatted: convertUnixToFormattedDate(marketInfo.creationTime),
     categories: marketInfo.categories,
     isArchived: archivedDuration && (Math.abs(archivedDuration.asDays()) >= ARCHIVED_MARKET_LENGTH),
     finalizationTimeFormatted: marketInfo.finalizationTime
-      ? convertUTCUnixToFormattedDate(marketInfo.finalizationTime)
+      ? convertUnixToFormattedDate(marketInfo.finalizationTime)
       : null,
     consensusFormatted: processConsensus(marketInfo),
     defaultSelectedOutcomeId: getDefaultOutcomeSelected(marketInfo.marketType),

--- a/packages/augur-ui/src/utils/format-date.ts
+++ b/packages/augur-ui/src/utils/format-date.ts
@@ -159,13 +159,13 @@ export function buildformattedDate(
   offset: number
 ): TimezoneDateObject {
 
-  let adjHour = hour;
+  let adjHour = Number(hour);
   const day = moment
     .unix(timestamp)
     .startOf('day').format('MMMM DD, YYYY');
 
-  if (meridiem && meridiem === 'PM' && hour < 12) {
-    adjHour = hour + 12;
+  if (meridiem && meridiem === 'PM' && adjHour < 12) {
+    adjHour = adjHour + 12;
   }
 
   // MMMM DD, YYYY h:mm A;
@@ -217,14 +217,6 @@ export function getUtcStartOfDayFromLocal(timestamp: number): number {
     .startOf('day')
     .unix();
     return value;
-}
-
-export function convertUTCUnixToFormattedDate(integer: number = 0) {
-  const localOffset: number = (new Date().getTimezoneOffset() / 60) * -1;
-  const value = moment
-    .unix(integer)
-    .add(localOffset, 'hours')
-  return formatDate(value.toDate());
 }
 
 export function convertUnixToFormattedDate(integer: number = 0) {

--- a/packages/augur-ui/src/utils/format-date.ts
+++ b/packages/augur-ui/src/utils/format-date.ts
@@ -192,20 +192,11 @@ export function buildformattedDate(
 export function timestampComponents(timestamp: number, offset: number = 0, timezone: string = null): Partial<DateTimeComponents> {
   // using local mode with moment, manually adjusting for offset
   const date = moment.unix(timestamp).add(offset, 'hours');
-  let meridiem = 'AM';
-  let hour = date.hours()
-  if (hour == 0) {
-    hour = 12; // moment uses 0 for 24 (12 am)
-    meridiem = 'AM';
-  } else if (hour >= 12) {
-    hour = hour > 12 ? hour - 12 : hour;
-    meridiem = 'PM'
-  }
   return {
     setEndTime: timestamp,
-    hour: String(hour),
-    minute: `0${date.minutes()}`.slice(-2),
-    meridiem,
+    hour: String(date.utc().format('h')),
+    minute: String(date.utc().format('m')),
+    meridiem: String(date.utc().format('A')),
     timezone
   }
 }

--- a/packages/augur-ui/src/utils/format-date.ts
+++ b/packages/augur-ui/src/utils/format-date.ts
@@ -159,20 +159,19 @@ export function buildformattedDate(
   offset: number
 ): TimezoneDateObject {
 
-  const endTime = moment
+  let adjHour = hour;
+  const day = moment
     .unix(timestamp)
-    .startOf('day');
+    .startOf('day').format('MMMM DD, YYYY');
 
-  endTime.set({
-    hour: hour,
-    minute: minute,
-  });
-
-  if ((meridiem === '' || meridiem === 'AM') && endTime.hours() >= 12) {
-    endTime.hours(endTime.hours() - 12);
-  } else if (meridiem && meridiem === 'PM' && endTime.hours() < 12) {
-    endTime.hours(endTime.hours() + 12);
+  if (meridiem && meridiem === 'PM' && hour < 12) {
+    adjHour = hour + 12;
   }
+
+  // MMMM DD, YYYY h:mm A;
+  const datetimeFormat = `${day} ${adjHour}:${minute} ${meridiem}`;
+  const endTime = moment.utc(datetimeFormat, LONG_FORMAT);
+
   const abbr = getTimezoneAbbr(endTime.toDate(), timezone);
   const timezoneFormat = endTime.format(LONG_FORMAT);
   const formattedLocalShortDateTimeWithTimezone = `${timezoneFormat} (${abbr})`;


### PR DESCRIPTION
parsing timestamp and adding hours/minutes doesn't work well for moment when using methods like `add` and .hours(). better to break down timestamp into formatted string and re-parse as needed. 

I made a mistake in previous PR displaying date in local time, needed to use regular existing helper method to formatted date. removed the UTC format date helper, not needed.