### PR TITLE
Fix filled orders hotloaded markets

### DIFF
--- a/packages/augur-ui/src/modules/orders/selectors/filled-orders.ts
+++ b/packages/augur-ui/src/modules/orders/selectors/filled-orders.ts
@@ -116,7 +116,7 @@ function findOrders(
         if (!isSameAddress(creator, accountId)) {
           foundOrder.originalQuantity = foundOrder.amount;
         }
-      } else {
+      } else if (outcomeValue !== undefined) {
         order.push({
           id: orderId,
           timestamp: timestampFormatted,


### PR DESCRIPTION
hot loaded markets are in marketInfos state which causes filled orders to not find outcome and blow up. if can not find outcome don't load fill order, regular marketInfos will be loaded once sdk is synced"