### PR TITLE
Ignore cross orderbook orders

### DIFF
--- a/packages/augur-sdk-lite/src/constants.ts
+++ b/packages/augur-sdk-lite/src/constants.ts
@@ -1,6 +1,7 @@
 import { TransactionMetadata } from '@augurproject/contract-dependencies-ethers';
 import { BigNumber } from 'bignumber.js';
 import { utils as ethersUtils } from 'ethers';
+import { Order } from '.';
 
 export {
   ZERO,
@@ -253,3 +254,36 @@ export interface TXStatus {
   hash?: string;
   reason?: string;
 }
+
+export interface OrderTypeOrders {
+  [orderType: string]: {
+    [orderId: string]: ZeroXOrder;
+  }
+}
+
+export interface OutcomeOrders {
+  [outcome: number]: OrderTypeOrders;
+};
+
+export interface ZeroXOrder extends Order {
+  expirationTimeSeconds: number;
+  makerAssetAmount: string;
+  takerAssetAmount: string;
+  salt: string;
+  makerAssetData: string;
+  takerAssetData: string;
+  signature: string;
+  makerFeeAssetData: string;
+  takerFeeAssetData: string;
+  feeRecipientAddress: string;
+  takerAddress: string;
+  makerAddress: string;
+  senderAddress: string;
+  makerFee: string;
+  takerFee: string;
+}
+
+export interface ZeroXOrders {
+  [marketId: string]: OutcomeOrders;
+}
+

--- a/packages/augur-sdk-lite/src/constants.ts
+++ b/packages/augur-sdk-lite/src/constants.ts
@@ -1,7 +1,7 @@
 import { TransactionMetadata } from '@augurproject/contract-dependencies-ethers';
 import { BigNumber } from 'bignumber.js';
 import { utils as ethersUtils } from 'ethers';
-import { Order } from '.';
+import { Order } from './onChainTrading';
 
 export {
   ZERO,

--- a/packages/augur-sdk-lite/src/zeroX.ts
+++ b/packages/augur-sdk-lite/src/zeroX.ts
@@ -1,6 +1,8 @@
 import { BigNumber as BN, defaultAbiCoder, ParamType } from 'ethers/utils';
 import { getAddress } from 'ethers/utils/address';
 import { BigNumber } from 'bignumber.js';
+import { OrderTypeOrders, OrderType, ZeroXOrder, ZeroXOrders, OutcomeOrders } from '.';
+import * as _ from 'lodash';
 
 const multiAssetDataAbi: ParamType[] = [
     { name: 'amounts', type: 'uint256[]' },
@@ -92,4 +94,124 @@ export function parseTradeAssetData(assetData: string): OrderData {
         outcome: `0x${tokenid.substr(60, 2)}`,
         orderType: `0x${tokenid.substr(62, 2)}`,
     };
+}
+
+export function ignoreCrossedOrders(books: ZeroXOrders, allowedAccount: string): ZeroXOrders {
+  const filteredBooks = _.reduce(_.keys(books), (aggs, marketId) => ({...aggs, [marketId]: filterMarketOutcomeOrders(books[marketId], allowedAccount) }), {})
+  return filteredBooks;
+}
+
+function filterMarketOutcomeOrders(outcomeOrders: OutcomeOrders, allowedAccount: string): OutcomeOrders {
+  const values = _.reduce(_.keys(outcomeOrders), (aggs, outcomeId) =>
+  ({ ...aggs, [Number(outcomeId)]: removeCrossedOrdersInOutcome(outcomeOrders[Number(outcomeId)], allowedAccount) }), {});
+  return values;
+}
+
+function removeCrossedOrdersInOutcome(orders: OrderTypeOrders, allowedAccount: string): OrderTypeOrders {
+  if (_.keys(orders).length < 2) return orders;
+  if (_.keys(orders[OrderType.Ask]).length === 0) return orders;
+  if (_.keys(orders[OrderType.Bid]).length === 0) return orders;
+
+  let asks = [..._.values(orders[OrderType.Ask]).sort(sortOrdersAscending)];
+  let bids = [..._.values(orders[OrderType.Bid]).sort(sortOrdersDecending)];
+  let hasCrossOrders = hasCrossedOrders(asks, bids);
+  if (!hasCrossOrders) return orders;
+
+  const { bestAsk, bestBid } = getBestOrders(asks, bids);
+  let crossedAsks = getCrossedOrders(asks, bestBid.price, (askPrice, price) => parseFloat(askPrice) <= parseFloat(price));
+  let crossedBids = getCrossedOrders(bids, bestAsk.price, (bidPrice, price) => parseFloat(bidPrice) >= parseFloat(price));
+  let ignoreOrders = []
+  while(hasCrossOrders) {
+    // get all orders that price cross
+    // remove smallest sized crossed orders
+    // if same size remove oldest crossed orders
+    // leave account orders if crossed
+    ignoreOrdersBasedOnSizeTtl(crossedAsks, crossedBids, ignoreOrders);
+    crossedAsks = crossedAsks.filter(o => !ignoreOrders.includes(o));
+    crossedBids = crossedBids.filter(o => !ignoreOrders.includes(o));
+    hasCrossOrders = hasCrossedOrders(crossedAsks, crossedBids);
+  }
+
+  getAccountFilteredOrderIds(
+    ignoreOrders,
+    allowedAccount
+  ).map(id => delete orders[OrderType.Ask][id]);
+  getAccountFilteredOrderIds(
+    ignoreOrders,
+    allowedAccount
+  ).map(id => delete orders[OrderType.Bid][id]);
+
+  return orders;
+}
+
+function ignoreOrdersBasedOnSizeTtl(
+  asks: ZeroXOrder[],
+  bids: ZeroXOrder[],
+  ignore: ZeroXOrder[]
+): void {
+  if (asks.length === 0 || bids.length === 0)
+    return;
+  const { bestAsk, bestBid } = getBestOrders(asks, bids);
+  let ignoreOrder = new BigNumber(bestAsk.amount).lt(new BigNumber(bestBid.amount)) ? bestAsk : bestBid;
+  if (bestAsk.amount === bestBid.amount) {
+    if (bestAsk.expirationTimeSeconds === bestBid.expirationTimeSeconds) {
+      ignoreOrder = parseFloat(bestAsk.price) < parseFloat(bestBid.price) ? bestAsk : bestBid;
+    } else {
+      ignoreOrder = bestAsk.expirationTimeSeconds > bestBid.expirationTimeSeconds ? bestAsk : bestBid;
+    }
+  }
+  ignore.push(ignoreOrder);
+}
+
+function getCrossedOrders(
+  orders: ZeroXOrder[],
+  limitPrice: string,
+  condition: Function
+) {
+  const crossed = [];
+  let process = !!orders.length;
+  let i = 0;
+  while (process) {
+    const order = orders[i];
+    order && condition(order.price, limitPrice)
+      ? crossed.push(order)
+      : (process = false);
+    i++;
+  }
+  return crossed;
+}
+
+function getBestOrders(askOrders: ZeroXOrder[], bidOrders: ZeroXOrder[]): { bestAsk: ZeroXOrder, bestBid: ZeroXOrder } {
+  const bestAsk = _.first(askOrders.sort(sortOrdersAscending));
+  const bestBid = _.first(bidOrders.sort(sortOrdersDecending));
+  return {bestAsk, bestBid};
+}
+
+function hasCrossedOrders(askOrders: ZeroXOrder[], bidOrders: ZeroXOrder[]): boolean {
+  const { bestAsk, bestBid } = getBestOrders(askOrders, bidOrders);
+  if (!bestAsk || !bestBid) return false;
+  return hasCrossBestOrders(bestAsk, bestBid);
+}
+
+function hasCrossBestOrders(ask, bid): boolean {
+  return parseFloat(ask.price) <= parseFloat(bid.price) || parseFloat(bid.price) >= parseFloat(ask.price)
+}
+
+function getAccountFilteredOrderIds(orders: ZeroXOrder[], account: string): string[] {
+  return orders.reduce(
+    (p, o) => (o.makerAddress === account ? p : [...p, o]),
+    []
+  ).map((o: ZeroXOrder) => o.orderId);
+}
+
+function sortOrdersAscending(order1: ZeroXOrder, order2: ZeroXOrder): number {
+  if (parseFloat(order1.price) > parseFloat(order2.price)) return 1;
+  if (parseFloat(order1.price) < parseFloat(order2.price)) return -1;
+  return 0;
+}
+
+function sortOrdersDecending(order1: ZeroXOrder, order2: ZeroXOrder): number {
+  if (parseFloat(order1.price) < parseFloat(order2.price)) return 1;
+  if (parseFloat(order1.price) > parseFloat(order2.price)) return -1;
+  return 0;
 }

--- a/packages/augur-sdk/src/api/ZeroX.ts
+++ b/packages/augur-sdk/src/api/ZeroX.ts
@@ -78,6 +78,7 @@ export interface ZeroXPlaceTradeDisplayParams
 
 export interface ZeroXPlaceTradeParams extends NativePlaceTradeChainParams {
   expirationTime: BigNumber;
+  ignoreCrossOrders?: boolean;
 }
 
 export interface ZeroXOrder {
@@ -302,7 +303,7 @@ export class ZeroX {
 
     const account = await this.client.getAccount();
 
-    const { orders, signatures, orderIds, loopLimit, gasLimit } = await this.getMatchingOrders(
+    const { orders, signatures, orderIds, loopLimit } = await this.getMatchingOrders(
       params,
       ignoreOrders
     );
@@ -673,6 +674,7 @@ export class ZeroX {
       orderType,
       matchPrice: `0x${price.padStart(20, '0')}`,
       ignoreOrders,
+      ignoreCrossOrders: params.ignoreCrossOrders,
     });
 
     if (_.size(zeroXOrders) < 1) {

--- a/packages/augur-sdk/src/state/getter/LiquidityPool.ts
+++ b/packages/augur-sdk/src/state/getter/LiquidityPool.ts
@@ -1,8 +1,5 @@
 import {
-  Order,
-  OrderState,
   MarketData,
-  OrderType,
   OrderTypeHex,
 } from '@augurproject/sdk-lite';
 import { DB } from '../db/DB';
@@ -10,11 +7,7 @@ import * as _ from 'lodash';
 import { Augur } from '../../index';
 import { BigNumber } from 'bignumber.js';
 import { Getter } from './Router';
-import { getMarkets } from './OnChainTrading';
-import { StoredOrder } from '../db/ZeroXOrders';
-import Dexie from 'dexie';
 import * as t from 'io-ts';
-import { ZeroXOrdersGetters } from './ZeroXOrdersGetters';
 import {
   convertOnChainPriceToDisplayPrice,
   convertOnChainAmountToDisplayAmount,

--- a/packages/augur-sdk/src/state/getter/Markets.ts
+++ b/packages/augur-sdk/src/state/getter/Markets.ts
@@ -115,6 +115,7 @@ export class Markets {
       account: t.string,
       onChain: t.boolean, // if false or not present, use 0x orderbook
       expirationCutoffSeconds: t.number,
+      ignoreCrossOrders: t.boolean,
     }),
   ]);
 
@@ -659,6 +660,7 @@ export class Markets {
         marketId: params.marketId,
         orderState: OrderState.OPEN,
         expirationCutoffSeconds: params.expirationCutoffSeconds,
+        ignoreCrossOrders: params.ignoreCrossOrders,
       });
     }
 

--- a/packages/augur-sdk/src/state/getter/OnChainTrading.ts
+++ b/packages/augur-sdk/src/state/getter/OnChainTrading.ts
@@ -6,6 +6,7 @@ import {
   OrderEventType,
   Orders,
   ParsedOrderEventLog,
+  ZeroXOrders,
 } from '@augurproject/sdk-lite';
 import { OrderState } from '@augurproject/sdk-lite';
 import { BigNumber } from 'bignumber.js';
@@ -22,7 +23,7 @@ import {
 import { DB } from '../db/DB';
 import { Getter } from './Router';
 import { sortOptions } from './types';
-import { ZeroXOrders, ZeroXOrdersGetters } from './ZeroXOrdersGetters';
+import { ZeroXOrdersGetters } from './ZeroXOrdersGetters';
 
 const ZERO = new BigNumber(0);
 

--- a/packages/augur-sdk/src/state/getter/OnChainTrading.ts
+++ b/packages/augur-sdk/src/state/getter/OnChainTrading.ts
@@ -61,6 +61,7 @@ export const OrdersParams = t.partial({
   account: t.string,
   orderState: t.string,
   expirationCutoffSeconds: t.number,
+  ignoreCrossOrders: t.boolean,
 });
 
 export const OrderType = t.keyof({

--- a/packages/augur-sdk/src/state/getter/Users.ts
+++ b/packages/augur-sdk/src/state/getter/Users.ts
@@ -10,8 +10,9 @@ import {
   OrderEventType,
   ParsedOrderEventLog,
   ProfitLossChangedLog,
+  ZeroXOrders,
+  Order,
 } from '@augurproject/sdk-lite';
-import { Order } from '@augurproject/sdk-lite/build';
 import {
   DisputeCrowdsourcerRedeemed,
   OrderEvent,
@@ -41,7 +42,7 @@ import {
 } from './OnChainTrading';
 import { Getter } from './Router';
 import { sortOptions } from './types';
-import { ZeroXOrders, collapseZeroXOrders } from './ZeroXOrdersGetters';
+import { collapseZeroXOrders } from './ZeroXOrdersGetters';
 
 const ONE_DAY = 1;
 const DAYS_IN_MONTH = 30;

--- a/packages/augur-test/src/tests/3rd-party/ZeroX.test.ts
+++ b/packages/augur-test/src/tests/3rd-party/ZeroX.test.ts
@@ -4,10 +4,6 @@ import { SDKConfiguration } from '@augurproject/utils';
 import { sleep } from '@augurproject/core/build/libraries/HelperFunctions';
 import { EthersProvider } from '@augurproject/ethersjs-provider';
 import { Connectors } from '@augurproject/sdk';
-import {
-  ZeroXOrder,
-  ZeroXOrders,
-} from '@augurproject/sdk/build/state/getter/ZeroXOrdersGetters';
 import { ACCOUNTS } from '@augurproject/tools';
 import { TestContractAPI } from '@augurproject/tools';
 import { stringTo32ByteHex } from '@augurproject/tools/build/libs/Utils';
@@ -15,6 +11,7 @@ import { BigNumber } from 'bignumber.js';
 import { JsonRpcProvider } from 'ethers/providers';
 import { formatBytes32String } from 'ethers/utils';
 import * as _ from 'lodash';
+import { ZeroXOrders, ZeroXOrder } from '@augurproject/sdk-lite';
 
 describe('3rd Party :: ZeroX :: ', () => {
   let john: TestContractAPI;

--- a/packages/augur-test/src/tests/api/ZeroX.test.ts
+++ b/packages/augur-test/src/tests/api/ZeroX.test.ts
@@ -2,7 +2,6 @@ import { WSClient } from '@0x/mesh-rpc-client';
 import { SDKConfiguration } from '@augurproject/utils';
 import { sleep } from '@augurproject/core/build/libraries/HelperFunctions';
 import { Connectors } from '@augurproject/sdk';
-import { ZeroXOrders } from '@augurproject/sdk/build/state/getter/ZeroXOrdersGetters';
 import {
   ACCOUNTS,
   defaultSeedPath,
@@ -17,6 +16,7 @@ import * as _ from 'lodash';
 import { enableZeroX, makeProvider } from '../../libs';
 import { MockBrowserMesh } from '../../libs/MockBrowserMesh';
 import { MockMeshServer, stopServer } from '../../libs/MockMeshServer';
+import { ZeroXOrders } from '@augurproject/sdk-lite/build';
 
 describe('Augur API :: ZeroX :: ', () => {
   let john: TestContractAPI;

--- a/packages/augur-test/src/tests/state/getter/CrossOrderbook.test.ts
+++ b/packages/augur-test/src/tests/state/getter/CrossOrderbook.test.ts
@@ -1,0 +1,337 @@
+import {
+  ignoreCrossedOrders,
+  ZeroXOrders,
+  OrderState,
+  OrderType,
+  ZeroXOrder,
+} from '@augurproject/sdk-lite';
+import * as _ from 'lodash';
+
+describe('Cross orderbook', () => {
+  const maker = 'maker';
+  const account2 = 'account2';
+  const fakeData = 'fakeData';
+  beforeAll(async () => {});
+
+  afterAll(() => {});
+
+  const createOrder = (
+    account,
+    orderId,
+    price,
+    amount,
+    expirationTimeSeconds
+  ): ZeroXOrder => {
+    return {
+      expirationTimeSeconds: expirationTimeSeconds,
+      makerAddress: account,
+      orderId,
+      price,
+      amount,
+      makerAssetAmount: fakeData,
+      takerAssetAmount: fakeData,
+      salt: fakeData,
+      makerAssetData: fakeData,
+      takerAssetData: fakeData,
+      signature: fakeData,
+      makerFeeAssetData: fakeData,
+      takerFeeAssetData: fakeData,
+      feeRecipientAddress: fakeData,
+      takerAddress: fakeData,
+      senderAddress: fakeData,
+      makerFee: fakeData,
+      takerFee: fakeData,
+      transactionHash: fakeData,
+      logIndex: 1,
+      owner: fakeData,
+      orderState: OrderState.OPEN,
+      amountFilled: '0',
+      fullPrecisionPrice: fakeData,
+      fullPrecisionAmount: fakeData,
+      tokensEscrowed: fakeData,
+      sharesEscrowed: fakeData,
+      creationTime: 1,
+      creationBlockNumber: 1,
+      originalFullPrecisionAmount: '0',
+    };
+  };
+
+  describe('tests', () => {
+    /* */
+    test('CrossOrderBook: no book', async () => {
+      const marketId = 'marketId';
+      const testOutcomeOrders: ZeroXOrders = {
+        [marketId]: {
+          1: {},
+        },
+      };
+      const newBook = ignoreCrossedOrders(testOutcomeOrders, maker);
+      expect(newBook).toMatchObject(testOutcomeOrders);
+    });
+
+    test('CrossOrderBook: no cross empty bids', async () => {
+      const marketId = 'marketId';
+      const testOutcomeOrders: ZeroXOrders = {
+        [marketId]: {
+          1: {
+            [String(OrderType.Ask)]: {
+              [`order3`]: createOrder(maker, `order3`, `0.52`, 100, 1111),
+              [`order2`]: createOrder(maker, `order2`, `0.42`, 100, 1111),
+              [`order1`]: createOrder(maker, `order1`, `0.41`, 100, 1111),
+            },
+            [String(OrderType.Bid)]: {},
+          },
+        },
+      };
+      const newBook = ignoreCrossedOrders(testOutcomeOrders, maker);
+      expect(newBook).toMatchObject(testOutcomeOrders);
+    });
+
+    test('CrossOrderBook: no bids book', async () => {
+      const marketId = 'marketId';
+      const testOutcomeOrders: ZeroXOrders = {
+        [marketId]: {
+          1: {
+            [String(OrderType.Ask)]: {
+              [`order3`]: createOrder(maker, `order3`, `0.52`, 100, 1111),
+              [`order2`]: createOrder(maker, `order2`, `0.42`, 100, 1111),
+              [`order1`]: createOrder(maker, `order1`, `0.41`, 100, 1111),
+            },
+          },
+        },
+      };
+      const newBook = ignoreCrossedOrders(testOutcomeOrders, maker);
+      expect(newBook).toMatchObject(testOutcomeOrders);
+    });
+
+    test('CrossOrderBook: no asks book', async () => {
+      const marketId = 'marketId';
+      const testOutcomeOrders: ZeroXOrders = {
+        [marketId]: {
+          1: {
+            [String(OrderType.Ask)]: {
+              [`order3`]: createOrder(maker, `order3`, `0.52`, 100, 1111),
+              [`order2`]: createOrder(maker, `order2`, `0.42`, 100, 1111),
+              [`order1`]: createOrder(maker, `order1`, `0.41`, 100, 1111),
+            },
+          },
+        },
+      };
+      const newBook = ignoreCrossedOrders(testOutcomeOrders, maker);
+      expect(newBook).toMatchObject(testOutcomeOrders);
+    });
+
+    test('CrossOrderBook: ignore one crossed ask order smaller size ', async () => {
+      const marketId = 'marketId';
+      const crossedOrder = 'order0'
+      const testOutcomeOrders: ZeroXOrders = {
+        [marketId]: {
+          1: {
+            [String(OrderType.Ask)]: {
+              [`order3`]: createOrder(maker, `order3`, `0.52`, 100, 1111),
+              [`order2`]: createOrder(maker, `order2`, `0.42`, 100, 1111),
+              [`order1`]: createOrder(maker, `order1`, `0.41`, 100, 1111),
+              [crossedOrder]: createOrder(maker, crossedOrder, `0.38`, 10, 1111),
+            },
+            [String(OrderType.Bid)]: {
+              [`order4`]: createOrder(maker, `order4`, `0.39`, 100, 1111),
+              [`order5`]: createOrder(maker, `order5`, `0.30`, 100, 1111),
+            },
+          },
+        },
+      };
+      const newBook = ignoreCrossedOrders(testOutcomeOrders, account2);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Bid)])).toHaveLength(2);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Ask)])).toHaveLength(3);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Ask)]).includes(crossedOrder)).toBe(false);
+    });
+
+
+    test('CrossOrderBook: ignore one crossed ask order older order ', async () => {
+      const marketId = 'marketId';
+      const testOutcomeOrders: ZeroXOrders = {
+        [marketId]: {
+          1: {
+            [String(OrderType.Ask)]: {
+              [`order3`]: createOrder(maker, `order3`, `0.52`, 100, 1111),
+              [`order2`]: createOrder(maker, `order2`, `0.42`, 100, 1111),
+              [`order1`]: createOrder(maker, `order1`, `0.41`, 100, 1111),
+              ['order0']: createOrder(maker, 'order0', `0.38`, 10, 1111),
+            },
+            [String(OrderType.Bid)]: {
+              [`order4`]: createOrder(maker, `order4`, `0.39`, 10, 2222),
+              [`order5`]: createOrder(maker, `order5`, `0.30`, 100, 1111),
+            },
+          },
+        },
+      };
+      const newBook = ignoreCrossedOrders(testOutcomeOrders, account2);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Bid)])).toHaveLength(1);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Ask)])).toHaveLength(4);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Bid)]).includes('order4')).toBe(false);
+    });
+
+    test('CrossOrderBook: ignore multiple crossed ask order size and ttl ', async () => {
+      const marketId = 'marketId';
+      const testOutcomeOrders: ZeroXOrders = {
+        [marketId]: {
+          1: {
+            [String(OrderType.Ask)]: {
+              [`order5`]: createOrder(maker, `order5`, `0.52`, 100, 1111),
+              [`order4`]: createOrder(maker, `order4`, `0.42`, 100, 1111),
+              [`order3`]: createOrder(maker, `order3`, `0.41`, 100, 1111),
+              [`order2`]: createOrder(maker, `order2`, `0.38`, 10, 1111),
+              [`order1`]: createOrder(maker, `order1`, `0.38`, 10, 1111),
+              [`order0`]: createOrder(maker, `order0`, `0.37`, 10, 1111),
+            },
+            [String(OrderType.Bid)]: {
+              [`order9`]: createOrder(maker, `order9`, `0.39`, 10, 2222),
+              [`order8`]: createOrder(maker, `order8`, `0.30`, 100, 1111),
+            },
+          },
+        },
+      };
+      const newBook = ignoreCrossedOrders(testOutcomeOrders, account2);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Bid)])).toHaveLength(1);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Ask)])).toHaveLength(6);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Bid)]).includes(`order9`)).toBe(false);
+    });
+
+    test('CrossOrderBook: crossed asks/bids keep bids large amount', async () => {
+      const marketId = 'marketId';
+      const testOutcomeOrders: ZeroXOrders = {
+        [marketId]: {
+          1: {
+            [String(OrderType.Ask)]: {
+              [`order5`]: createOrder(maker, `order5`, `0.52`, 100, 1111),
+              [`order4`]: createOrder(maker, `order4`, `0.42`, 100, 1111),
+              [`order3`]: createOrder(maker, `order3`, `0.41`, 100, 1111),
+              [`order2`]: createOrder(maker, `order2`, `0.38`, 10, 1111),
+              [`order1`]: createOrder(maker, `order1`, `0.38`, 10, 1111),
+              [`order0`]: createOrder(maker, `order0`, `0.37`, 10, 1111),
+            },
+            [String(OrderType.Bid)]: {
+              [`order9`]: createOrder(maker, `order9`, `0.39`, 100, 1111),
+              [`order81`]: createOrder(maker, `order81`, `0.38`, 100, 1111),
+              [`order82`]: createOrder(maker, `order82`, `0.37`, 100, 1111),
+              [`order83`]: createOrder(maker, `order83`, `0.30`, 100, 1111),
+              [`order84`]: createOrder(maker, `order84`, `0.30`, 100, 1111),
+            },
+          },
+        },
+      };
+      const newBook = ignoreCrossedOrders(testOutcomeOrders, account2);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Ask)])).toHaveLength(3);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Bid)])).toHaveLength(5);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Ask)]).includes(`order0`)).toBe(false);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Ask)]).includes(`order1`)).toBe(false);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Ask)]).includes(`order2`)).toBe(false);
+    });
+
+    test('CrossOrderBook: crossed asks/bids keep bids ttl', async () => {
+      const marketId = 'marketId';
+      const testOutcomeOrders: ZeroXOrders = {
+        [marketId]: {
+          1: {
+            [String(OrderType.Ask)]: {
+              [`order5`]: createOrder(maker, `order5`, `0.52`, 100, 1111),
+              [`order4`]: createOrder(maker, `order4`, `0.42`, 100, 1111),
+              [`order3`]: createOrder(maker, `order3`, `0.41`, 100, 1115),
+              [`order2`]: createOrder(maker, `order2`, `0.38`, 100, 1114),
+              [`order1`]: createOrder(maker, `order1`, `0.38`, 100, 1113),
+              [`order0`]: createOrder(maker, `order0`, `0.37`, 100, 1112),
+            },
+            [String(OrderType.Bid)]: {
+              [`order9`]: createOrder(maker, `order9`, `0.39`, 10, 2222),
+              [`order81`]: createOrder(maker, `order81`, `0.38`, 100, 9999),
+              [`order82`]: createOrder(maker, `order82`, `0.37`, 100, 1110),
+              [`order83`]: createOrder(maker, `order83`, `0.30`, 100, 1119),
+              [`order84`]: createOrder(maker, `order84`, `0.30`, 100, 1121),
+            },
+          },
+        },
+      };
+      const newBook = ignoreCrossedOrders(testOutcomeOrders, account2);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Ask)])).toHaveLength(5);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Bid)])).toHaveLength(3);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Ask)]).includes(`order0`)).toBe(false);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Bid)]).includes(`order9`)).toBe(false);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Bid)]).includes(`order81`)).toBe(false);
+    });
+
+    test('CrossOrderBook: crossed asks/bids remove last bid', async () => {
+      const marketId = 'marketId';
+      const testOutcomeOrders: ZeroXOrders = {
+        [marketId]: {
+          1: {
+            [String(OrderType.Ask)]: {
+              [`order5`]: createOrder(maker, `order5`, `0.52`, 100, 1111),
+              [`order4`]: createOrder(maker, `order4`, `0.42`, 100, 1111),
+              [`order3`]: createOrder(maker, `order3`, `0.41`, 100, 1115),
+              [`order2`]: createOrder(maker, `order2`, `0.38`, 100, 1114),
+              [`order1`]: createOrder(maker, `order1`, `0.38`, 100, 1113),
+              [`order0`]: createOrder(maker, `order0`, `0.37`, 100, 1112),
+            },
+            [String(OrderType.Bid)]: {
+              [`order9`]: createOrder(maker, `order9`, `0.37`, 10, 2222),
+            },
+          },
+        },
+      };
+      const newBook = ignoreCrossedOrders(testOutcomeOrders, account2);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Ask)])).toHaveLength(6);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Bid)])).toHaveLength(0);
+    });
+
+
+    test('CrossOrderBook: crossed asks/bids keep all orders by user', async () => {
+      const marketId = 'marketId';
+      const testOutcomeOrders: ZeroXOrders = {
+        [marketId]: {
+          1: {
+            [String(OrderType.Ask)]: {
+              [`order5`]: createOrder(maker, `order5`, `0.52`, 100, 1111),
+              [`order4`]: createOrder(maker, `order4`, `0.42`, 100, 1111),
+              [`order3`]: createOrder(maker, `order3`, `0.41`, 100, 1115),
+              [`order2`]: createOrder(maker, `order2`, `0.38`, 100, 1114),
+              [`order1`]: createOrder(maker, `order1`, `0.38`, 100, 1113),
+              [`order0`]: createOrder(maker, `order0`, `0.37`, 100, 1112),
+            },
+            [String(OrderType.Bid)]: {
+              [`order9`]: createOrder(account2, `order9`, `0.37`, 10, 2222),
+              [`order81`]: createOrder(maker, `order81`, `0.38`, 100, 9999),
+            },
+          },
+        },
+      };
+      const newBook = ignoreCrossedOrders(testOutcomeOrders, account2);
+      expect(newBook).toMatchObject(testOutcomeOrders);
+    });
+
+    test('CrossOrderBook: crossed asks/bids remove non users crossed orders', async () => {
+      const marketId = 'marketId';
+      const testOutcomeOrders: ZeroXOrders = {
+        [marketId]: {
+          1: {
+            [String(OrderType.Ask)]: {
+              [`order5`]: createOrder(maker, `order5`, `0.52`, 100, 1111),
+              [`order4`]: createOrder(maker, `order4`, `0.42`, 100, 1111),
+              [`order3`]: createOrder(maker, `order3`, `0.41`, 100, 1115),
+              [`order2`]: createOrder(maker, `order2`, `0.38`, 100, 1114),
+              [`order1`]: createOrder(maker, `order1`, `0.38`, 100, 1113),
+              [`order0`]: createOrder(maker, `order0`, `0.37`, 100, 1112),
+            },
+            [String(OrderType.Bid)]: {
+              [`order9`]: createOrder(account2, `order9`, `0.40`, 10, 2222),
+              [`order81`]: createOrder(maker, `order81`, `0.39`, 100, 9999),
+            },
+          },
+        },
+      };
+      const newBook = ignoreCrossedOrders(testOutcomeOrders, account2);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Ask)])).toHaveLength(6);
+      expect(_.keys(newBook[marketId][1][String(OrderType.Bid)])).toHaveLength(1);
+    });
+
+  });
+});

--- a/packages/augur-ui/src/modules/orders/actions/load-market-orderbook.ts
+++ b/packages/augur-ui/src/modules/orders/actions/load-market-orderbook.ts
@@ -38,10 +38,10 @@ export const loadMarketOrderBook = (
   const augur = augurSdk.get();
   const expirationCutoffSeconds = await augur.getGasConfirmEstimate();
   let params = loginAccount.address
-    ? { marketId, account: loginAccount.address, expirationCutoffSeconds }
-    : { marketId };
+    ? { account: loginAccount.address, expirationCutoffSeconds }
+    : { };
   const Augur = augurSdk.get();
-  const marketOrderBook = await Augur.getMarketOrderBook(params);
+  const marketOrderBook = await Augur.getMarketOrderBook({ ...params, marketId, ignoreCrossOrders: true });
   dispatch(updateOrderBook(marketId, marketOrderBook));
   callback(null, marketOrderBook);
 };


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/8328


1. removes orders from orderbook based on amount, ttl and price.
2. unit tests to get coverage of different scenarios
3. leave users' orders in the orderbook. 