### PR TITLE
Brings Migrate UI in line with new naming convention.

### DIFF
--- a/packages/augur-ui/src/modules/modal/migrate-rep.tsx
+++ b/packages/augur-ui/src/modules/modal/migrate-rep.tsx
@@ -111,13 +111,13 @@ export const MigrateRep = () => {
       />
 
       <main>
-        {!inSigningWallet && <h1>You have V1 REP in your trading account</h1>}
-        {inSigningWallet && <h1>You have V1 REP in your wallet</h1>}
+        {!inSigningWallet && <h1>You have REP in your trading account</h1>}
+        {inSigningWallet && <h1>You have REP in your wallet</h1>}
 
         <h2>
-          Migrate your V1 REP to V2 REP to use it in Augur V2. The quantity of
-          V1 REP shown below will migrate to an equal amount of V2 REP. For
-          example 100 V1 REP will migrate to 100 V2 REP.
+          Migrate your REP to REPv2 to use it in Augur v2. The quantity of
+          REP shown below will migrate to an equal amount of REPv2. For
+          example 100 REP will migrate to 100 REPv2.
           <ExternalLinkButton
             label="Learn more"
             URL={HELP_CENTER_MIGRATE_REP}


### PR DESCRIPTION
Figured a PR was just as easy an issue suggesting the change.  While I disagree with the choice in naming of `REP` (instead of `REPv1`), I feel even stronger that we should be consistent with the chosen naming scheme throughout the Augur UI, and the ecosystem at large.

I suspect there are many other places in the UI that refer to `REP` which should instead refer to `REPv2`, but I'm not sure where they all live.  The Token used in Augur v2 is **NOT** `REP`, it is `REPv2`.  If we had decided to name `REPv1` then this would be less of an issue.  😉  As it is, if someone sees they need "REP" in order to dispute an incorrect outcome, they will go buy `REP` off an exchange and be sad when it isn't what they need to dispute.