### PR TITLE
Bruno/8473

### DIFF
--- a/packages/augur-ui/src/modules/market/components/market-orders-positions-table/market-orders-positions-table.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-orders-positions-table/market-orders-positions-table.tsx
@@ -46,7 +46,7 @@ const MarketOrdersPositionsTable: React.FC<MarketOrdersPositionsTableProps> = ({
     >
       <ModulePane label="Open Orders">
         <OpenOrdersTable openOrders={openOrders} marketId={market.marketId} />
-        {openOrders.length > 0 && (
+        {openOrders.length > 0 && openOrders.filter(openOrder => !openOrder.pending).length > 0 && (
           <div className={Styles.Footer}>
             <CancelTextButton
               action={() => cancelAllOpenOrders(openOrders)}


### PR DESCRIPTION
#8473 

If there was no orders in the table and the user placed an order that fails, the table footer would overlap the table header and get in front of the tabs.

I've added a check to see if at least 1 order is not pending, meaning it's actually populating the table.

@mergifyio backport dev