### PR TITLE
Fix defaulting user defined gas price

### DIFF
--- a/packages/augur-ui/src/modules/auth/actions/load-account-data.ts
+++ b/packages/augur-ui/src/modules/auth/actions/load-account-data.ts
@@ -13,6 +13,7 @@ import { getEthToDaiRate } from 'modules/app/actions/get-ethToDai-rate';
 import { getRepToDaiRate } from 'modules/app/actions/get-repToDai-rate';
 import { getTradePageMarketId } from "modules/trades/helpers/get-trade-page-market-id";
 import { loadMarketOrderBook } from 'modules/orders/actions/load-market-orderbook';
+import { loadGasPriceInfo } from 'modules/app/actions/load-gas-price-info';
 
 export const loadAccountData = (
   callback: NodeStyleCallback = logError
@@ -41,7 +42,8 @@ export const loadAccountData = (
     dispatch(loadUniverseDetails(universe.id, address));
     dispatch(getEthToDaiRate());
     dispatch(getRepToDaiRate());
-    dispatch(registerUserDefinedGasPriceFunction(gasPriceInfo.userDefinedGasPrice, gasPriceInfo.average));
+    dispatch(loadGasPriceInfo());
+    gasPriceInfo.userDefinedGasPrice && dispatch(registerUserDefinedGasPriceFunction(gasPriceInfo.userDefinedGasPrice, gasPriceInfo.average));
     const marketId = getTradePageMarketId();
     if (marketId) {
       dispatch(loadMarketOrderBook(marketId));

--- a/packages/augur-ui/src/modules/modal/containers/modal-gas-price.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-gas-price.ts
@@ -17,7 +17,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({
   closeAction: () => dispatch(closeModal()),
   saveAction: (userDefinedGasPrice: number, average: number) => {
     dispatch(updateGasPriceInfo({ userDefinedGasPrice }));
-    dispatch(registerUserDefinedGasPriceFunction(userDefinedGasPrice, average));
+    userDefinedGasPrice && dispatch(registerUserDefinedGasPriceFunction(userDefinedGasPrice, average));
     dispatch(closeModal());
   },
 });

--- a/packages/augur-ui/src/modules/modal/gas.tsx
+++ b/packages/augur-ui/src/modules/modal/gas.tsx
@@ -78,7 +78,6 @@ export const Gas = (props: GasProps) => {
 
   const updateAmount = (newAmount: number) => {
     let amt = newAmount;
-    if (newAmount) amt = Math.round(Math.abs(Number(amt)));
     setAmount(amt);
     setShowLowAlert(!amt || amt < props.safeLow);
   };


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/8572

there is an initial delay to get new Block events. added getting gas prices from api when user logs in so that UI has new gasPrices. 

also, don't store the average as user defined so that average will be used if user never sets their own gasPrice.

@Mergifyio backport dev