### PR TITLE
Switched from 0.5fr to 50vh and removed a useless filter

### DIFF
--- a/packages/augur-ui/src/modules/market/components/market-orders-positions-table/market-orders-positions-table.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-orders-positions-table/market-orders-positions-table.tsx
@@ -46,7 +46,7 @@ const MarketOrdersPositionsTable: React.FC<MarketOrdersPositionsTableProps> = ({
     >
       <ModulePane label="Open Orders">
         <OpenOrdersTable openOrders={openOrders} marketId={market.marketId} />
-        {openOrders.length > 0 && openOrders.filter(openOrder => !openOrder.pending).length > 0 && (
+        {openOrders.length > 0 && (
           <div className={Styles.Footer}>
             <CancelTextButton
               action={() => cancelAllOpenOrders(openOrders)}

--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.styles.less
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.styles.less
@@ -75,7 +75,7 @@
   @media @breakpoint-tablet {
     grid-gap: @size-4;
     grid-template-columns: 1fr 1fr 1fr;
-    grid-template-rows: 0fr 0fr 0fr 0fr 0.5fr;
+    grid-template-rows: 0fr 0fr 0fr 0fr 50vh;
     //  hide the toggle buttons because the layout doesn't allow them to do anything useful.
     button[class*="buttons-styles_ToggleExtendButton"] {
       display: none;


### PR DESCRIPTION
#8589 

Safari was not showing orders because they implement Flexbox in a weird way.
That fix also fixes the footer of the table getting in front of the header, so I reverted that openOrders.filter because it could potentially cause perfomance issues.