### PR TITLE
Remove Invalid clause about source in the title

### DIFF
--- a/packages/augur-ui/src/modules/create-market/constants.ts
+++ b/packages/augur-ui/src/modules/create-market/constants.ts
@@ -141,7 +141,6 @@ export const InvalidRules = [
   'Any of the outcomes are duplicates',
   'The market can resolve with more than one winning outcome.',
   'Any of the outcomes don’t answer the market question ONLY. (outcomes cannot introduce a secondary question)',
-  'If using a resolution source (a source is a noun that reports on or decides the result of a market), the source\'s URL or full name is NOT in the Market Question, regardless of it being in the resolution details.',
   'If using a resolution source, it is not referenced consistently between the Market Question and Resolution Details e.g. as either a URL or its full name.',
   'Player or team is not in the correct league, division or conference, at the time the market was created.',
 ];


### PR DESCRIPTION
A market with a question that does not give the resolution source while market details give a resolution source does not seem and should not be Invalid in my opinion.

As an example, consider markets that use multiple fallback sources. Should the market say "What will be the number of deaths due to Covid by [date] according to [source 1], or [source 2] if [source 1] is unavailable, or [source 3] if [source 1] and [source 2] are unavailable?". Clearly no, the market should say "What will be the number of deaths due to Covid by [date]?" and specify the primary resolution source and fallback source in the details.

Another example would be a market about the average number of whatever metric reported by multiple sources.

The argument is made that this would allow markets such as "What will the price of bitcoin be at the end of 12/31/2019?" while the description says "According to twitter.com/scamaccount". While adopting this rule would lead to systematic resolution to such markets as Invalid, thus limiting the possibility of misleading users, it comes at the cost of greatly reduced functionality for legitimate users who would like to aggregate multiple sources our use backup sources. Furthermore, the expectation that users will be able to bet on Augur at 0 risk has to stop. The truth is that users have to read the market details no matter what, as this is what the oracle will use to resolve markets.

All in all, this rule does more harm than good, and in general the default UI should refrain from adding Invalid clauses as much as possible as it may give the impression to users that these rules are set in stone, while the final arbiters are REP holders, not text from the UI added by the developers as they wish.