### PR TITLE
Sportsgroup page settings updates

### DIFF
--- a/packages/augur-sdk/src/api/BestOffer.ts
+++ b/packages/augur-sdk/src/api/BestOffer.ts
@@ -65,7 +65,7 @@ export class BestOffer {
           hasBestOffer &&
           poolBestPrice[_.first(_.keys(poolBestPrice))][
             Number(new BigNumber(order.outcome))
-          ].price;
+          ]?.price || null;
         // if outcome order is null, then no offers, send null for that outcome
         if (
           !poolBestPrice ||

--- a/packages/augur-ui/src/modules/app/store/local-storage-persistence.ts
+++ b/packages/augur-ui/src/modules/app/store/local-storage-persistence.ts
@@ -7,7 +7,7 @@ import { augurSdk } from "services/augursdk";
 import { processFavorites } from "modules/markets/helpers/favorites-processor";
 
 export const handleLocalStorage = () => {
-  const { drafts, analytics, alerts, notifications, favorites, loginAccount, isLogged, isConnected, env, gasPriceInfo, pendingQueue } = AppStatus.get();
+  const { drafts, analytics, alerts, notifications, favorites, loginAccount, isLogged, isConnected, env, gasPriceInfo, pendingQueue, theme, oddsType, timeFormat } = AppStatus.get();
   const { pendingOrders, pendingLiquidityOrders } = PendingOrders.get();
   if (
     !loginAccount?.address ||
@@ -61,7 +61,10 @@ export const handleLocalStorage = () => {
           ...storedAccountData.selectedUniverse,
         },
         settings,
-        affiliate
+        affiliate,
+        theme,
+        oddsType,
+        timeFormat
       })
     );
   }

--- a/packages/augur-ui/src/modules/auth/actions/load-account-data-from-local-storage.ts
+++ b/packages/augur-ui/src/modules/auth/actions/load-account-data-from-local-storage.ts
@@ -10,9 +10,7 @@ import { loadAnalytics } from 'modules/app/actions/analytics-management';
 import { AppStatus } from 'modules/app/store/app-status';
 import isAddress from 'modules/auth/helpers/is-address';
 
-export const loadAccountDataFromLocalStorage = (
-  address: string
-) => {
+export const loadAccountDataFromLocalStorage = (address: string) => {
   const localStorageRef = typeof window !== 'undefined' && window.localStorage;
   const { universe, filterSortOptions } = AppStatus.get();
 
@@ -27,13 +25,25 @@ export const loadAccountDataFromLocalStorage = (
         updateGasPriceInfo,
         updateNotifications,
         loadDrafts,
+        setOdds,
+        setTimeFormat,
       } = AppStatus.actions;
-      const { selectedUniverse } = storedAccountData;
-      const { favorites } = storedAccountData;
-      const { notifiations } = storedAccountData;
-      const { pendingQueue } = storedAccountData;
-      const { affiliate } = storedAccountData;
-      const { settings } = storedAccountData;
+      const {
+        oddsType,
+        timeFormat,
+        settings,
+        selectedUniverse,
+        favorites,
+        notifications,
+        pendingQueue,
+        affiliate,
+        alerts,
+        pendingLiquidityOrders,
+        pendingOrders,
+        gasPriceInfo,
+        drafts,
+        analytics,
+      } = storedAccountData;
 
       if (settings) {
         const filterOptions = Object.keys(settings).reduce(
@@ -49,8 +59,8 @@ export const loadAccountDataFromLocalStorage = (
       if (!!affiliate && isAddress(affiliate))
         updateLoginAccount({ affiliate });
 
-      if (notifiations) {
-        updateNotifications(notifiations);
+      if (notifications) {
+        updateNotifications(notifications);
       }
       const networkId = getNetworkId();
       const selectedUniverseId = selectedUniverse[networkId];
@@ -70,14 +80,6 @@ export const loadAccountDataFromLocalStorage = (
       ) {
         loadFavorites(favorites[networkId][universe.id]);
       }
-      const {
-        alerts,
-        pendingLiquidityOrders,
-        pendingOrders,
-        gasPriceInfo,
-        drafts,
-        analytics,
-      } = storedAccountData;
       if (drafts) {
         loadDrafts(drafts);
       }
@@ -115,6 +117,13 @@ export const loadAccountDataFromLocalStorage = (
           userDefinedGasPrice: gasPriceInfo.userDefinedGasPrice,
         });
       }
+      if (oddsType) {
+        setOdds(oddsType);
+      }
+      if (timeFormat) {
+        setTimeFormat(timeFormat);
+      }
+
     }
   }
 };

--- a/packages/augur-ui/src/modules/market/components/common/common.tsx
+++ b/packages/augur-ui/src/modules/market/components/common/common.tsx
@@ -1,7 +1,8 @@
 import { MarketData, QueryEndpoints } from 'modules/types';
 import { useHistory } from 'react-router';
-import * as React from 'react';
+import React, { useEffect } from 'react';
 import * as classNames from 'classnames';
+import Clipboard from 'clipboard';
 import { CATEGORY_PARAM_NAME } from 'modules/common/constants';
 import { LeftChevron, CopyAlternateIcon } from 'modules/common/icons';
 import {
@@ -49,6 +50,11 @@ export const HeadingBar = ({
     loginAccount: { address: userAccount },
   } = useAppStatusStore();
   const history = useHistory();
+
+  useEffect(() => {
+    new Clipboard('#copy_marketURL');
+  }, []);
+
   const isScalar = marketType === SCALAR;
 
   const process = arr =>

--- a/packages/augur-ui/src/modules/market/components/market-view/betting-market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/betting-market-view.tsx
@@ -108,7 +108,7 @@ const BettingMarketView = () => {
         <div>
           <PropertyLabel
             label="matched"
-            value={formatDai(0).full}
+            value={formatDai(sportsGroup.current?.totalVolume || '0').full}
             hint={<h4>Matched</h4>}
             large
           />

--- a/packages/augur-ui/src/modules/market/components/market-view/betting-market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/betting-market-view.tsx
@@ -5,15 +5,14 @@ import { MARKET_ID_PARAM_NAME } from 'modules/routes/constants/param-names';
 import { getAddress } from 'ethers/utils/address';
 import { selectMarket } from 'modules/markets/selectors/market';
 import Styles from 'modules/market/components/market-view/betting-market-view.styles.less';
-import { HeadingBar, InfoTicket } from 'modules/market/components/common/common';
+import {
+  HeadingBar,
+  InfoTicket,
+} from 'modules/market/components/common/common';
 import { PropertyLabel, FullTimeLabel } from 'modules/common/labels';
 import { formatPercent, formatDai } from 'utils/format-number';
 import { Subheaders } from 'modules/reporting/common';
-import {
-  BetsIcon,
-  BettorsIcon,
-  DaiLogoIcon
-} from 'modules/common/icons';
+import { BetsIcon, BettorsIcon, DaiLogoIcon } from 'modules/common/icons';
 import { SportsGroupMarkets } from 'modules/market-cards/common';
 import { getSportsGroupsFromSportsIDs } from 'modules/markets-list/components/markets-list';
 import { getMarkets } from 'modules/markets/selectors/markets-all';
@@ -35,6 +34,7 @@ const BettingMarketView = () => {
     actions: { updateMarketsData, bulkMarketTradingHistory },
   } = useMarketsStore();
   const location = useLocation();
+  const [showCopied, setShowCopied] = useState(false);
   const totalBets = useRef(0);
   const totalBettors = useRef(0);
   const uniqueAddresses = useRef([]);
@@ -53,6 +53,16 @@ const BettingMarketView = () => {
   }, []);
 
   useEffect(() => {
+    let isMounted = true;
+    if (showCopied) {
+      setTimeout(() => {
+        if (isMounted) setShowCopied(false);
+      }, 4000);
+    }
+    return () => (isMounted = false);
+  }, [showCopied]);
+
+  useEffect(() => {
     if (sportsGroup.current === null && market?.sportsBook?.groupId) {
       sportsGroup.current = getSportsGroupsFromSportsIDs(
         [market.sportsBook.groupId],
@@ -61,21 +71,26 @@ const BettingMarketView = () => {
       marketIds.current = sportsGroup.current.markets.map(market => market.id);
       if (marketIds.current.length > 0) {
         bulkLoadMarketTradingHistory(marketIds.current, (err, tradeHistory) => {
-          bulkMarketTradingHistory(tradeHistory)
+          bulkMarketTradingHistory(tradeHistory);
         });
       }
     }
-  }, [market.sportsBook])
+  }, [market.sportsBook]);
 
   useEffect(() => {
     let tradeCount = 0;
-    sportsGroupTradeHistory.current = marketIds.current.map(marketId => {
-      if (marketTradingHistory[marketId]) {
-        tradeCount = tradeCount + marketTradingHistory[marketId].length;
-        return marketTradingHistory[marketId];
-      };
-    }).filter(item => !!item);
-    if (sportsGroupTradeHistory.current.length > 0 && tradeCount !== totalBets.current) {
+    sportsGroupTradeHistory.current = marketIds.current
+      .map(marketId => {
+        if (marketTradingHistory[marketId]) {
+          tradeCount = tradeCount + marketTradingHistory[marketId].length;
+          return marketTradingHistory[marketId];
+        }
+      })
+      .filter(item => !!item);
+    if (
+      sportsGroupTradeHistory.current.length > 0 &&
+      tradeCount !== totalBets.current
+    ) {
       sportsGroupTradeHistory.current.forEach(MarketTradeHistoryArray => {
         MarketTradeHistoryArray.forEach(({ creator, filler }) => {
           if (!uniqueAddresses.current.includes(creator)) {
@@ -84,12 +99,12 @@ const BettingMarketView = () => {
           if (!uniqueAddresses.current.includes(filler)) {
             uniqueAddresses.current.push(filler);
           }
-        })
+        });
       });
       totalBets.current = tradeCount;
       totalBettors.current = uniqueAddresses.current.length;
     }
-  }, [marketTradingHistory[marketId]])
+  }, [marketTradingHistory[marketId]]);
 
   if (!market) {
     return <div />;
@@ -113,7 +128,12 @@ const BettingMarketView = () => {
   return (
     <div className={Styles.BettingMarketView}>
       <div>
-        <HeadingBar market={market} showReportingLabel />
+        <HeadingBar
+          market={market}
+          showReportingLabel
+          showCopied={showCopied}
+          setShowCopied={() => setShowCopied(true)}
+        />
         <span>{header}</span>
         <div>
           <PropertyLabel
@@ -149,7 +169,9 @@ const BettingMarketView = () => {
           )}
         </div>
       </div>
-      {sportsGroup.current && <SportsGroupMarkets sportsGroup={sportsGroup.current} />}
+      {sportsGroup.current && (
+        <SportsGroupMarkets sportsGroup={sportsGroup.current} />
+      )}
       <div>
         <Subheaders
           header="creation date"

--- a/packages/augur-ui/src/modules/market/components/market-view/betting-market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/betting-market-view.tsx
@@ -24,6 +24,7 @@ import parsePath from 'modules/routes/helpers/parse-path';
 import { convertInputs, findStartTime } from '../common/market-title';
 import { convertUnixToFormattedDate } from 'utils/format-date';
 import { bulkLoadMarketTradingHistory } from 'modules/markets/actions/market-trading-history-management';
+import { useEffect } from 'react';
 
 export const isMarketView = location =>
   parsePath(location.pathname)[0] === MARKET;
@@ -40,46 +41,62 @@ const BettingMarketView = () => {
   const sportsGroup = useRef(null);
   const marketIds = useRef([]);
   const sportsGroupTradeHistory = useRef([]);
-  const [loadHistory, setLoadHistory] = useState(false);
   const queryId = parseQuery(location.search)[MARKET_ID_PARAM_NAME];
   const marketId = getAddress(queryId);
   const market = selectMarket(marketId);
   const markets = getMarkets();
-  if (!market.sportsBook) {
-    updateMarketsData(null, loadMarketsInfo([marketId]));
-  } else if (sportsGroup.current === null) {
-    sportsGroup.current = getSportsGroupsFromSportsIDs(
-      [market.sportsBook.groupId],
-      markets
-    )[0];
-    marketIds.current = sportsGroup.current.markets.map(market => market.id);
-    if (!loadHistory && marketIds.current.length > 0) {
-      bulkLoadMarketTradingHistory(marketIds.current, (err, tradeHistory) => {
-        bulkMarketTradingHistory(tradeHistory)
-      });
-      setLoadHistory(true);
+
+  useEffect(() => {
+    console.log('use effect 1 -- make sure we have sportsBook');
+    if (!market.sportsBook) {
+      console.log('use effect 1 -- going to load sportsBook');
+      updateMarketsData(null, loadMarketsInfo([marketId]));
     }
-  }
-  sportsGroupTradeHistory.current = marketIds.current.map(marketId => {
-    if (marketTradingHistory[marketId]) return marketTradingHistory[marketId];
-  });
-  sportsGroupTradeHistory.current = sportsGroupTradeHistory.current.filter(item => !!item);
-  if (sportsGroupTradeHistory.current.length > 0) {
-    let tradeCount = 0;
-    sportsGroupTradeHistory.current.forEach(MarketTradeHistoryArray => {
-      tradeCount = tradeCount + MarketTradeHistoryArray.length;
-      MarketTradeHistoryArray.forEach(({ creator, filler }) => {
-        if (!uniqueAddresses.current.includes(creator)) {
-          uniqueAddresses.current.push(creator);
-        }
-        if (!uniqueAddresses.current.includes(filler)) {
-          uniqueAddresses.current.push(filler);
-        }
-      })
-    });
-    totalBets.current = tradeCount;
-    totalBettors.current = uniqueAddresses.current.length;
-  }
+  }, []);
+
+  useEffect(() => {
+    console.log('use effect 2 -- initial bulk trade history load');
+    if (sportsGroup.current === null && market?.sportsBook?.groupId) {
+      console.log("use effect 2 -- code triggered");
+      sportsGroup.current = getSportsGroupsFromSportsIDs(
+        [market.sportsBook.groupId],
+        markets
+      )[0];
+      marketIds.current = sportsGroup.current.markets.map(market => market.id);
+      if (marketIds.current.length > 0) {
+        console.log('use effect 2 -- Actually bulk load history');
+        bulkLoadMarketTradingHistory(marketIds.current, (err, tradeHistory) => {
+          bulkMarketTradingHistory(tradeHistory)
+        });
+      }
+    }
+  }, [market.sportsBook])
+
+  useEffect(() => {
+    console.log("use effect 3 -- update trade history on history update -- updates totalBets, bettors, sportsGroupHistory, UniqueAddresses");
+    sportsGroupTradeHistory.current = marketIds.current.map(marketId => {
+      if (marketTradingHistory[marketId]) return marketTradingHistory[marketId];
+    }).filter(item => !!item);
+    console.log("use effect 3 -- part 1", sportsGroupTradeHistory.current);
+    // sportsGroupTradeHistory.current = sportsGroupTradeHistory.current;
+    if (sportsGroupTradeHistory.current.length > 0) {
+      console.log("use effect 3 -- sportsGroupTradeHistory length > 0")
+      let tradeCount = 0;
+      sportsGroupTradeHistory.current.forEach(MarketTradeHistoryArray => {
+        tradeCount = tradeCount + MarketTradeHistoryArray.length;
+        MarketTradeHistoryArray.forEach(({ creator, filler }) => {
+          if (!uniqueAddresses.current.includes(creator)) {
+            uniqueAddresses.current.push(creator);
+          }
+          if (!uniqueAddresses.current.includes(filler)) {
+            uniqueAddresses.current.push(filler);
+          }
+        })
+      });
+      totalBets.current = tradeCount;
+      totalBettors.current = uniqueAddresses.current.length;
+    }
+  }, [marketTradingHistory[marketId]])
 
   if (!market) {
     return <div />;

--- a/packages/augur-ui/src/modules/market/components/market-view/betting-market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/betting-market-view.tsx
@@ -24,7 +24,6 @@ import parsePath from 'modules/routes/helpers/parse-path';
 import { convertInputs, findStartTime } from '../common/market-title';
 import { convertUnixToFormattedDate } from 'utils/format-date';
 import { bulkLoadMarketTradingHistory } from 'modules/markets/actions/market-trading-history-management';
-import { useEffect } from 'react';
 
 export const isMarketView = location =>
   parsePath(location.pathname)[0] === MARKET;
@@ -46,8 +45,9 @@ const BettingMarketView = () => {
   const marketId = getAddress(queryId);
   const market = selectMarket(marketId);
   const markets = getMarkets();
-
-  if (market.sportsBook && sportsGroup.current === null) {
+  if (!market.sportsBook) {
+    updateMarketsData(null, loadMarketsInfo([marketId]));
+  } else if (sportsGroup.current === null) {
     sportsGroup.current = getSportsGroupsFromSportsIDs(
       [market.sportsBook.groupId],
       markets
@@ -59,8 +59,6 @@ const BettingMarketView = () => {
       });
       setLoadHistory(true);
     }
-  } else {
-    updateMarketsData(null, loadMarketsInfo([marketId]));
   }
   sportsGroupTradeHistory.current = marketIds.current.map(marketId => {
     if (marketTradingHistory[marketId]) return marketTradingHistory[marketId];

--- a/packages/augur-ui/src/modules/market/components/market-view/betting-market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/betting-market-view.tsx
@@ -47,24 +47,19 @@ const BettingMarketView = () => {
   const markets = getMarkets();
 
   useEffect(() => {
-    console.log('use effect 1 -- make sure we have sportsBook');
-    if (!market.sportsBook) {
-      console.log('use effect 1 -- going to load sportsBook');
+    if (!market?.sportsBook) {
       updateMarketsData(null, loadMarketsInfo([marketId]));
     }
   }, []);
 
   useEffect(() => {
-    console.log('use effect 2 -- initial bulk trade history load');
     if (sportsGroup.current === null && market?.sportsBook?.groupId) {
-      console.log("use effect 2 -- code triggered");
       sportsGroup.current = getSportsGroupsFromSportsIDs(
         [market.sportsBook.groupId],
         markets
       )[0];
       marketIds.current = sportsGroup.current.markets.map(market => market.id);
       if (marketIds.current.length > 0) {
-        console.log('use effect 2 -- Actually bulk load history');
         bulkLoadMarketTradingHistory(marketIds.current, (err, tradeHistory) => {
           bulkMarketTradingHistory(tradeHistory)
         });
@@ -73,17 +68,15 @@ const BettingMarketView = () => {
   }, [market.sportsBook])
 
   useEffect(() => {
-    console.log("use effect 3 -- update trade history on history update -- updates totalBets, bettors, sportsGroupHistory, UniqueAddresses");
+    let tradeCount = 0;
     sportsGroupTradeHistory.current = marketIds.current.map(marketId => {
-      if (marketTradingHistory[marketId]) return marketTradingHistory[marketId];
+      if (marketTradingHistory[marketId]) {
+        tradeCount = tradeCount + marketTradingHistory[marketId].length;
+        return marketTradingHistory[marketId];
+      };
     }).filter(item => !!item);
-    console.log("use effect 3 -- part 1", sportsGroupTradeHistory.current);
-    // sportsGroupTradeHistory.current = sportsGroupTradeHistory.current;
-    if (sportsGroupTradeHistory.current.length > 0) {
-      console.log("use effect 3 -- sportsGroupTradeHistory length > 0")
-      let tradeCount = 0;
+    if (sportsGroupTradeHistory.current.length > 0 && tradeCount !== totalBets.current) {
       sportsGroupTradeHistory.current.forEach(MarketTradeHistoryArray => {
-        tradeCount = tradeCount + MarketTradeHistoryArray.length;
         MarketTradeHistoryArray.forEach(({ creator, filler }) => {
           if (!uniqueAddresses.current.includes(creator)) {
             uniqueAddresses.current.push(creator);


### PR DESCRIPTION
Persists odds and timeFormat settings for each account, updated loading efficiency for sports group page, updated header bar to copy market id correctly on both market page and sports group page. updated bestOffer API to correctly return null for outcomes that have been updated to be empty. Fixed warnings in form.tsx for updating state on an unmounted component. updated the `matched` value on the top of the sports group page to show a real value instead of always $0.