### PR TITLE
disable account activation

### DIFF
--- a/packages/augur-ui/src/modules/common/buttons.tsx
+++ b/packages/augur-ui/src/modules/common/buttons.tsx
@@ -208,7 +208,7 @@ const ProcessingButtonComponent = (props: DefaultButtonProps) => {
           icon={icon}
           text={buttonText}
           action={buttonAction}
-          disabled={isDisabled}
+          disabled={isDisabled || props.disabled}
         />
       )}
       {!props.secondaryButton && !props.cancelButton && !props.submitTextButtton && (
@@ -219,7 +219,7 @@ const ProcessingButtonComponent = (props: DefaultButtonProps) => {
           icon={icon}
           text={buttonText}
           action={buttonAction}
-          disabled={isDisabled}
+          disabled={isDisabled || props.disabled}
         />
       )}
       {props.submitTextButtton && (
@@ -229,7 +229,7 @@ const ProcessingButtonComponent = (props: DefaultButtonProps) => {
           failed={failed}
           text={buttonText}
           action={buttonAction}
-          disabled={isDisabled}
+          disabled={isDisabled || props.disabled}
         />
       )}
       {props.cancelButton && (
@@ -240,7 +240,7 @@ const ProcessingButtonComponent = (props: DefaultButtonProps) => {
           icon={icon}
           text={buttonText}
           action={buttonAction}
-          disabled={isDisabled}
+          disabled={isDisabled || props.disabled}
         />
       )}
     </>

--- a/packages/augur-ui/src/modules/modal/common.tsx
+++ b/packages/augur-ui/src/modules/modal/common.tsx
@@ -411,9 +411,10 @@ interface TransferMyDaiProps {
   showTransferModal: Function;
   isCondensed: boolean;
   tokenName: string;
+  autoClose?: boolean;
 }
 
-export const TransferMyTokens = ({ walletType, tokenAmount, showTransferModal, tokenName, isCondensed = false}: TransferMyDaiProps) => {
+export const TransferMyTokens = ({ walletType, tokenAmount, showTransferModal, tokenName, isCondensed = false, autoClose = false }: TransferMyDaiProps) => {
   if (isCondensed) {
     return (
       <div className={Styles.TransferMyDaiCondensed}>
@@ -436,7 +437,7 @@ export const TransferMyTokens = ({ walletType, tokenAmount, showTransferModal, t
         <span>Transfer any amount to your trading account.</span>
       </div>
       <PrimaryButton
-        action={() => showTransferModal()}
+        action={() => showTransferModal(autoClose)}
         text={`Transfer my ${titleCase(tokenName)}`}
       />
     </div>

--- a/packages/augur-ui/src/modules/modal/containers/modal-p2p-trading.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-p2p-trading.ts
@@ -79,6 +79,7 @@ const mergeProps = (sP: any, dP: any, oP: any) => ({
       sP.pendingQueue[TRANSACTIONS] &&
       sP.pendingQueue[TRANSACTIONS][CREATEAUGURWALLET] &&
       sP.pendingQueue[TRANSACTIONS][CREATEAUGURWALLET].status === 'Success'),
+  disableActivatebutton: sP.walletStatus === WALLET_STATUS_VALUES.CREATED,
   analyticsEvent: () => dP.track(AUGUR_IS_P2P, {}),
   createFundedGsnWallet: () => dP.createFundedGsnWallet(),
   changeCurrentStep: step => {

--- a/packages/augur-ui/src/modules/modal/containers/modal-transfer.ts
+++ b/packages/augur-ui/src/modules/modal/containers/modal-transfer.ts
@@ -16,7 +16,6 @@ import { totalTradingBalance } from 'modules/auth/selectors/login-account';
 import { getTransactionLabel } from 'modules/auth/selectors/get-gas-price';
 import { WALLET_STATUS } from 'modules/app/actions/update-app-status';
 import { WALLET_STATUS_VALUES } from 'modules/common/constants';
-import { getEthReserve } from 'modules/auth/selectors/get-eth-reserve';
 
 const mapStateToProps = (state: AppState) => {
   const { loginAccount, appStatus, modal } = state;
@@ -39,7 +38,8 @@ const mapStateToProps = (state: AppState) => {
     rep: TRANSFER_REP_GAS_COST,
     dai: TRANSFER_DAI_GAS_COST,
   },
-  transactionLabel: getTransactionLabel(state)
+  transactionLabel: getTransactionLabel(state),
+  autoClose: modal?.autoClose,
 }
 };
 
@@ -53,6 +53,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({
 });
 
 const mergeProps = (sP: any, dP: any, oP: any) => ({
+  autoClose: sP.autoClose,
   signingEthBalance: sP.signingEthBalance,
   fallBackGasCosts: sP.fallBackGasCosts,
   GsnEnabled: sP.GsnEnabled,

--- a/packages/augur-ui/src/modules/modal/containers/transfer-my-tokens.ts
+++ b/packages/augur-ui/src/modules/modal/containers/transfer-my-tokens.ts
@@ -4,7 +4,7 @@ import { AppState } from 'appStore';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
 import { TransferMyTokens } from 'modules/modal/common';
-import { formatDaiPrice, formatDai } from 'utils/format-number';
+import { formatDai } from 'utils/format-number';
 import { updateModal } from '../actions/update-modal';
 import {
   MODAL_BUY_DAI,
@@ -17,6 +17,7 @@ interface OwnProps {
   tokenName: string,
   condensed: boolean,
   callBack: Function,
+  autoClose?: boolean,
 }
 
 const mapStateToProps = (state: AppState, ownProps: OwnProps) => ({
@@ -32,9 +33,9 @@ const mapStateToProps = (state: AppState, ownProps: OwnProps) => ({
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<void, any, Action>) => ({
   showBuyDaiModal: () => dispatch(updateModal({ type: MODAL_BUY_DAI })),
-  transferfunds: (callback, tokenName) =>
+  transferfunds: (callback, tokenName, autoClose) =>
     dispatch(
-      updateModal({ type: MODAL_TRANSFER, useSigner: true, cb: callback, tokenName })
+      updateModal({ type: MODAL_TRANSFER, useSigner: true, cb: callback, tokenName, autoClose })
     ),
 });
 
@@ -43,12 +44,13 @@ const mergeProps = (sP: any, dP: any, oP: OwnProps) => ({
   isCondensed: oP.condensed || false,
   tokenName: oP.tokenName ? oP.tokenName : DAI,
   tokenAmount: formatDai(sP.tokenAmount),
-  showTransferModal: () => {
+  autoClose: oP.autoClose,
+  showTransferModal: (autoClose) => {
     dP.transferfunds(() => {
       if (oP.callBack) {
         setTimeout(() => oP.callBack());
       }
-    }, oP.tokenName);
+    }, oP.tokenName, autoClose);
   },
 });
 

--- a/packages/augur-ui/src/modules/modal/onboarding.tsx
+++ b/packages/augur-ui/src/modules/modal/onboarding.tsx
@@ -39,6 +39,7 @@ interface OnboardingProps {
   createFundedGsnWallet?: Function;
   showAugurP2PModal?: Function;
   gasPrice: number;
+  disableActivatebutton: boolean;
 }
 
 export const Onboarding = ({
@@ -57,6 +58,7 @@ export const Onboarding = ({
   showAugurP2PModal,
   showActivationButton,
   createFundedGsnWallet,
+  disableActivatebutton,
   gasPrice,
 }: OnboardingProps) => {
   const [activationEstimate, setActivationEstimate] = useState('-');
@@ -81,6 +83,7 @@ export const Onboarding = ({
             action={() => createFundedGsnWallet()}
             queueName={TRANSACTIONS}
             queueId={CREATEAUGURWALLET}
+            disabled={disableActivatebutton}
             customConfirmedButtonText={'Account Activated!'}
           />
         }
@@ -113,7 +116,7 @@ export const Onboarding = ({
           {smallHeader && <SmallSubheader text={smallHeader} />}
           {mediumHeader && <MediumSubheader text={mediumHeader} />}
           {linkContent && <LinkContentSection linkContent={modLinkContent} />}
-          {showTransferMyDai && <TransferMyTokens tokenName={DAI} callBack={() => showAugurP2PModal()}/>}
+          {showTransferMyDai && <TransferMyTokens tokenName={DAI} autoClose={true} callBack={() => showAugurP2PModal()}/>}
         </main>
 
         <div className={Styles.OnboardingNav}>{NavControls}</div>

--- a/packages/augur-ui/src/modules/modal/transfer-form.tsx
+++ b/packages/augur-ui/src/modules/modal/transfer-form.tsx
@@ -47,6 +47,7 @@ interface TransferFormProps {
   transactionLabel: string;
   signingEthBalance: string;
   tokenName: string;
+  autoClose: boolean;
 }
 
 function sanitizeArg(arg) {
@@ -68,6 +69,7 @@ export const TransferForm = ({
   transactionLabel,
   signingEthBalance,
   tokenName,
+  autoClose,
 }: TransferFormProps) => {
   const [currency, setCurrency] = useState(DAI);
   const [signerPays, setSignerPays] = useState(true);
@@ -340,8 +342,9 @@ export const TransferForm = ({
                   useTopOff = false;
                 }
               }
-              transferFunds(formattedAmount.fullPrecision, currency, address, useSigner, useTopOff)}
-            }
+              transferFunds(formattedAmount.fullPrecision, currency, address, useSigner, useTopOff)
+              if (autoClose) closeAction();
+            }}
             queueName={TRANSACTIONS}
             queueId={currency === ETH ? SENDETHER : TRANSFER}
             disabled={!isValid}


### PR DESCRIPTION
disable account activation button so user doesn't accidentally click it again. 
dismiss transfer modal so user doesn't get confused when they transfer from onboarding 