### PR TITLE
Fixes local IPFS hosting.

### DIFF
--- a/packages/augur-ui/src/index.ejs
+++ b/packages/augur-ui/src/index.ejs
@@ -109,7 +109,7 @@
   <script type="text/javascript">
     if (
       window.location.protocol === "http:" &&
-      window.location.hostname !== "localhost" && 
+      !window.location.hostname.endsWith("localhost") && 
       window.location.hostname !== "127.0.0.1"
     ){
         window.location.href = window.location.href.replace('http', 'https');


### PR DESCRIPTION
Modern versions of IPFS use localhost subdomains for serving content in order to guarantee that each application operates within its own browser context.  If you are running with the IPFS browser companion, or try to access the site via IPFS desktop, or get given a localhost IPFS link you will end up at an address like `http://<CIDv1>.ipfs.localhost:8080`.  Prior to this patch, this code would force redirect such an address to `https://<CIDv1>.ipfs.localhost:8080` which will never work (because 8080 is a 'standard' HTTP port and because IPFS is not served over HTTPS and because getting valid localhost certificates is effectively impossible).

This PR fixes the redirect so it doesn't occur for *any* localhost subdomains (or localhost root domain itself).