### PR TITLE
oversight in using the wrong variable to format ether with

### DIFF
--- a/packages/augur-ui/src/modules/common/labels.tsx
+++ b/packages/augur-ui/src/modules/common/labels.tsx
@@ -1534,7 +1534,7 @@ export const ApprovalTxButtonLabel = ({
       const notEnoughEth = createBigNumber(userEthBalance).lt(createBigNumber(ethNeededForGas));
       setInsufficientEth(notEnoughEth);
       if (notEnoughEth) {
-        const ethDo = formatEther(notEnoughEth);
+        const ethDo = formatEther(ethNeededForGas);
         setDescription(`Insufficient ETH to approve trading. ${ethDo.formatted} ETH cost.`);
       } else {
         switch(approvalType) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3970376/89134641-2963d400-d4ec-11ea-8e55-50e9c9f04b6c.png)
