### PR TITLE
don't need to process alert when pulled from local storage

### DIFF
--- a/packages/augur-ui/src/modules/auth/actions/load-account-data-from-local-storage.ts
+++ b/packages/augur-ui/src/modules/auth/actions/load-account-data-from-local-storage.ts
@@ -1,6 +1,6 @@
 import { loadFavoritesMarkets } from 'modules/markets/actions/update-favorites';
 import { loadDrafts } from 'modules/create-market/actions/update-drafts';
-import { updateAlert } from 'modules/alerts/actions/alerts';
+import { ADD_ALERT } from 'modules/alerts/actions/alerts';
 import { loadPendingLiquidityOrders } from 'modules/orders/actions/liquidity-management';
 import { updateReadNotifications } from 'modules/notifications/actions/update-notifications';
 import { loadPendingOrdersTransactions } from 'modules/orders/actions/pending-orders-management';
@@ -13,7 +13,6 @@ import { ThunkDispatch, ThunkAction } from 'redux-thunk';
 import { Action } from 'redux';
 import { AppState } from 'appStore';
 import { getNetworkId } from 'modules/contracts/actions/contractCalls';
-import { loadMarketsInfoIfNotLoaded } from 'modules/markets/actions/load-markets-info';
 import { loadAnalytics } from 'modules/app/actions/analytics-management';
 import {
   saveAffiliateAddress,
@@ -81,22 +80,7 @@ export const loadAccountDataFromLocalStorage = (
         dispatch(loadDrafts(drafts));
       }
       if (alerts) {
-        // get all market ids and load markets then process alerts
-        const marketIds = Array.from(
-          new Set(
-            alerts.reduce((p, alert) => {
-              const marketId =
-                alert.marketId ||
-                ((alert.params && alert.params.market) || alert.params._market);
-              return marketId ? [...p, marketId] : p;
-            }, [])
-          )
-        ) as string[];
-        dispatch(
-          loadMarketsInfoIfNotLoaded(marketIds, () => {
-            alerts.map(n => dispatch(updateAlert(n.id, n, true)));
-          })
-        );
+        alerts.map(alert => dispatch({ type: ADD_ALERT, data: { alert }}));
       }
       if (affiliate) dispatch(saveAffiliateAddress(affiliate));
       if (pendingLiquidityOrders) {


### PR DESCRIPTION
@Mergifyio backport dev

original alert
![Screen Shot 2020-08-03 at 22 52 35](https://user-images.githubusercontent.com/3970376/89251359-6e673380-d5dc-11ea-955e-2f5845cb5b30.png)

alert pulled in after refreshing the UI
![Screen Shot 2020-08-03 at 22 53 08](https://user-images.githubusercontent.com/3970376/89251395-876fe480-d5dc-11ea-87fb-b90bdef687f8.png)


