### PR TITLE
remove label in open orders for shares just have number

### DIFF
--- a/packages/augur-ui/src/utils/format-number.ts
+++ b/packages/augur-ui/src/utils/format-number.ts
@@ -149,7 +149,7 @@ export function formatMarketShares(
   const formattedShares = formatNumber(num, {
     decimals: decimals,
     decimalsRounded: decimals,
-    denomination: v => `${v} Shares`,
+    denomination: v => `${v}`,
     minimized: false,
     zeroStyled: false,
     blankZero: false,


### PR DESCRIPTION
remove `Shares` from share cost in open orders section
![image](https://user-images.githubusercontent.com/3970376/89337019-e7f43580-d65f-11ea-9a87-6c1cf0105f9a.png)
