### PR TITLE
only show 2 decimals for PL which uses formatDai

### DIFF
--- a/packages/augur-ui/src/utils/format-number.ts
+++ b/packages/augur-ui/src/utils/format-number.ts
@@ -231,7 +231,7 @@ export function formatDai(
       const val = isNegative
         ? createBigNumber(v)
             .abs()
-            .toFixed(3)
+            .decimalPlaces(2)
         : v;
       return `${isNegative ? '-' : ''}$${val}`;
     },


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/8942
for some reason this was a prio/2 bug

for full there is a `toFixed(3)` which isn't correct should just use decimal places (2).

before:
![image](https://user-images.githubusercontent.com/3970376/90077039-bb2ac880-dcc6-11ea-87a0-6d5577243510.png)

seem to only effect negative values.
after:
![image](https://user-images.githubusercontent.com/3970376/90077051-c41b9a00-dcc6-11ea-9afe-7cc1932afe92.png)

