### PR TITLE
dont run sim trade if user isn't logged in

### DIFF
--- a/packages/augur-sdk/src/api/ZeroX.ts
+++ b/packages/augur-sdk/src/api/ZeroX.ts
@@ -600,7 +600,7 @@ export class ZeroX {
         : false;
     if (orders.length < 1 && !params.doNotCreateOrders) {
       simulationData = await this.simulateMakeOrder(onChainTradeParams);
-    } else if (orders.length < 1) {
+    } else if (orders.length < 1 || !params.takerAddress) {
       return {
         sharesFilled: new BigNumber(0),
         tokensDepleted: new BigNumber(0),


### PR DESCRIPTION
don't run simulate trade if user isn't logged in return result as if no orders were matched to make sure the order form is populated. 