### PR TITLE
Update migrate fix create

### DIFF
--- a/packages/augur-ui/src/modules/app/components/side-nav/side-nav.tsx
+++ b/packages/augur-ui/src/modules/app/components/side-nav/side-nav.tsx
@@ -60,7 +60,7 @@ const SideNav = ({
     pendingQueue[TRANSACTIONS] &&
     pendingQueue[TRANSACTIONS][MIGRATE_FROM_LEG_REP_TOKEN];
   const showMigrateRepButton =
-    !!balances.legacyRep || !!balances.legacyRepNonSafe || !!pending;
+    balances?.legacyRep !== "0" || balances?.legacyAttoRep !== "0" || !!pending;
   const whichChatPlugin = env.plugins?.chat;
   const accessFilteredMenu = menuData.filter(
     item => !(item.requireLogin && !isLogged)

--- a/packages/augur-ui/src/modules/app/components/top-bar.tsx
+++ b/packages/augur-ui/src/modules/app/components/top-bar.tsx
@@ -113,7 +113,7 @@ const TopBar = () => {
     pendingQueue[TRANSACTIONS] &&
     pendingQueue[TRANSACTIONS][MIGRATE_FROM_LEG_REP_TOKEN];
   const showMigrateRepButton =
-    !!balances.legacyRep || !!balances.legacyRepNonSafe || !!pending;
+    balances?.legacyRep !== "0" || balances?.legacyAttoRep !== "0" || !!pending;
   return (
     <header className={Styles.TopBar}>
       <div className={Styles.Logo}>

--- a/packages/augur-ui/src/modules/common/form.tsx
+++ b/packages/augur-ui/src/modules/common/form.tsx
@@ -2387,6 +2387,7 @@ export const CategoryRow = ({
       {showChildrenOption && children &&
         Object.keys(children).map(childName => (
           <CategoryRow
+            key={childName}
             category={childName}
             count={children[childName].count}
             handleClick={() =>

--- a/packages/augur-ui/src/modules/common/selection.styles.less
+++ b/packages/augur-ui/src/modules/common/selection.styles.less
@@ -602,8 +602,17 @@
 
 :root[theme="BETTING"],
 :root[theme="SPORTS"] {
-  .PillSelection > li > button {
-    padding: @size-6 @size-8;
+  .PillSelection {
+      > li > button {
+      padding: @size-6 @size-8;
+    }
+
+    &.LargePillSelection {
+      > li > button {
+        padding: @size-12 @size-24;
+        height: @size-40;
+      }  
+    }
   }
 }
 

--- a/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
+++ b/packages/augur-ui/src/modules/market/components/market-view/market-view.tsx
@@ -126,9 +126,8 @@ const MarketView = ({
   const location = useLocation();
   const history = useHistory();
   const node = useRef(null);
-
   const queryId = parseQuery(location.search)[MARKET_ID_PARAM_NAME];
-  const marketId = queryId === TRADING_TUTORIAL ? queryId : getAddress(queryId);
+  const marketId = (queryId === TRADING_TUTORIAL || isPreview) ? queryId : getAddress(queryId);
   const queryOutcomeId = parseQuery(location.search)[
     OUTCOME_ID_PARAM_NAME
   ];

--- a/packages/augur-ui/src/modules/markets-list/components/markets-view.tsx
+++ b/packages/augur-ui/src/modules/markets-list/components/markets-view.tsx
@@ -253,6 +253,27 @@ const MarketsView = () => {
             sportGroup => sportGroup.id
           );
           const sportsGroupCount = sportsGroups.length;
+          const numDaily = sportsGroups.filter(
+            m => m.type === SPORTS_MARKET_TYPES[0].header
+          ).length;
+          const numFutures = sportsGroups.filter(
+            m => m.type === SPORTS_MARKET_TYPES[1].header
+          ).length;
+          const selectedNum =
+            SPORTS_MARKET_TYPES[0].header === sportsGroupTypeFilter
+              ? numDaily
+              : numFutures;
+          let newSportsGroupTypeFilter = sportsGroupTypeFilter;
+          if (
+            selectedNum === 0 &&
+            sportsFilterSortedMarkets.length > 0 &&
+            selectedCategories.length > 1
+          ) {
+            newSportsGroupTypeFilter =
+              sportsGroupTypeFilter === SPORTS_MARKET_TYPES[0].header
+                ? SPORTS_MARKET_TYPES[1].header
+                : sportsGroupTypeFilter;
+          }
           const sportsShowPagination = sportsGroupCount > limit;
           const marketInfos = result.markets
             .filter(marketHasData => marketHasData)
@@ -275,8 +296,12 @@ const MarketsView = () => {
               : showPagination,
           });
           // TODO: put liquidity getter here if we are in sportsbook.
-          let data = { isSearching: false, meta: result.meta };
-          if(!selectedCategories || selectedCategories.length === 0) {
+          let data = {
+            isSearching: false,
+            meta: result.meta,
+            sportsGroupTypeFilter: newSportsGroupTypeFilter,
+          };
+          if (!selectedCategories || selectedCategories.length === 0) {
             data.allCategoriesMeta = result.meta;
           }
           updateMarketsList(data);
@@ -342,7 +367,9 @@ const MarketsView = () => {
         <section>
           <PillSelection
             options={SPORTS_MARKET_TYPES}
-            defaultSelection={0}
+            defaultSelection={
+              SPORTS_MARKET_TYPES[0].header === sportsGroupTypeFilter ? 0 : 1
+            }
             onChange={v => {
               if (SPORTS_MARKET_TYPES[v].header !== sportsGroupTypeFilter) {
                 updateMarketsList({


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/9035
https://github.com/AugurProject/augur/issues/8871

A few fixes in this one: 
**Migrate Button**
Corrected the behavior for migrate v1 rep to v2. we were doing the check incorrectly to determine if it should show the button at all. This was effecting both trading and sports.

**Missing Market**
Turns out it's not actually missing, the example just didn't tab over to futures. Put in new behavior to determine if the currently selected daily/futures filter will result in 0 markets and if the other one does have markets it will automatically switch the user over when they click at least 2 categories deep (in this case sports > golf). Also updated the Pill Selection to be more inline with the docs on sportsbook. Also corrected a missing key prop for a category row to squelch those errors in console.

**Preview Market bug**
No ticket for this, but is outlined in the testing of dev trading ui that we have in a google doc somewhere. There was an issue when creating a market and hitting the preview market button on the review step. It was simply not working and throwing errors in console. This has been corrected and we should now be able to preview a market again on dev.
