### PR TITLE
Added spinner for rep conversion button

### DIFF
--- a/packages/augur-ui/src/assets/styles/_colors.less
+++ b/packages/augur-ui/src/assets/styles/_colors.less
@@ -88,6 +88,7 @@
   --color-primary-action: #09CFE1;
   --color-primary-action-5-dark:#08b9c9;
   --color-primary-action-15-dark: #068c98;
+  --color-primary-action-0: fade(#09CFE1, 0%);
   --color-primary-action-5: fade(#09CFE1, 5%);
   --color-primary-action-10: fade(#09CFE1, 10%);
   --color-primary-action-15: fade(#09CFE1, 15%);
@@ -221,6 +222,7 @@
   --color-primary-action: #0CCE8D;
   --color-primary-action-5-dark: #0BB77E;
   --color-primary-action-15-dark: #08875D;
+  --color-primary-action-0: fade(#0CCE8D, 0%);
   --color-primary-action-5: fade(#0CCE8D, 5%);
   --color-primary-action-10: fade(#0CCE8D, 10%);
   --color-primary-action-15: fade(#0CCE8D, 15%);

--- a/packages/augur-ui/src/assets/styles/_colors.less
+++ b/packages/augur-ui/src/assets/styles/_colors.less
@@ -88,7 +88,6 @@
   --color-primary-action: #09CFE1;
   --color-primary-action-5-dark:#08b9c9;
   --color-primary-action-15-dark: #068c98;
-  --color-primary-action-0: fade(#09CFE1, 0%);
   --color-primary-action-5: fade(#09CFE1, 5%);
   --color-primary-action-10: fade(#09CFE1, 10%);
   --color-primary-action-15: fade(#09CFE1, 15%);
@@ -222,7 +221,6 @@
   --color-primary-action: #0CCE8D;
   --color-primary-action-5-dark: #0BB77E;
   --color-primary-action-15-dark: #08875D;
-  --color-primary-action-0: fade(#0CCE8D, 0%);
   --color-primary-action-5: fade(#0CCE8D, 5%);
   --color-primary-action-10: fade(#0CCE8D, 10%);
   --color-primary-action-15: fade(#0CCE8D, 15%);

--- a/packages/augur-ui/src/modules/app/components/side-nav/side-nav.tsx
+++ b/packages/augur-ui/src/modules/app/components/side-nav/side-nav.tsx
@@ -33,6 +33,7 @@ import { NewLogo } from 'modules/app/components/logo';
 import { OddsMenu } from 'modules/app/components/odds-menu';
 import { logout } from 'modules/auth/actions/logout';
 import CategoryFilters from '../inner-nav/category-filters';
+import ButtonStyles from 'modules/common/buttons.styles.less';
 
 interface SideNavProps {
   isLogged: boolean;
@@ -150,6 +151,8 @@ const SideNav = ({
                     queueName={TRANSACTIONS}
                     queueId={MIGRATE_FROM_LEG_REP_TOKEN}
                     primaryButton
+                    spinner
+                    className={ButtonStyles.ProcessingSpinnerButton}
                   />
                   <label
                     className={classNames(Styles.SideNavMigrateTooltipHint)}

--- a/packages/augur-ui/src/modules/app/components/top-bar.tsx
+++ b/packages/augur-ui/src/modules/app/components/top-bar.tsx
@@ -8,6 +8,7 @@ import {
   LinearPropertyLabelUnderlineTooltip,
 } from 'modules/common/labels';
 import Styles from 'modules/app/components/top-bar.styles.less';
+import ButtonStyles from 'modules/common/buttons.styles.less';
 import { Link } from 'react-router-dom';
 import makePath from 'modules/routes/helpers/make-path';
 import { NewLogo } from 'modules/app/components/logo';
@@ -131,6 +132,8 @@ const TopBar = () => {
             queueName={TRANSACTIONS}
             queueId={MIGRATE_FROM_LEG_REP_TOKEN}
             primaryButton
+            spinner
+            className={ButtonStyles.ProcessingSpinnerButton}
           />
         )}
         {(showActivationButton || showAddFundsButton) && (

--- a/packages/augur-ui/src/modules/app/components/top-nav/top-nav.tsx
+++ b/packages/augur-ui/src/modules/app/components/top-nav/top-nav.tsx
@@ -27,6 +27,7 @@ import Styles from 'modules/app/components/top-nav/top-nav.styles.less';
 import { LinearPropertyLabelUnderlineTooltip } from 'modules/common/labels';
 import { formatNumber } from 'utils/format-number';
 import { getEthReserveInDai } from 'modules/auth/helpers/get-eth-reserve';
+import ButtonStyles from 'modules/common/buttons.styles.less';
 
 interface TopNavProps {
   isLogged: boolean;
@@ -111,6 +112,8 @@ const TopNav = ({ isLogged, menuData }: TopNavProps) => {
                       queueName={TRANSACTIONS}
                       queueId={MIGRATE_FROM_LEG_REP_TOKEN}
                       primaryButton
+                      spinner
+                      className={ButtonStyles.ProcessingSpinnerButton}
                     />
                   </div>
                   <span>

--- a/packages/augur-ui/src/modules/common/buttons.styles.less
+++ b/packages/augur-ui/src/modules/common/buttons.styles.less
@@ -127,6 +127,13 @@
     text-decoration: underline;
   }
 }
+
+.ProcessingSpinnerButton {
+  &:disabled {
+    opacity: 1;
+  }
+}
+
 :root[theme='BETTING'],
 :root[theme='SPORTS'] {
   .Button {
@@ -410,6 +417,22 @@
 
   .FilterButton {
     text-transform: uppercase;
+  }
+
+  .ProcessingSpinnerButton {
+    > svg {
+      width: @size-8;
+      height: @size-8;
+      margin: 0 @size-10 0 0;
+
+      > path {
+        stroke: var(--color-module-background);
+      }
+    }
+
+    &:disabled {
+      opacity: 1;
+    }
   }
 }
 
@@ -797,7 +820,7 @@
       }
     }
   }
-  
+
   .PendingIconButton {
     &.NEWFILL {
       > svg {

--- a/packages/augur-ui/src/modules/common/buttons.tsx
+++ b/packages/augur-ui/src/modules/common/buttons.tsx
@@ -54,6 +54,7 @@ import { createBigNumber } from 'utils/create-big-number';
 import { formatDai } from 'utils/format-number';
 import { convertToOdds } from 'utils/get-odds';
 import { BET_STATUS } from 'modules/trading/store/constants';
+import { Spinner } from 'modules/common/spinner';
 
 export interface DefaultButtonProps {
   id?: string;
@@ -235,7 +236,7 @@ export const ProcessingButton = ({
   queueId = null,
   matchingId = null,
   nonMatchingIds = null,
-  ...props,
+  ...props
 }: ProcessingButtonProps) => {
   const { pendingQueue, theme } = useAppStatusStore();
   const isSports = theme === THEMES.SPORTS;
@@ -267,7 +268,7 @@ export const ProcessingButton = ({
     status === TXEventName.Pending ||
     status === TXEventName.AwaitingSigning
   ) {
-    buttonText = 'Processing...';
+    buttonText = props.spinner ? <Spinner /> : 'Processing...';
     isDisabled = true;
   }
   const failed = status === TXEventName.Failure;
@@ -286,7 +287,7 @@ export const ProcessingButton = ({
     icon = XIcon;
     isDisabled = false;
   }
-  
+
   if (confirmed && isSports) {
     return (
       <div className={Styles.ProcessingCheckmark}>
@@ -318,6 +319,7 @@ export const ProcessingButton = ({
             text={buttonText}
             action={buttonAction}
             disabled={isDisabled}
+            className={props.className}
           />
         )}
       {props.submitTextButtton && (
@@ -886,8 +888,8 @@ export const CashoutButton = ({
       cashoutDisabled = false;
       cashout = () => {
         setModal({
-          type: MODAL_CASHOUT_BET, 
-          wager: bet.wager, 
+          type: MODAL_CASHOUT_BET,
+          wager: bet.wager,
           odds: convertToOdds(bet.normalizedPrice).full,
           cashOut: bet.orderCost,
           positive: bet.potentialDaiProfit.gt(ZERO),

--- a/packages/augur-ui/src/modules/common/spinner.styles.less
+++ b/packages/augur-ui/src/modules/common/spinner.styles.less
@@ -23,7 +23,7 @@
   &:before {
     border-radius: 50%;
     background:
-      linear-gradient(  0deg, var(--color-primary-action-0) 50%, var(--color-primary-action-20) 100%)   0%   0%,
+      linear-gradient(  0deg, transparent 50%, var(--color-primary-action-20) 100%)   0%   0%,
       linear-gradient( 90deg, var(--color-primary-action-20)  0%, var(--color-primary-action-40) 100%) 100%   0%,
       linear-gradient(180deg, var(--color-primary-action-40)  0%, var(--color-primary-action-70) 100%) 100% 100%,
       linear-gradient(270deg, var(--color-primary-action-70) 0%, var(--color-primary-action) 100%)   0% 100%

--- a/packages/augur-ui/src/modules/common/spinner.styles.less
+++ b/packages/augur-ui/src/modules/common/spinner.styles.less
@@ -23,13 +23,14 @@
   &:before {
     border-radius: 50%;
     background:
-      linear-gradient(  0deg, rgba(#09CFE1,   0) 50%, rgba(#09CFE1, 0.3) 100%)   0%   0%,
-      linear-gradient( 90deg, rgba(#09CFE1, 0.3)  0%, rgba(#09CFE1, 0.5) 100%) 100%   0%,
-      linear-gradient(180deg, rgba(#09CFE1, 0.5)  0%, rgba(#09CFE1, 0.7) 100%) 100% 100%,
-      linear-gradient(270deg, rgba(#09CFE1, 0.7)  0%, rgba(#09CFE1,   1) 100%)   0% 100%
+      linear-gradient(  0deg, var(--color-primary-action-0) 50%, var(--color-primary-action-20) 100%)   0%   0%,
+      linear-gradient( 90deg, var(--color-primary-action-20)  0%, var(--color-primary-action-40) 100%) 100%   0%,
+      linear-gradient(180deg, var(--color-primary-action-40)  0%, var(--color-primary-action-70) 100%) 100% 100%,
+      linear-gradient(270deg, var(--color-primary-action-70) 0%, var(--color-primary-action) 100%)   0% 100%
     ;
     background-repeat: no-repeat;
     background-size: 50% 50%;
+    color: rgba(var(--color-primary-action), 0.5);
     top: -@size-1;
     bottom: -@size-1;
     left: -@size-1;
@@ -51,17 +52,6 @@
 :root[theme='BETTING'],
 :root[theme='SPORTS'] {
   .Spinner {
-    &:before {
-      background:
-        linear-gradient(  0deg, rgba(#0CCE8D,   0) 50%, rgba(#0CCE8D, 0.3) 100%)   0%   0%,
-        linear-gradient( 90deg, rgba(#0CCE8D, 0.3)  0%, rgba(#0CCE8D, 0.5) 100%) 100%   0%,
-        linear-gradient(180deg, rgba(#0CCE8D, 0.5)  0%, rgba(#0CCE8D, 0.7) 100%) 100% 100%,
-        linear-gradient(270deg, rgba(#0CCE8D, 0.7)  0%, rgba(#0CCE8D,   1) 100%)   0% 100%
-      ;
-      background-repeat: no-repeat;
-      background-size: 50% 50%;
-    }
-
     &:after {
       // had to use the opaque hex representation of the transparent color --color-primary-action-15, otherwise
       // it wouldn't work

--- a/packages/augur-ui/src/modules/common/spinner.styles.less
+++ b/packages/augur-ui/src/modules/common/spinner.styles.less
@@ -1,0 +1,71 @@
+@import (reference) '~assets/styles/shared';
+
+@keyframes rotate {
+  from { transform: rotate(0deg);   }
+  to   { transform: rotate(360deg); }
+}
+
+.Spinner {
+  animation: rotate 1s linear infinite;
+  background: transparent;
+  border-radius: 50%;
+  height: @size-24;
+  width: @size-24;
+  position: relative;
+  margin: 0 @size-56;
+
+  &:before,
+  &:after {
+    content: '';
+    position: absolute;
+  }
+
+  &:before {
+    border-radius: 50%;
+    background:
+      linear-gradient(  0deg, rgba(#09CFE1,   0) 50%, rgba(#09CFE1, 0.3) 100%)   0%   0%,
+      linear-gradient( 90deg, rgba(#09CFE1, 0.3)  0%, rgba(#09CFE1, 0.5) 100%) 100%   0%,
+      linear-gradient(180deg, rgba(#09CFE1, 0.5)  0%, rgba(#09CFE1, 0.7) 100%) 100% 100%,
+      linear-gradient(270deg, rgba(#09CFE1, 0.7)  0%, rgba(#09CFE1,   1) 100%)   0% 100%
+    ;
+    background-repeat: no-repeat;
+    background-size: 50% 50%;
+    top: -@size-1;
+    bottom: -@size-1;
+    left: -@size-1;
+    right: -@size-1;
+  }
+
+  &:after {
+    // had to use the opaque hex representation of the transparent color --color-primary-action-40, otherwise
+    // it wouldn't work
+    background-color: #11686c;
+    border-radius: 50%;
+    top: @size-1;
+    bottom: @size-1;
+    left: @size-1;
+    right: @size-1;
+  }
+}
+
+:root[theme='BETTING'],
+:root[theme='SPORTS'] {
+  .Spinner {
+    &:before {
+      background:
+        linear-gradient(  0deg, rgba(#0CCE8D,   0) 50%, rgba(#0CCE8D, 0.3) 100%)   0%   0%,
+        linear-gradient( 90deg, rgba(#0CCE8D, 0.3)  0%, rgba(#0CCE8D, 0.5) 100%) 100%   0%,
+        linear-gradient(180deg, rgba(#0CCE8D, 0.5)  0%, rgba(#0CCE8D, 0.7) 100%) 100% 100%,
+        linear-gradient(270deg, rgba(#0CCE8D, 0.7)  0%, rgba(#0CCE8D,   1) 100%)   0% 100%
+      ;
+      background-repeat: no-repeat;
+      background-size: 50% 50%;
+    }
+
+    &:after {
+      // had to use the opaque hex representation of the transparent color --color-primary-action-15, otherwise
+      // it wouldn't work
+      background-color: #0c2a31;
+    }
+  }
+}

--- a/packages/augur-ui/src/modules/common/spinner.tsx
+++ b/packages/augur-ui/src/modules/common/spinner.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import Styles from 'modules/common/spinner.styles.less';
+
+export const Spinner = () => <div className={Styles.Spinner} />;


### PR DESCRIPTION
#9101 

## .Spinner:before
I had 2 choices for the :before pseudo-element, so I chose the first one:
1. Add a "color-primary-action-0" and use var in the spinner background
2. Use 2 hardcoded hex values (1 for trading, 1 for betting/sb) since "rgba(var(--color-primary-action), 0)" didn't work but "rgba(#hardcoded-hex, 0)". Tried updating to Less 3.12.2 and it didn't work either.

## .Spinner:after
The :after is a smaller circle that goes inside the spinner ring, hiding the gradient background color. I had no choice when hardcoding the background with a hex representation of the colors --color-primary-action-15 and --color-primary-action-40, otherwise it would show how the background really looks like because of the transparency in the rgba.
See image bellow:

![Captura de Tela 2020-09-22 às 00 33 02](https://user-images.githubusercontent.com/10351013/93841828-3179fd80-fc6b-11ea-8cee-1fe9bf453a7e.png)

