### PR TITLE
Added hover style to footer links and support for mobile Safari and FF

### DIFF
--- a/packages/augur-ui/src/modules/app/components/terms-and-conditions.styles.less
+++ b/packages/augur-ui/src/modules/app/components/terms-and-conditions.styles.less
@@ -35,8 +35,21 @@
     padding: 0 0 0 @size-16;
 
     > a {
-      text-decoration: underline dotted var(--color-primary-text);
-      text-underline-position: under;
+      text-decoration: none;
+      position: relative;
+
+      &:after {
+        content: '';
+        position: absolute;
+        bottom: -@size-2;
+        left: @size-16;
+        right: @size-16;
+        border-bottom: @size-1 dotted var(--color-primary-text);
+      }
+
+      &:hover:after {
+        border-bottom: @size-1 solid var(--color-primary-text);
+      }
     }
 
     > a:last-of-type {


### PR DESCRIPTION
#9243 

I changed back to the :after underline styling because `text-underline-position: under` does not support hover effects.