### PR TITLE
Adjusted styles for alerts and fixed a style bug for trading's alerts

### DIFF
--- a/packages/augur-ui/src/modules/alerts/components/alert.styles.less
+++ b/packages/augur-ui/src/modules/alerts/components/alert.styles.less
@@ -128,10 +128,10 @@
   margin-left: auto;
 
   > svg {
-    width: @size-8;
-    height: @size-8;
+    width: @size-16;
+    height: @size-16;
     > path {
-      fill: var(--color-inactive-text);
+      stroke: var(--color-inactive-text);
     }
   }
 }
@@ -164,9 +164,13 @@
   .Alert {
     background-color: var(--color-module-background);
     padding: @size-8;
-    border: @size-1 solid var(--color-dark-grey);
+    border: @size-1 solid var(--color-dark-text);
     border-radius: @border-radius-rounded;
     margin: @size-4 @size-8;
+
+    &:not(:disabled):hover {
+      background-color: var(--color-active-background);
+    }
   }
 
   .Timestamp {
@@ -206,13 +210,13 @@
 
   .Status {
     .mono-12-semi-bold;
-  
+
     color: var(--color-primary-text);
   }
 
   .EtherLink {
     .text-10-semi-bold;
-  
+
     color: var(--color-primary-text);
     text-decoration: none;
     margin-top: @size-6;
@@ -240,11 +244,19 @@
         }
       }
     }
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
   .Close {
     margin-top: auto;
     margin-bottom: auto;
+
+    &:not(:disabled):active > svg > path {
+      stroke: var(--color-primary-text);
+    }
   }
 
   .Description {

--- a/packages/augur-ui/src/modules/alerts/components/alert.tsx
+++ b/packages/augur-ui/src/modules/alerts/components/alert.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { Close } from 'modules/common/icons';
+import { Close, MobileNavCloseIcon } from 'modules/common/icons';
 import { FAILURE } from 'modules/common/constants';
 import Styles from 'modules/alerts/components/alert.styles.less';
 import { ViewTransactionDetailsButton } from 'modules/common/buttons';
@@ -54,7 +54,7 @@ const Alert = ({
               removeAlert();
             }}
           >
-            {Close}
+            <MobileNavCloseIcon />
           </button>
         </div>
         <div className={Styles.Row}>

--- a/packages/augur-ui/src/modules/alerts/components/alerts-view.styles.less
+++ b/packages/augur-ui/src/modules/alerts/components/alerts-view.styles.less
@@ -94,7 +94,7 @@
   display: flex;
   justify-content: flex-end;
   margin-top: auto;
-  padding: @size-10 @size-12;
+  padding: 0 @size-9;
 
   > span {
     display: none;
@@ -112,6 +112,7 @@
     display: flex;
     justify-content: center;
     padding: @size-4;
+    margin: @size-6 0;
     text-transform: uppercase;
 
     &:hover {
@@ -169,6 +170,9 @@
     border-bottom: @size-1 solid var(--color-dark-grey);
     border-radius: 0;
     justify-content: space-between;
+    align-items: center;
+    padding: 0 @size-12;
+    margin: 0;
 
     > span {
       .mono-12-semi-bold;
@@ -176,7 +180,7 @@
       display: initial;
       color: var(--color-primary-text);
       text-transform: uppercase;
-      margin: auto 0;
+      padding: @size-14 0;
     }
 
     > button {
@@ -186,9 +190,24 @@
       text-transform: capitalize;
       background-color: var(--color-page-background);
       border: none;
-      text-decoration: underline;
-      text-decoration-color: var(--color-primary-text);
-      text-decoration-style: dashed;
+      text-decoration: none;
+      position: relative;
+      padding: 0;
+      margin: 0;
+      align-self: center;
+
+      &:after {
+        content: '';
+        position: absolute;
+        bottom: -@size-1;
+        left: 0;
+        right: 0;
+        border-bottom: @size-1 dotted var(--color-primary-text);
+      }
+
+      &:hover:after {
+        border-bottom: @size-1 solid var(--color-primary-text);
+      }
     }
   }
 }


### PR DESCRIPTION
#9077 

Trading UI was showing an empty white bar on the bottom when there were no alerts, like this:

![Captura de Tela 2020-09-30 às 19 30 20](https://user-images.githubusercontent.com/10351013/94746569-66fda580-0353-11eb-99b1-2d24c02fa915.png)
