### PR TITLE
view-detials-futures

### DIFF
--- a/packages/augur-ui/src/modules/market-cards/common.tsx
+++ b/packages/augur-ui/src/modules/market-cards/common.tsx
@@ -963,7 +963,7 @@ export const SportsMarketContainer = ({
         ): null}
       </header>
       <div>{innerContent}</div>
-      {isGrid && <OutcomeGroupFooter market={market} />}
+      {isFutures && <OutcomeGroupFooter market={market} />}
     </section>
   );
 };


### PR DESCRIPTION
updated view market details link to show for any futures markets regardless of outcomes amount. was only showing on greater than 4 outcomes markets previously.


https://github.com/AugurProject/augur/issues/9452