### PR TITLE
updates-for-long-titles

### DIFF
--- a/packages/augur-ui/src/modules/market-cards/common.styles.less
+++ b/packages/augur-ui/src/modules/market-cards/common.styles.less
@@ -1407,10 +1407,9 @@
 
 				color: var(--color-secondary-text);
 				text-transform: uppercase;
-				display: flex;
-				height: 100%;
 				align-items: center;
 				text-overflow: ellipsis;
+				padding-right: @size-16;
 			}
 
 			> span[class*="ProgressLabel"] {

--- a/packages/augur-ui/src/modules/market-cards/common.tsx
+++ b/packages/augur-ui/src/modules/market-cards/common.tsx
@@ -994,7 +994,7 @@ export const SportsMarketContainer = ({
     const newBase = window.location.href.replace('markets', 'market?id=');
     headingContent = (
       <Fragment key={`${marketId}-heading`}>
-        <h6>{market.description}</h6>
+        <h6 title={market.description}>{market.description}</h6>
         {tradingPositionsPerMarket &&
           tradingPositionsPerMarket.current !== '0' &&
           PositionIcon}


### PR DESCRIPTION
added title for hover effect on sub titles on futures cards. added some small padding to the right of the title to leave some space before experiation time, updated cut off to force no more than 2 lines of text.