### PR TITLE
Ui updates

### DIFF
--- a/packages/augur-ui/src/modules/market-cards/common.styles.less
+++ b/packages/augur-ui/src/modules/market-cards/common.styles.less
@@ -1143,7 +1143,11 @@
 		border-radius: @border-radius-default;
 
 		> header {
-			> span:first-of-type[class*="ProgressLabel"] {
+			> span:first-of-type:not(:last-of-type) > a > span:first-of-type[class*="ProgressLabel"],
+			> button.FuturesBar > span:first-of-type[class*="ProgressLabel"] {
+				display: flex;
+				flex-flow: row nowrap;
+
 				> span:first-of-type {
 					.text-12;
 				}
@@ -1155,18 +1159,7 @@
 				}
 			}
 
-			> div[class*="DotSelection"] {
-				height: @size-18;
-				width: @size-18;
-
-				> button > svg {
-					height: @size-18;
-					width: @size-18;
-					transform: none;
-				}
-			}
-
-      > div[class$="HoverIcon"] {
+			> button.FuturesBar > div[class$="HoverIcon"] {
         margin-right: @size-12;
 
         > svg {
@@ -1188,6 +1181,17 @@
           border-color: var(--color-secondary-text);
         }
 			}
+
+			> div[class*="DotSelection"] {
+				height: @size-18;
+				width: @size-18;
+
+				> button > svg {
+					height: @size-18;
+					width: @size-18;
+					transform: none;
+				}
+			}
 		}
 
 		&.Collapsed {
@@ -1200,7 +1204,8 @@
 				}
 			}
 
-			> div {
+			> div,
+			> button.FuturesBar > div {
 				display: none;
 			}
 
@@ -1240,28 +1245,44 @@
 			}
 
 			&.Collapsed {
-				> header > span:last-of-type {
-					align-items: center;
-					display: flex;
-					justify-content: space-between;
-					width: @size-24;
-					height: @size-18;
-					justify-content: flex-end;
-
-					> a {
-						display: flex;
-						height: 100%;
+				> header {
+					> span:first-of-type:not(:last-of-type) {
 						width: 100%;
+						display: flex;
+						flex-flow: row nowrap;
+						flex: 1 100%;
+						
+						> a {
+							display: flex;
+							flex-flow: row nowrap;
+							align-items: center;
+							flex: 1 100%;
+							justify-content: space-between;
+						}
+					}
+					> span:last-of-type {
 						align-items: center;
+						display: flex;
+						justify-content: space-between;
+						width: @size-24;
+						height: @size-18;
 						justify-content: flex-end;
-
-							> svg {
-							width: @size-10;
-							height: @size-6;
-							transform: rotate(-.25turn);
-
-							> path {
-								fill: var(--color-primary-text);
+	
+						> a {
+							display: flex;
+							height: 100%;
+							width: 100%;
+							align-items: center;
+							justify-content: flex-end;
+	
+								> svg {
+								width: @size-10;
+								height: @size-6;
+								transform: rotate(-.25turn);
+	
+								> path {
+									fill: var(--color-primary-text);
+								}
 							}
 						}
 					}
@@ -1480,7 +1501,9 @@
 			max-height: @size-35;
 			min-height: @size-30;
 			padding: 0 @size-12;
-
+			
+			> button.FuturesBar > h6,
+			> span:first-of-type:not(:last-of-type) > a > h6,
 			> h6 {
 				.text-10-semi-bold;
 				.limit-lines(1);
@@ -1498,38 +1521,50 @@
 				}
 			}
 
-			> span[class*="ProgressLabel"] {
+			> button.FuturesBar {
+				display: flex;
 				flex-flow: row nowrap;
-				flex: 0;
 				align-items: center;
-				height: 100%;
-				margin-left: auto;
+				border-top-right-radius: @border-radius-default;
+				border-top-left-radius: @border-radius-default;
+				flex: 1;
+				max-height: @size-35;
+				min-height: @size-30;
 
-				@media @breakpoint-mobile {
-					display: none;
-				}
-
-				> span {
-					margin: 0;
-
-					&:last-of-type {
-						margin-left: @size-4;
-						text-transform: capitalize;
+				> span[class*="ProgressLabel"] {
+					flex-flow: row nowrap;
+					flex: 0;
+					align-items: center;
+					height: 100%;
+					margin-left: auto;
+	
+					@media @breakpoint-mobile {
+						display: none;
+					}
+	
+					> span {
+						margin: 0;
+	
+						&:last-of-type {
+							margin-left: @size-4;
+							text-transform: capitalize;
+						}
 					}
 				}
 			}
-
-			> div[class*="DotSelection"],
-			> button[class*="FavoriteButton"] {
-				margin-left: @size-12;
-			}
-
+			> button.FuturesBar > button:not([class*="FavoriteButton"]),
 			> button:not([class*="FavoriteButton"]) {
 				align-items: center;
 				display: flex;
 				width: 100%;
 				height: 100%;
 				justify-content: space-between;
+
+				&.FuturesBar {
+					height: auto;
+					width: auto;
+					justify-content: unset;
+				}
 
 				&.toggleCollapsed {
 					width: @size-24;
@@ -1557,6 +1592,11 @@
 						fill: var(--color-primary-text);
 					}
 				}
+			}
+
+			> div[class*="DotSelection"],
+			> button.FuturesBar > button[class*="FavoriteButton"] {
+				margin-left: @size-12;
 			}
 		}
 
@@ -1599,7 +1639,7 @@
 			display: none;
 		}
 	}
-
+	.SportsMarketContainer > header > button.FuturesBar > button[class*="FavoriteButton"],
 	.SportsMarketContainer > header > button[class*="FavoriteButton"] {
 		display: none;
 	}

--- a/packages/augur-ui/src/modules/market-cards/common.styles.less
+++ b/packages/augur-ui/src/modules/market-cards/common.styles.less
@@ -1157,6 +1157,10 @@
 
 					text-transform: capitalize;
 				}
+
+				@media @breakpoint-mobile {
+					display: none;
+				}
 			}
 
 			> button.FuturesBar > div[class$="HoverIcon"] {
@@ -1260,6 +1264,7 @@
 							justify-content: space-between;
 						}
 					}
+
 					> span:last-of-type {
 						align-items: center;
 						display: flex;
@@ -1581,6 +1586,7 @@
 					color: var(--color-secondary-text);
 					text-transform: uppercase;
 					margin-right: auto;
+					text-align: left;
 				}
 
 				> svg {

--- a/packages/augur-ui/src/modules/market-cards/common.styles.less
+++ b/packages/augur-ui/src/modules/market-cards/common.styles.less
@@ -1255,6 +1255,9 @@
 						display: flex;
 						flex-flow: row nowrap;
 						flex: 1 100%;
+						min-height: @size-30;
+						max-height: @size-35;
+						height: 100%;
 						
 						> a {
 							display: flex;
@@ -1262,6 +1265,9 @@
 							align-items: center;
 							flex: 1 100%;
 							justify-content: space-between;
+							min-height: @size-30;
+							max-height: @size-35;
+							height: 100%;
 						}
 					}
 

--- a/packages/augur-ui/src/modules/market-cards/common.tsx
+++ b/packages/augur-ui/src/modules/market-cards/common.tsx
@@ -577,7 +577,9 @@ export const OutcomeGroupFooter = ({
   sportsGroup,
   showLeader = false,
 }) => {
-  const { actions: { setModal }} = useAppStatusStore();
+  const {
+    actions: { setModal },
+  } = useAppStatusStore();
   const location = useLocation();
   const { isGroupPage } = isMarketView(location);
   const isDaily = sportsGroup.type === SPORTS_GROUP_TYPES.DAILY;
@@ -606,16 +608,16 @@ export const OutcomeGroupFooter = ({
       <Fragment key="content">
         <MarketLink id={id}>View Market Details</MarketLink>
         <button
-            className={Styles.RulesButton}
-            onClick={() =>
-              setModal({
-                type: MODAL_MARKET_RULES,
-                sportMarkets: sportsGroup.markets,
-                description: header,
-                endTime: endTimeFormatted.formattedUtc,
-              })
-            }
-          >
+          className={Styles.RulesButton}
+          onClick={() =>
+            setModal({
+              type: MODAL_MARKET_RULES,
+              sportMarkets: sportsGroup.markets,
+              description: header,
+              endTime: endTimeFormatted.formattedUtc,
+            })
+          }
+        >
           {Rules} Rules
         </button>
         <CountdownProgress
@@ -827,9 +829,15 @@ export const ComboMarketContainer = ({
   isGroupPage = false,
 }: ComboMarketContainerProps) => {
   const { SPREAD, MONEY_LINE, OVER_UNDER } = SPORTS_GROUP_MARKET_TYPES;
-  const [spreadCollapsed, setSpreadCollapsed] = useState(data[SPREAD].length === 0);
-  const [moneyLineCollapsed, setMoneyLineCollapsed] = useState(data[MONEY_LINE].length === 0);
-  const [overUnderCollapsed, setOverUnderCollapsed] = useState(data[OVER_UNDER].length === 0);
+  const [spreadCollapsed, setSpreadCollapsed] = useState(
+    data[SPREAD].length === 0
+  );
+  const [moneyLineCollapsed, setMoneyLineCollapsed] = useState(
+    data[MONEY_LINE].length === 0
+  );
+  const [overUnderCollapsed, setOverUnderCollapsed] = useState(
+    data[OVER_UNDER].length === 0
+  );
   const {
     sportsBook: { placeholderOutcomes },
   } = sportsGroup.markets.find(
@@ -858,21 +866,23 @@ export const ComboMarketContainer = ({
         <li>{placeholderOutcomes[1]}</li>
         <li>{placeholderOutcomes[2]}</li>
       </ul>
-      <ul className={classNames({
-        [Styles.ListCollapse]: spreadCollapsed,
-      })}>
+      <ul
+        className={classNames({
+          [Styles.ListCollapse]: spreadCollapsed,
+        })}
+      >
         <li>
-        <button
+          <button
             className={Styles.toggleCollapsed}
             onClick={e => {
               e.preventDefault();
               setSpreadCollapsed(!spreadCollapsed);
             }}
           >
-          Spread
-          <span>{`${data[SPREAD][0]?.market?.sportsBook?.marketLine}.5`}</span>
-          {ThickChevron}
-        </button>
+            Spread
+            <span>{`${data[SPREAD][0]?.market?.sportsBook?.marketLine}.5`}</span>
+            {ThickChevron}
+          </button>
         </li>
         <li>
           <SportsOutcome {...data[SPREAD][0]} />
@@ -884,20 +894,22 @@ export const ComboMarketContainer = ({
           <SportsOutcome {...data[SPREAD][2]} />
         </li>
       </ul>
-      <ul className={classNames({
-        [Styles.ListCollapse]: moneyLineCollapsed,
-      })}>
+      <ul
+        className={classNames({
+          [Styles.ListCollapse]: moneyLineCollapsed,
+        })}
+      >
         <li>
-        <button
+          <button
             className={Styles.toggleCollapsed}
             onClick={e => {
               e.preventDefault();
               setMoneyLineCollapsed(!moneyLineCollapsed);
             }}
           >
-          Moneyline
-          {ThickChevron}
-        </button>
+            Moneyline
+            {ThickChevron}
+          </button>
         </li>
         <li>
           <SportsOutcome {...data[MONEY_LINE][0]} />
@@ -909,21 +921,23 @@ export const ComboMarketContainer = ({
           <SportsOutcome {...data[MONEY_LINE][2]} />
         </li>
       </ul>
-      <ul className={classNames({
-        [Styles.ListCollapse]: overUnderCollapsed,
-      })}>
+      <ul
+        className={classNames({
+          [Styles.ListCollapse]: overUnderCollapsed,
+        })}
+      >
         <li>
-        <button
+          <button
             className={Styles.toggleCollapsed}
             onClick={e => {
               e.preventDefault();
               setOverUnderCollapsed(!overUnderCollapsed);
             }}
           >
-          Over/Under
-          <span>{`${data[OVER_UNDER][0]?.market?.sportsBook?.marketLine}.5`}</span>
-          {ThickChevron}
-        </button>
+            Over/Under
+            <span>{`${data[OVER_UNDER][0]?.market?.sportsBook?.marketLine}.5`}</span>
+            {ThickChevron}
+          </button>
         </li>
         <li>
           <SportsOutcome {...data[OVER_UNDER][0]} />
@@ -1006,31 +1020,31 @@ export const SportsMarketContainer = ({
     const { tradingPositionsPerMarket = null } =
       accountPositions[marketId] || {};
     const newBase = window.location.href.replace('markets', 'market?id=');
-    headingContent = (
-      <Fragment key={`${marketId}-heading`}>
+    const LeftContent = (
+      <Fragment key={`${marketId}-heading-leftContent`}>
         <h6 title={market.description}>{market.description}</h6>
         {tradingPositionsPerMarket &&
-        tradingPositionsPerMarket.current !== '0' && (
-          <div
-            className={Styles.HoverIcon}
-            data-tip
-            data-for={`${market.id}-youHaveABet`}
-            data-iscapture={false}
-          >
-            {PositionIcon}
-            <ReactTooltip
-              id={`${market.id}-youHaveABet`}
-              className={TooltipStyles.Tooltip}
-              effect="solid"
-              place="top"
-              type="light"
-              data-event="mouseover"
-              data-event-off="blur scroll"
+          tradingPositionsPerMarket.current !== '0' && (
+            <div
+              className={Styles.HoverIcon}
+              data-tip
+              data-for={`${market.id}-youHaveABet`}
+              data-iscapture={false}
             >
-              You have a bet
-            </ReactTooltip>
-          </div>
-        )}
+              {PositionIcon}
+              <ReactTooltip
+                id={`${market.id}-youHaveABet`}
+                className={TooltipStyles.Tooltip}
+                effect="solid"
+                place="top"
+                type="light"
+                data-event="mouseover"
+                data-event-off="blur scroll"
+              >
+                You have a bet
+              </ReactTooltip>
+            </div>
+          )}
         <CountdownProgress
           label="Event Expiration"
           time={market.endTimeFormatted}
@@ -1038,6 +1052,21 @@ export const SportsMarketContainer = ({
           forceLongDate
           onlyFinalCountdown
         />
+      </Fragment>
+    );
+    headingContent = (
+      <Fragment key={`${marketId}-heading`}>
+        {forceCollapse ? (
+          <MarketLink id={marketId}>{LeftContent}</MarketLink>
+        ) : (
+          <button
+            className={Styles.FuturesBar}
+            onClick={e => {
+              e.preventDefault();
+              setIsCollapsed(!isCollapsed);
+            }}
+          >{LeftContent}</button>
+        )}
         <DotSelection
           customClass={classNames({ [Styles.ShowCopied]: isCopied })}
         >
@@ -1555,10 +1584,7 @@ export const TopRow = ({ market, categoriesWithClick, showStart }) => {
     const clipboardMarketId = new Clipboard('#copy_marketId');
     const clipboardAuthor = new Clipboard('#copy_author');
   }, [market.id, market.author]);
-  const {
-    theme,
-    isLogged,
-  } = useAppStatusStore();
+  const { theme, isLogged } = useAppStatusStore();
   const {
     marketType,
     id,
@@ -1599,13 +1625,15 @@ export const TopRow = ({ market, categoriesWithClick, showStart }) => {
       <CategoryTagTrail categories={categoriesWithClick} />
       {theme !== THEMES.TRADING ? (
         <>
-          {showStart && <CountdownProgress
-            label="Estimated Start Time"
-            time={formatTime(Number(market.sportsBook.estTimestamp))}
-            reportingState={reportingState}
-            forceLongDate
-            onlyFinalCountdown
-          />}
+          {showStart && (
+            <CountdownProgress
+              label="Estimated Start Time"
+              time={formatTime(Number(market.sportsBook.estTimestamp))}
+              reportingState={reportingState}
+              forceLongDate
+              onlyFinalCountdown
+            />
+          )}
         </>
       ) : (
         <MarketProgress

--- a/packages/augur-ui/src/modules/market-charts/sports-group-charts.tsx
+++ b/packages/augur-ui/src/modules/market-charts/sports-group-charts.tsx
@@ -5,7 +5,11 @@ import PriceHistory from 'modules/market-charts/components/price-history/price-h
 import Styles from 'modules/market-charts/sports-group-charts.styles.less';
 import { selectMarket } from 'modules/markets/selectors/market';
 import { SquareDropdown } from 'modules/common/selection';
-import { SPORTS_GROUP_TYPES } from 'modules/common/constants';
+import {
+  SPORTS_GROUP_TYPES,
+  SPORTS_GROUP_MARKET_TYPES,
+  SPORTS_GROUP_MARKET_TYPES_READABLE,
+} from 'modules/common/constants';
 
 const RANGE_OPTIONS = [
   {
@@ -40,13 +44,16 @@ export const SportsGroupCharts = ({ sportsGroup, marketId }) => {
     const outcomes = market.outcomesFormatted;
     const invalid = outcomes.shift();
     outcomes.push(invalid);
-    const options = sportsGroup.markets.map(m => {
-      return {
-        value: m.id,
-        label: m.sportsBook.title,
-        name: m.sportsBook.title,
-      };
-    });
+    const options = sportsGroup.markets.map(
+      ({ id, sportsBook: { title, groupType } }) => {
+        const readableName = SPORTS_GROUP_MARKET_TYPES_READABLE[groupType];
+        return {
+          value: id,
+          label: title ? title : readableName,
+          name: title ? title : readableName,
+        };
+      }
+    );
     return {
       market,
       outcomes,


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/9586
https://github.com/AugurProject/augur/issues/9745
https://github.com/AugurProject/augur/issues/9747

https://github.com/AugurProject/augur/issues/9764 - unable to reproduce the latest sent back comment.

Also fixes a bug that has no ticket to provide some sort of label for the market chart dropdowns if we don't have a title given to us from the sportsbook object on that market. defaults to grabbing the mapping of sportsMarketType > readable Type Name (example is Combo Money Lines, no titles, but spreads and o/u do have titles. Now it will say `Combo Money Line` instead of nothing, this is most likely a stop gap until design gives us a correction and we can update how the sportsbook object is calculated)