### PR TITLE
Fixed issues with product switcher, account summary and account dropdown

### DIFF
--- a/packages/augur-ui/src/modules/account/components/open-markets.styles.less
+++ b/packages/augur-ui/src/modules/account/components/open-markets.styles.less
@@ -27,7 +27,9 @@
 
     > div:nth-of-type(2):not([class*="EmptyDisplay"]) {
       @media @breakpoint-mobile {
-        border-top: @size-1 solid var(--color-dark-grey);
+        border-top: none;
+        border-right: none;
+        border-left: none;
       }
     }
   }

--- a/packages/augur-ui/src/modules/app/components/app.tsx
+++ b/packages/augur-ui/src/modules/app/components/app.tsx
@@ -128,6 +128,7 @@ const AppView = ({
     modal,
     env,
     isMobile,
+    isConnectionTrayOpen,
     betslipMinimized,
     actions: {
       setIsMobile,
@@ -238,12 +239,18 @@ const AppView = ({
       window.scrollTo(0, 0);
     }
     if (currentBasePath !== currentPath) setCurrentBasePath(currentPath);
-    if (mobileMenuState === MOBILE_MENU_STATES.FIRSTMENU_OPEN || mobileMenuState === MOBILE_MENU_STATES.SIDEBAR_OPEN || !betslipMinimized || ModalShowing) {
+    if (
+      mobileMenuState === MOBILE_MENU_STATES.FIRSTMENU_OPEN ||
+      mobileMenuState === MOBILE_MENU_STATES.SIDEBAR_OPEN ||
+      mobileMenuState === MOBILE_MENU_STATES.ACCOUNT_DROPDOWN_OPEN ||
+      !betslipMinimized ||
+      ModalShowing
+    ) {
       document.body.classList.add('App--noScroll');
     } else {
       document.body.classList.remove('App--noScroll');
     }
-  }, [mobileMenuState, isMobile, currentPath, betslipMinimized, ModalShowing]);
+  }, [mobileMenuState, isMobile, currentPath, betslipMinimized, ModalShowing, isConnectionTrayOpen]);
 
   function mainSectionClickHandler(e: any, testSideNav = true) {
     if (

--- a/packages/augur-ui/src/modules/app/components/inner-nav/base-inner-nav-pure.tsx
+++ b/packages/augur-ui/src/modules/app/components/inner-nav/base-inner-nav-pure.tsx
@@ -50,9 +50,9 @@ const BaseInnerNavPure = () => {
   const sortProps = {
     setFilterSortState: updates => setFilterSortState({ ...filterSortState, ...updates }),
   };
-  const showMainMenu = mobileMenuState >= MOBILE_MENU_STATES.FIRSTMENU_OPEN;
+  const showMainMenu = mobileMenuState >= MOBILE_MENU_STATES.FIRSTMENU_OPEN && mobileMenuState <= MOBILE_MENU_STATES.SUBMENU_OPEN;
 
-  const getFilters = (originalFilters = false) => {   
+  const getFilters = (originalFilters = false) => {
     const filters = [
       {
         filterType: TEMPLATE_FILTER,

--- a/packages/augur-ui/src/modules/app/components/select-product-dropdown.tsx
+++ b/packages/augur-ui/src/modules/app/components/select-product-dropdown.tsx
@@ -46,28 +46,43 @@ export const SelectProductDropdown = ({hideOnMobile}: SelectProductDropdownProps
     title: 'Create Market',
     link: makePath(CREATE_MARKET),
     active: currentBasePath === CREATE_MARKET,
-    action: () => setTheme(THEMES.TRADING)
+    action: () => {
+      setTheme(THEMES.TRADING);
+      setToggleDropdown(false);
+    }
   }, {
     title: 'Disputing',
     link: makePath(DISPUTING),
     active: currentBasePath === DISPUTING,
-    action: () => setTheme(THEMES.TRADING)
+    action: () => {
+      setTheme(THEMES.TRADING);
+      setToggleDropdown(false);
+    }
   }, {
     title: 'Reporting',
     link: makePath(REPORTING),
     active: currentBasePath === REPORTING,
-    action: () => setTheme(THEMES.TRADING)
+    action: () => {
+      setTheme(THEMES.TRADING);
+      setToggleDropdown(false);
+    }
   }] : [];
 
   const isTradingOrSportsbook: DropdownOptions = isTrading ? {
     title: 'Sportsbook',
       link: makePath(MARKETS),
-      action: () => setTheme(THEMES.SPORTS),
+      action: () => {
+        setTheme(THEMES.SPORTS);
+        setToggleDropdown(false);
+      },
       active: isSportsbook
   } : isSportsbook ? {
     title: 'Trading',
       link: makePath(MARKETS),
-      action: () => setTheme(THEMES.TRADING),
+      action: () => {
+        setTheme(THEMES.TRADING);
+        setToggleDropdown(false);
+      },
       active: isTrading
   } : null;
 
@@ -77,18 +92,24 @@ export const SelectProductDropdown = ({hideOnMobile}: SelectProductDropdownProps
     dropdownStatus: toggleAugurPro,
     dropdown: [{
       title: 'DAI',
-      action: () => {},
+      action: () => {
+        setToggleDropdown(false);
+      },
       link: null,
       icon: DaiIcon,
     }, {
       title: 'ETH',
-      action: () => {},
+      action: () => {
+        setToggleDropdown(false);
+      },
       link: null,
       icon: StylizedEthIcon,
     }]
   }, {
     title: 'AMM',
-    action: () => {},
+    action: () => {
+      setToggleDropdown(false);
+    },
   }, isTradingOrSportsbook,
     ...isLoggedDropdownOptions
   ];
@@ -136,17 +157,11 @@ export const SelectProductDropdown = ({hideOnMobile}: SelectProductDropdownProps
         {dropdownOptions.map(({title, action, link, dropdownStatus, dropdown, active}) => (
           <div key={title}>
             {link ? (
-              <Link to={link} onClick={() => {
-                action();
-                setToggleDropdown(false);
-              }} className={classNames(Styles.Dropdown, {
+              <Link to={link} onClick={() => action()} className={classNames(Styles.Dropdown, {
                 [Styles.Active]: active
               })}>{title}</Link>
             ) : (
-              <button onClick={() => {
-                action();
-                setToggleDropdown(false);
-              }} className={classNames(Styles.Dropdown, {
+              <button onClick={() => action()} className={classNames(Styles.Dropdown, {
                 [Styles.Active]: active
               })}>
                 {title}
@@ -171,10 +186,7 @@ export const SelectProductDropdown = ({hideOnMobile}: SelectProductDropdownProps
                       {title}
                     </Link>
                   ) : (
-                    <button onClick={() => {
-                      action();
-                      setToggleDropdown(false);
-                    }} key={title}>
+                    <button onClick={() => action()} key={title}>
                       <span>{icon}</span>
                       {title}
                     </button>

--- a/packages/augur-ui/src/modules/app/components/select-product-dropdown.tsx
+++ b/packages/augur-ui/src/modules/app/components/select-product-dropdown.tsx
@@ -46,26 +46,17 @@ export const SelectProductDropdown = ({hideOnMobile}: SelectProductDropdownProps
     title: 'Create Market',
     link: makePath(CREATE_MARKET),
     active: currentBasePath === CREATE_MARKET,
-    action: () => {
-      setTheme(THEMES.TRADING);
-      setToggleDropdown(false);
-    }
+    action: () => setTheme(THEMES.TRADING)
   }, {
     title: 'Disputing',
     link: makePath(DISPUTING),
     active: currentBasePath === DISPUTING,
-    action: () => {
-      setTheme(THEMES.TRADING);
-      setToggleDropdown(false);
-    }
+    action: () => setTheme(THEMES.TRADING)
   }, {
     title: 'Reporting',
     link: makePath(REPORTING),
     active: currentBasePath === REPORTING,
-    action: () => {
-      setTheme(THEMES.TRADING);
-      setToggleDropdown(false);
-    }
+    action: () => setTheme(THEMES.TRADING)
   }] : [];
 
   const isTradingOrSportsbook: DropdownOptions = isTrading ? {
@@ -73,7 +64,6 @@ export const SelectProductDropdown = ({hideOnMobile}: SelectProductDropdownProps
       link: makePath(MARKETS),
       action: () => {
         setTheme(THEMES.SPORTS);
-        setToggleDropdown(false);
       },
       active: isSportsbook
   } : isSportsbook ? {
@@ -81,7 +71,6 @@ export const SelectProductDropdown = ({hideOnMobile}: SelectProductDropdownProps
       link: makePath(MARKETS),
       action: () => {
         setTheme(THEMES.TRADING);
-        setToggleDropdown(false);
       },
       active: isTrading
   } : null;
@@ -92,24 +81,18 @@ export const SelectProductDropdown = ({hideOnMobile}: SelectProductDropdownProps
     dropdownStatus: toggleAugurPro,
     dropdown: [{
       title: 'DAI',
-      action: () => {
-        setToggleDropdown(false);
-      },
+      action: () => {},
       link: null,
       icon: DaiIcon,
     }, {
       title: 'ETH',
-      action: () => {
-        setToggleDropdown(false);
-      },
+      action: () => {},
       link: null,
       icon: StylizedEthIcon,
     }]
   }, {
     title: 'AMM',
-    action: () => {
-      setToggleDropdown(false);
-    },
+    action: () => {},
   }, isTradingOrSportsbook,
     ...isLoggedDropdownOptions
   ];
@@ -157,11 +140,17 @@ export const SelectProductDropdown = ({hideOnMobile}: SelectProductDropdownProps
         {dropdownOptions.map(({title, action, link, dropdownStatus, dropdown, active}) => (
           <div key={title}>
             {link ? (
-              <Link to={link} onClick={() => action()} className={classNames(Styles.Dropdown, {
+              <Link to={link} onClick={() => {
+                action();
+                !dropdown && setToggleDropdown(false);
+              }} className={classNames(Styles.Dropdown, {
                 [Styles.Active]: active
               })}>{title}</Link>
             ) : (
-              <button onClick={() => action()} className={classNames(Styles.Dropdown, {
+              <button onClick={() => {
+                action();
+                !dropdown && setToggleDropdown(false);
+              }} className={classNames(Styles.Dropdown, {
                 [Styles.Active]: active
               })}>
                 {title}
@@ -186,7 +175,10 @@ export const SelectProductDropdown = ({hideOnMobile}: SelectProductDropdownProps
                       {title}
                     </Link>
                   ) : (
-                    <button onClick={() => action()} key={title}>
+                    <button onClick={() => {
+                      action();
+                      setToggleDropdown(false);
+                    }} key={title}>
                       <span>{icon}</span>
                       {title}
                     </button>

--- a/packages/augur-ui/src/modules/app/components/select-product-dropdown.tsx
+++ b/packages/augur-ui/src/modules/app/components/select-product-dropdown.tsx
@@ -59,6 +59,18 @@ export const SelectProductDropdown = ({hideOnMobile}: SelectProductDropdownProps
     action: () => setTheme(THEMES.TRADING)
   }] : [];
 
+  const isTradingOrSportsbook: DropdownOptions = isTrading ? {
+    title: 'Sportsbook',
+      link: makePath(MARKETS),
+      action: () => setTheme(THEMES.SPORTS),
+      active: isSportsbook
+  } : isSportsbook ? {
+    title: 'Trading',
+      link: makePath(MARKETS),
+      action: () => setTheme(THEMES.TRADING),
+      active: isTrading
+  } : null;
+
   const dropdownOptions: DropdownOptions[] = [{
     title: 'Augur Pro',
     action: () => setToggleAugurPro(!toggleAugurPro),
@@ -77,17 +89,8 @@ export const SelectProductDropdown = ({hideOnMobile}: SelectProductDropdownProps
   }, {
     title: 'AMM',
     action: () => {},
-  }, {
-    title: 'Sportsbook',
-    link: makePath(MARKETS),
-    action: () => setTheme(THEMES.SPORTS),
-    active: isSportsbook
-  }, {
-    title: 'Trading',
-    link: makePath(MARKETS),
-    action: () => setTheme(THEMES.TRADING),
-    active: isTrading
-  }, ...isLoggedDropdownOptions
+  }, isTradingOrSportsbook,
+    ...isLoggedDropdownOptions
   ];
 
   const inputRef = useRef(null);
@@ -133,11 +136,17 @@ export const SelectProductDropdown = ({hideOnMobile}: SelectProductDropdownProps
         {dropdownOptions.map(({title, action, link, dropdownStatus, dropdown, active}) => (
           <div key={title}>
             {link ? (
-              <Link to={link} onClick={() => action()} className={classNames(Styles.Dropdown, {
+              <Link to={link} onClick={() => {
+                action();
+                setToggleDropdown(false);
+              }} className={classNames(Styles.Dropdown, {
                 [Styles.Active]: active
               })}>{title}</Link>
             ) : (
-              <button onClick={() => action()} className={classNames(Styles.Dropdown, {
+              <button onClick={() => {
+                action();
+                setToggleDropdown(false);
+              }} className={classNames(Styles.Dropdown, {
                 [Styles.Active]: active
               })}>
                 {title}
@@ -162,7 +171,10 @@ export const SelectProductDropdown = ({hideOnMobile}: SelectProductDropdownProps
                       {title}
                     </Link>
                   ) : (
-                    <button onClick={() => action()} key={title}>
+                    <button onClick={() => {
+                      action();
+                      setToggleDropdown(false);
+                    }} key={title}>
                       <span>{icon}</span>
                       {title}
                     </button>

--- a/packages/augur-ui/src/modules/auth/connect-account.tsx
+++ b/packages/augur-ui/src/modules/auth/connect-account.tsx
@@ -30,13 +30,9 @@ const ConnectAccount = () => {
 
   useEffect(() => {
     if (isMobile) {
-      if (isConnectionTrayOpen) {
-        // document.body.classList.add('App--noScroll');
-        setMobileMenuState(MOBILE_MENU_STATES.ACCOUNT_DROPDOWN_OPEN);
-      } else {
-        // document.body.classList.remove('App--noScroll');
+      isConnectionTrayOpen ?
+        setMobileMenuState(MOBILE_MENU_STATES.ACCOUNT_DROPDOWN_OPEN) :
         setMobileMenuState(MOBILE_MENU_STATES.CLOSED);
-      }
     }
   }, [isConnectionTrayOpen]);
 

--- a/packages/augur-ui/src/modules/auth/connect-account.tsx
+++ b/packages/augur-ui/src/modules/auth/connect-account.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import classNames from 'classnames';
 import Blockies from 'react-blockies';
 
@@ -8,6 +8,7 @@ import { formatDai } from 'utils/format-number';
 import { useAppStatusStore } from 'modules/app/store/app-status';
 import Styles from 'modules/auth/connect-account.styles.less';
 import ToggleHeightStyles from 'utils/toggle-height.styles.less';
+import { MOBILE_MENU_STATES } from 'modules/common/constants';
 
 const ConnectAccount = () => {
   const connectAccount = useRef(null);
@@ -15,9 +16,10 @@ const ConnectAccount = () => {
   const {
     loginAccount: { meta: userInfo, balances },
     isLogged,
+    isMobile,
     restoredAccount,
     isConnectionTrayOpen,
-    actions: { setIsConnectionTrayOpen },
+    actions: { setIsConnectionTrayOpen, setMobileMenuState },
   } = useAppStatusStore();
   if ((!isLogged && !restoredAccount) || !userInfo) return null;
 
@@ -25,6 +27,18 @@ const ConnectAccount = () => {
     setIsConnectionTrayOpen(!isConnectionTrayOpen);
     if (cb && typeof cb === 'function') cb();
   }
+
+  useEffect(() => {
+    if (isMobile) {
+      if (isConnectionTrayOpen) {
+        // document.body.classList.add('App--noScroll');
+        setMobileMenuState(MOBILE_MENU_STATES.ACCOUNT_DROPDOWN_OPEN);
+      } else {
+        // document.body.classList.remove('App--noScroll');
+        setMobileMenuState(MOBILE_MENU_STATES.CLOSED);
+      }
+    }
+  }, [isConnectionTrayOpen]);
 
   return (
     <div

--- a/packages/augur-ui/src/modules/common/constants.ts
+++ b/packages/augur-ui/src/modules/common/constants.ts
@@ -279,6 +279,7 @@ export const MOBILE_MENU_STATES = {
   SIDEBAR_OPEN: 1,
   FIRSTMENU_OPEN: 2,
   SUBMENU_OPEN: 3,
+  ACCOUNT_DROPDOWN_OPEN: 4,
 };
 
 export const SUB_MENU = 'subMenu';


### PR DESCRIPTION
#9578 see last comment - locked the scroll on mobile when account dropdown is open
#9671 see last comment - fixed the borders of the 24h thing, kept search on top

Made a few improvements to account switcher (no ticket, just a talk with JD):
- Trading button shouldn't appear when the user is in Trading UI, same for Sportsbook.
- Dropdown now closes when a link that is not an inner dropdown is clicked.
