### PR TITLE
Add first pass at Approval button

### DIFF
--- a/packages/augur-simplified/src/modules/common/buttons.styles.less
+++ b/packages/augur-simplified/src/modules/common/buttons.styles.less
@@ -154,3 +154,26 @@
   background: var(--simple-primary-text);
   color: var(--simple-light-bg)
 }
+
+.ApproveButton {
+  .Button;
+
+  color: var(--color-primary-text);
+  background-color: var(--simple-primary-text);
+  border: @size-1 solid var(--simple-border);
+
+  &:not(:disabled):not(.Disabled):focus {
+    .Focused;
+
+    background-color: var(--simple-primary-text);
+  }
+
+  &:not(:disabled):not(.Disabled):active {
+    background-color: var(--simple-alternate-background);
+  }
+}
+
+.Approval button {
+  margin-top: @size-16;
+  width: 100%;
+}

--- a/packages/augur-simplified/src/modules/common/buttons.tsx
+++ b/packages/augur-simplified/src/modules/common/buttons.tsx
@@ -1,7 +1,10 @@
-import React, {ReactNode} from 'react';
+import React, {ReactNode, useEffect, useState} from 'react';
 import Styles from 'modules/common/buttons.styles.less';
 import classNames from 'classnames';
 import { Arrow } from './icons';
+import { useApproveCallback, useIsTokenApproved } from '../hooks/use-approval-callback';
+import { useAppStatusStore } from '../stores/app-status';
+import { ApprovalAction, ApprovalState } from '../constants';
 
 interface ButtonProps {
   text?: string;
@@ -60,6 +63,7 @@ export const PrimaryButton = (props: ButtonProps) => <Button {...props} classNam
 export const SecondaryButton = (props: ButtonProps) => <Button {...props} className={classNames(Styles.SecondaryButton, props.className)} />;
 export const TinyButton = (props: ButtonProps) => <Button {...props} className={classNames(Styles.TinyButton, props.className)} />;
 export const BuySellButton = (props: ButtonProps) => <Button className={classNames(Styles.BuySellButton, props.className)} {...props} />;
+export const ApproveButton = (props: ButtonProps) => <Button className={classNames(Styles.ApproveButton, props.className)} {...props} />;
 
 export interface DirectionButtonProps {
   action: Function;
@@ -85,3 +89,83 @@ export const DirectionButton = ({
     {Arrow}
   </button>
 );
+
+export const ApprovalButton = ({ amm, actionType }) => {
+  const marketCashType = amm?.cash?.name;
+  const tokenAddress = amm?.cash?.address
+
+  const [isApprovedToTrade, setIsApprovedToTrade] = useState(false);
+  const [isPendingTx, setIsPendingTx] = useState(false);
+
+  const {
+    loginAccount,
+    approvals,
+    actions: { setApprovals }
+  } = useAppStatusStore();
+
+  const isTokenApproved = useIsTokenApproved(tokenAddress, loginAccount.account);
+  const [approvalState, approve ] = useApproveCallback(tokenAddress, marketCashType, loginAccount.account);
+
+  useEffect(() => {
+    if (loginAccount && !isApprovedToTrade) {
+      isTokenApproved
+      .then(isApproved => {
+        if (isApproved) {
+          setIsPendingTx(false);
+          setIsApprovedToTrade(true);
+          const approvalState = approvals;
+          approvalState.trade[marketCashType] = true;
+          setApprovals(approvalState);
+        }
+      })
+      .catch(error => {
+        console.log('error', error)
+        setIsApprovedToTrade(false);
+      })
+    }
+  }, [loginAccount, isTokenApproved, isApprovedToTrade, marketCashType, approvals, setApprovals]);
+
+  const approveTrade = () => {
+    if ([ApprovalState.UNKNOWN, ApprovalState.NOT_APPROVED].includes(approvalState)) {
+      setIsPendingTx(true);
+      approve()
+        .then(_ => {
+          setIsPendingTx(false);
+          setIsApprovedToTrade(true);
+          const approvalState = approvals;
+          approvalState.trade[marketCashType] = true;
+          setApprovals(approvalState);
+      })
+      .catch(error => {
+        console.log(error)
+        setIsPendingTx(false);
+      });
+    }
+    else if (ApprovalState.PENDING === approvalState) {
+      // TODO
+    }
+    else if (ApprovalState.APPROVED === approvalState) {
+      // TODO
+    }
+  }
+
+  if (!loginAccount) {
+    return null;
+  }
+
+  if (isApprovedToTrade) {
+    return null;
+  }
+
+  return (
+    <div className={Styles.Approval}>
+      {ApprovalAction.TRADE === actionType &&
+        <ApproveButton
+          disabled={isPendingTx}
+          text={isPendingTx ? 'Approving...' : 'Approve to Buy'}
+          action={() => approveTrade()}
+        />
+      }
+    </div>
+  )
+}

--- a/packages/augur-simplified/src/modules/common/top-nav.tsx
+++ b/packages/augur-simplified/src/modules/common/top-nav.tsx
@@ -11,7 +11,6 @@ import { GearIcon, ThreeLinesIcon } from 'modules/common/icons';
 import { useAppStatusStore } from 'modules/stores/app-status';
 import { useLocalStorage } from 'modules/stores/local-storage';
 import ConnectAccount from 'modules/ConnectAccount/index';
-import { useActiveWeb3React } from 'modules/ConnectAccount/hooks';
 import { SecondaryButton, TinyButton } from 'modules/common/buttons';
 import { Toasts } from '../toasts/toasts';
 

--- a/packages/augur-simplified/src/modules/constants.ts
+++ b/packages/augur-simplified/src/modules/constants.ts
@@ -196,6 +196,12 @@ export enum ApprovalState {
   APPROVED
 }
 
+export enum ApprovalAction {
+  TRADE,
+  ADD_LIQUIDITY,
+  REMOVE_LIQUIDITY,
+}
+
 export const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 // Modals

--- a/packages/augur-simplified/src/modules/market/market-view.tsx
+++ b/packages/augur-simplified/src/modules/market/market-view.tsx
@@ -81,12 +81,13 @@ const MarketView = ({ defaultMarket = null }) => {
     document.getElementById("mainContent")?.scrollTo(0, 0);
     window.scrollTo(0, 1);
   }, []);
-
   const market: MarketInfo = !!defaultMarket ? defaultMarket : markets[marketId];
   const amm: AmmExchange = market?.amm;
 
   if (!market) return <div className={Styles.MarketView} />;
   const details = getDetails(market);
+  const marketCashType = market.amm?.cash?.name;
+
   return (
     <div className={Styles.MarketView}>
       <section>
@@ -157,7 +158,7 @@ const MarketView = ({ defaultMarket = null }) => {
       </section>
       {(!isMobile || showTradingForm) && (
         <section>
-          <TradingForm initialSelectedOutcome={selectedOutcome} />
+          <TradingForm initialSelectedOutcome={selectedOutcome} marketCashType={marketCashType} amm={amm} />
           {!isMobile && <AddLiquidity market={market} />}
         </section>
       )}

--- a/packages/augur-simplified/src/modules/market/trading-form.tsx
+++ b/packages/augur-simplified/src/modules/market/trading-form.tsx
@@ -6,6 +6,8 @@ import { PrimaryButton } from 'modules/common/buttons';
 import { CurrencyDropdown } from 'modules/common/selection';
 import { useAppStatusStore } from 'modules/stores/app-status';
 import { CloseIcon } from 'modules/common/icons';
+import { ApprovalButton } from '../common/buttons';
+import { ApprovalAction } from '../constants';
 
 interface OutcomeType {
   id: number;
@@ -177,9 +179,13 @@ const TradingForm = ({
   outcomes = fakeYesNoOutcomes,
   initialSelectedOutcome,
   marketType = YES_NO,
+  marketCashType,
+  amm,
 }) => {
   const {
     isMobile,
+    loginAccount,
+    approvals,
     actions: { setShowTradingForm },
   } = useAppStatusStore();
   const [orderType, setOrderType] = useState(BUY);
@@ -234,7 +240,13 @@ const TradingForm = ({
             },
           ]}
         />
-        <PrimaryButton disabled text={orderType} />
+        {loginAccount &&
+          <ApprovalButton
+            amm={amm}
+            actionType={ApprovalAction.TRADE}
+          />
+        }
+        <PrimaryButton disabled={!approvals?.trade[marketCashType]} text={orderType} />
       </div>
     </div>
   );

--- a/packages/augur-simplified/src/modules/stores/app-status-hooks.ts
+++ b/packages/augur-simplified/src/modules/stores/app-status-hooks.ts
@@ -10,6 +10,7 @@ import { ParaDeploys, TransactionDetails, UserBalances } from '../types';
 
 const {
   SET_SHOW_TRADING_FORM,
+  SET_APPROVALS,
   SET_IS_MOBILE,
   SET_SIDEBAR,
   UPDATE_GRAPH_DATA,
@@ -26,6 +27,7 @@ const {
 } = APP_STATUS_ACTIONS;
 
 const {
+  APPROVALS,
   IS_MOBILE,
   SIDEBAR_TYPE,
   GRAPH_DATA,
@@ -88,6 +90,10 @@ export function AppStatusReducer(state, action) {
   const updatedState = { ...state };
   const now = new Date().getTime();
   switch (action.type) {
+    case SET_APPROVALS: {
+      updatedState[APPROVALS] = action.approvals;
+      break;
+    }
     case SET_IS_MOBILE: {
       updatedState[IS_MOBILE] = action[IS_MOBILE];
       break;
@@ -204,6 +210,7 @@ export const useAppStatus = (defaultState = MOCK_APP_STATUS_STATE) => {
         dispatch({ type: SET_SHOW_TRADING_FORM, showTradingForm }),
       setSidebar: (sidebarType) => dispatch({ type: SET_SIDEBAR, sidebarType }),
       setIsMobile: (isMobile) => dispatch({ type: SET_IS_MOBILE, isMobile }),
+      setApprovals: (approvals) => dispatch({ type: SET_APPROVALS, approvals }),
       updateGraphData: (graphData) =>
         dispatch({ type: UPDATE_GRAPH_DATA, graphData }),
       updateProcessed: (processed) =>

--- a/packages/augur-simplified/src/modules/stores/constants.ts
+++ b/packages/augur-simplified/src/modules/stores/constants.ts
@@ -17,6 +17,7 @@ import { AppStatusState } from '../types';
 
 export const STUBBED_APP_STATUS_ACTIONS = {
   setIsMobile: isMobile => {},
+  setApprovals: approvals => {},
   setSidebar: (sidebarType) => {},
   updateGraphData: graphData => {},
   setShowTradingForm: showTradingForm => {},
@@ -34,6 +35,12 @@ export const STUBBED_APP_STATUS_ACTIONS = {
 
 export const DEFAULT_APP_STATUS_STATE: AppStatusState = {
   isMobile: false,
+  approvals: {
+    trade: {
+      USDC: false,
+      ETH: false,
+    },
+  },
   sidebarType: null,
   loginAccount: null,
   modal: {},
@@ -87,6 +94,7 @@ export const DEFAULT_APP_STATUS_STATE: AppStatusState = {
 };
 
 export const APP_STATE_KEYS = {
+  APPROVALS: 'approvals',
   IS_MOBILE: 'isMobile',
   SIDEBAR_TYPE: 'sidebarType',
   LOGIN_ACCOUNT: 'loginAccount',
@@ -105,6 +113,7 @@ export const APP_STATE_KEYS = {
 };
 
 export const APP_STATUS_ACTIONS = {
+  SET_APPROVALS: 'SET_APPROVALS',
   SET_IS_MOBILE: 'SET_IS_MOBILE',
   SET_SIDEBAR: 'SET_SIDEBAR',
   UPDATE_GRAPH_DATA: 'UPDATE_GRAPH_DATA',

--- a/packages/augur-simplified/src/modules/types.ts
+++ b/packages/augur-simplified/src/modules/types.ts
@@ -1092,6 +1092,12 @@ interface Modal {
 }
 
 export interface AppStatusState {
+  approvals: {
+    trade: {
+      USDC: boolean,
+      ETH: boolean,
+    },
+  },
   processed: ProcessedData,
   loginAccount: LoginAccount,
   userInfo: {


### PR DESCRIPTION
#9962
- first pass at Approval button, Trade (enter)
- added approval info to appStatus store
- TODO: fixing bug where approval state isn't cleared between account switches
- TODO: style updates

<img width="222" alt="Screen Shot 2021-01-06 at 10 49 16 AM" src="https://user-images.githubusercontent.com/1683736/103790659-80c41e00-500f-11eb-84ed-5cc14aa85418.png">
<img width="222" alt="Screen Shot 2021-01-06 at 10 48 58 AM" src="https://user-images.githubusercontent.com/1683736/103790662-81f54b00-500f-11eb-8966-62c681b4ab7c.png">
<img width="222" alt="Screen Shot 2021-01-06 at 10 49 05 AM" src="https://user-images.githubusercontent.com/1683736/103790663-83267800-500f-11eb-9deb-4d60824f4332.png">
