### PR TITLE
Fixed the reset button and some style changes

### DIFF
--- a/packages/augur-simplified/src/modules/constants.ts
+++ b/packages/augur-simplified/src/modules/constants.ts
@@ -207,3 +207,10 @@ export const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 // Modals
 export const MODAL_ADD_LIQUIDITY = 'MODAL_ADD_LIQUIDITY';
+
+export const DEFAULT_MARKET_VIEW_SETTINGS = {
+  categories: ALL_MARKETS,
+  reportingState: OPEN,
+  sortBy: TOTAL_VOLUME,
+  currency: ALL
+};

--- a/packages/augur-simplified/src/modules/sidebar/sidebar.tsx
+++ b/packages/augur-simplified/src/modules/sidebar/sidebar.tsx
@@ -4,7 +4,7 @@ import { CloseIcon } from 'modules/common/icons';
 import { useAppStatusStore } from 'modules/stores/app-status';
 import { PrimaryButton, SecondaryButton } from 'modules/common/buttons';
 import { RadioBarGroup } from 'modules/common/selection';
-import { MARKETS, PORTFOLIO, SIDEBAR_TYPES } from 'modules/constants';
+import {MARKETS, PORTFOLIO, SIDEBAR_TYPES, DEFAULT_MARKET_VIEW_SETTINGS} from 'modules/constants';
 import Logo from 'modules/common/logo';
 import classNames from 'classnames';
 import makePath from 'modules/routes/helpers/make-path';
@@ -40,15 +40,9 @@ const SideBarHeader = ({ header, showLogo }: SideBarHeaderProps) => {
 const FilterSideBar = () => {
   const {
     marketsViewSettings,
-    actions: { updateMarketsViewSettings },
+    actions: { updateMarketsViewSettings, setSidebar },
   } = useAppStatusStore();
-  const { categories, sortBy, reportingState, currency } = marketsViewSettings;
-  const [localSettings, setLocalSettings] = useState({
-    categories,
-    sortBy,
-    reportingState,
-    currency,
-  });
+  const [localSettings, setLocalSettings] = useState(marketsViewSettings);
   return (
     <>
       <SideBarHeader header={'filters'} />
@@ -87,13 +81,13 @@ const FilterSideBar = () => {
         />
       </div>
       <div className={Styles.Footer}>
-        <PrimaryButton
+        <SecondaryButton
           text="reset all"
           action={() => {
-            setLocalSettings({ categories, sortBy, reportingState, currency });
+            setLocalSettings(DEFAULT_MARKET_VIEW_SETTINGS);
           }}
         />
-        <SecondaryButton
+        <PrimaryButton
           text="apply filters"
           action={() => {
             updateMarketsViewSettings({
@@ -102,6 +96,7 @@ const FilterSideBar = () => {
               reportingState: localSettings.reportingState,
               currency: localSettings.currency,
             });
+            setSidebar(null);
           }}
         />
       </div>

--- a/packages/augur-simplified/src/modules/stores/constants.ts
+++ b/packages/augur-simplified/src/modules/stores/constants.ts
@@ -9,10 +9,10 @@ import {
   BUY,
   SELL,
   USDC,
+  DEFAULT_MARKET_VIEW_SETTINGS,
 } from 'modules/constants';
 import { createBigNumber } from 'utils/create-big-number';
 import { formatDai } from 'utils/format-number';
-import { ALL, ALL_MARKETS, OPEN, TOTAL_VOLUME } from 'modules/constants';
 import { AppStatusState } from '../types';
 
 export const STUBBED_APP_STATUS_ACTIONS = {
@@ -47,12 +47,7 @@ export const DEFAULT_APP_STATUS_STATE: AppStatusState = {
   showTradingForm: false,
   marketInfos: {},
   transactions: [],
-  marketsViewSettings: {
-    categories: ALL_MARKETS,
-    reportingState: OPEN,
-    sortBy: TOTAL_VOLUME,
-    currency: ALL
-  },
+  marketsViewSettings: DEFAULT_MARKET_VIEW_SETTINGS,
   paraConfig: { addresses: {}, paraDeploys: {}},
   processed: {
     markets: {},


### PR DESCRIPTION
#9941 

Also:
- Switched reset/apply buttons primary/secondary style. It was reversed.
- Added close action when you apply something (talked to Matt about it).
- Reset filter now resets to the filters "selected by default", instead of "previously selected" (talked to Matt about it).