### PR TITLE
Add/remove liquidity market share avg price

### DIFF
--- a/packages/augur-simplified/src/modules/apollo/queries.ts
+++ b/packages/augur-simplified/src/modules/apollo/queries.ts
@@ -126,6 +126,8 @@ export const GET_MARKETS = blockNumber => {
         cash
         cashValue
         lpTokens
+        noShareCashValue
+        yesShareCashValue
       }
       removeLiquidity {
         id
@@ -138,6 +140,8 @@ export const GET_MARKETS = blockNumber => {
         noShares
         cash
         cashValue
+        noShareCashValue
+        yesShareCashValue
       }
     }
   }

--- a/packages/augur-simplified/src/modules/common/tables.tsx
+++ b/packages/augur-simplified/src/modules/common/tables.tsx
@@ -229,14 +229,14 @@ const LiquidityRow = ({ liquidity, amm }: { liquidity: LPTokenBalance, amm: AmmE
   const [earnedFees, setEarnedFees] = useState(null);
   useEffect(() => {
     let isMounted = true;
-    const getInitValue = async (balance: string, amm: AmmExchange) => {
+    const getCurrentValue = async (balance: string, amm: AmmExchange) => {
       const value = await getLPCurrentValue(balance, amm);
       if (isMounted) {
         setInitValue(value);
         setEarnedFees(createBigNumber(value).minus(createBigNumber(liquidity.initCostUsd)));
       }
     }
-    getInitValue(liquidity.balance, amm);
+    getCurrentValue(liquidity.balance, amm);
     return () => isMounted = false;
   }, [])
   return (

--- a/packages/augur-simplified/src/modules/common/tables.tsx
+++ b/packages/augur-simplified/src/modules/common/tables.tsx
@@ -1,11 +1,11 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import Styles from 'modules/common/tables.styles.less';
 import { EthIcon, UsdIcon } from './icons';
 import {
   PrimaryButton,
   SecondaryButton,
   TinyButton,
-} from 'modules/common/buttons';
+} from '../common/buttons';
 import classNames from 'classnames';
 import {
   POSITIONS,
@@ -14,8 +14,8 @@ import {
   ADD,
   REMOVE,
   SWAP,
-} from 'modules/constants';
-import { Pagination } from 'modules/common/pagination';
+} from '../constants';
+import { Pagination } from '../common/pagination';
 import { SmallDropdown } from './selection';
 import {
   AmmExchange,
@@ -32,6 +32,8 @@ import { MODAL_ADD_LIQUIDITY, USDC } from '../constants';
 import { useAppStatusStore } from '../stores/app-status';
 import { AddressLink, MarketLink } from '../routes/helpers/links';
 import { sliceByPage } from './pagination';
+import { getLPCurrentValue } from '../../utils/contract-calls';
+import { createBigNumber } from '../../utils/create-big-number';
 
 interface PositionsTableProps {
   market: MarketInfo;
@@ -222,17 +224,27 @@ const LiquidityHeader = () => {
   );
 };
 
-const LiquidityRow = ({ liquidity }: { liquidity: LPTokenBalance }) => {
+const LiquidityRow = ({ liquidity, amm }: { liquidity: LPTokenBalance, amm: AmmExchange }) => {
+  const [currValue, setInitValue] = useState(null);
+  const [earnedFees, setEarnedFees] = useState(null);
+  useEffect(() => {
+    let isMounted = true;
+    const getInitValue = async (balance: string, amm: AmmExchange) => {
+      const value = await getLPCurrentValue(balance, amm);
+      if (isMounted) {
+        setInitValue(value);
+        setEarnedFees(createBigNumber(value).minus(createBigNumber(liquidity.initCostUsd)));
+      }
+    }
+    getInitValue(liquidity.balance, amm);
+    return () => isMounted = false;
+  }, [])
   return (
     <ul className={Styles.LiquidityRow}>
       <li>{formatDai(liquidity.balance).formatted}</li>
       <li>{formatDai(liquidity.initCostUsd).full}</li>
-      <li>{liquidity.usdValue ? formatDai(liquidity.usdValue).full : '-'}</li>
-      <li>
-        {
-          '-' /*liquidity.feesEarned ? formatDai(liquidity.feesEarned).full : '-'*/
-        }
-      </li>
+      <li>{currValue ? formatDai(currValue).full : '-'}</li>
+      <li>{currValue ? formatDai(earnedFees).full : '-'}</li>
     </ul>
   );
 };
@@ -336,7 +348,7 @@ export const LiquidityTable = ({
           />
         </span>
       )}
-      {lpTokens && <LiquidityRow liquidity={lpTokens} />}
+      {lpTokens && <LiquidityRow liquidity={lpTokens} amm={ammExchange} />}
       {lpTokens && <LiquidityFooter market={market} />}
     </div>
   );

--- a/packages/augur-simplified/src/modules/types.ts
+++ b/packages/augur-simplified/src/modules/types.ts
@@ -116,8 +116,7 @@ export interface AmmTransaction {
   sender: string,
   timestamp: string,
   tx_hash: string,
-  price: string | null,
-
+  price?: string,
   value: string,
   subheader: string,
   date: string,
@@ -129,6 +128,7 @@ export interface AmmTransaction {
   lpTokens?: string,
   yesShareCashValue?: string,
   noShareCashValue?: string
+  cashValue?: string, // for add/remove liquidity
 }
 
 export interface Trade {

--- a/packages/augur-simplified/src/modules/types.ts
+++ b/packages/augur-simplified/src/modules/types.ts
@@ -127,6 +127,8 @@ export interface AmmTransaction {
   tokenAmount: string,
   cashValueUsd?: string,
   lpTokens?: string,
+  yesShareCashValue?: string,
+  noShareCashValue?: string
 }
 
 export interface Trade {

--- a/packages/augur-simplified/src/utils/contract-calls.ts
+++ b/packages/augur-simplified/src/utils/contract-calls.ts
@@ -794,7 +794,7 @@ const getPositionUsdValues = (trades: UserTrades, rawBalance: string, balance: s
   }
 }
 
-const getLPCurrentValue = async (displayBalance: string, amm: AmmExchange): Promise<string> => {
+export const getLPCurrentValue = async (displayBalance: string, amm: AmmExchange): Promise<string> => {
   const usdPrice = amm.cash?.usdPrice ? amm.cash?.usdPrice : "0";
   const { marketId, cash, feeRaw, priceNo, priceYes } = amm;
   const estimate = await getRemoveLiquidity(marketId, cash, feeRaw, displayBalance)

--- a/packages/augur-simplified/src/utils/contract-calls.ts
+++ b/packages/augur-simplified/src/utils/contract-calls.ts
@@ -874,12 +874,12 @@ const accumLpSharesPrice = (transactions: AmmTransaction[], isYesOutcome: boolea
     if (isYesOutcome) {
       const netYesShares = noShares.minus(yesShares)
       if (netYesShares.lte(new BN(0))) return p;
-      const price = netYesShares.div(new BN(t.yesShareCashValue));
+      const price = (new BN(t.cash).minus(new BN(t.cashValue))).div(netYesShares);
       return { shares: p.shares.plus(netYesShares), price: p.price.plus(price), count: p.count.plus(1) }
     }
     const netNoShares = yesShares.minus(noShares)
     if (netNoShares.lte(new BN(0))) return p;
-    const price = netNoShares.div(new BN(t.noShareCashValue));
+    const price = (new BN(t.cash).minus(new BN(t.cashValue))).div(netNoShares);
     return { shares: p.shares.plus(netNoShares), price: p.price.plus(price), count: p.count.plus(1) }
   },
     { shares: new BN(0), price: new BN(0), count: new BN(0) });

--- a/packages/augur-simplified/src/utils/process-data.ts
+++ b/packages/augur-simplified/src/utils/process-data.ts
@@ -46,11 +46,15 @@ interface GraphAddLiquidity extends GraphTransaction {
   ammExchange: GraphAmmExchange,
   cashValue: string,
   lpTokens: string,
+  yesShareCashValue: string,
+  noShareCashValue: string
 }
 
 interface GraphRemoveLiquidity extends GraphTransaction {
   ammExchange: GraphAmmExchange,
   cashValue: string,
+  yesShareCashValue: string,
+  noShareCashValue: string
 }
 
 interface GraphAmmExchange {


### PR DESCRIPTION
<https://github.com/AugurProject/augur/issues/9949> 

Update LP token table to only call getRemoveLiquidity on first render instead of each block. 
Include add/remove liquidity logs when calculating average price of user's position.
