### PR TITLE
on create always set price, different from add

### DIFF
--- a/packages/augur-simplified/src/modules/modal/modal-add-liquidity.tsx
+++ b/packages/augur-simplified/src/modules/modal/modal-add-liquidity.tsx
@@ -176,7 +176,7 @@ const ModalAddLiquidity = ({
   const account = loginAccount?.account;
 
   let amm = market?.amm;
-  const mustSetPrices =
+  const mustSetPrices = liquidityModalType === CREATE ||
     !amm || amm?.liquidity === undefined || amm?.liquidity === '0';
   const modalType = liquidityModalType;
 


### PR DESCRIPTION
On create always set price, different from add. This scenario the market already has an AMM and user wants to create a new AMM in different cash