### PR TITLE
minor clean up to add liquidity, format cash logic

### DIFF
--- a/packages/augur-simplified/src/modules/market/trading-form.tsx
+++ b/packages/augur-simplified/src/modules/market/trading-form.tsx
@@ -562,8 +562,8 @@ const TradingForm = ({
             from: loginAccount.account,
             addedTime: new Date().getTime(),
             message: `${
-              direction === TradingDirection.ENTRY ? 'Enter' : 'Exit'
-            } Trade`,
+              direction === TradingDirection.ENTRY ? 'Buy' : 'Sell'
+            } Shares`,
             marketDescription: amm?.market?.description,
           });
           response

--- a/packages/augur-simplified/src/modules/market/trading-form.tsx
+++ b/packages/augur-simplified/src/modules/market/trading-form.tsx
@@ -159,6 +159,7 @@ interface AmountInputProps {
   amountError?: string;
   updateAmountError?: Function;
   ammCash: Cash;
+  isBuy?: boolean;
 }
 
 export const AmountInput = ({
@@ -171,6 +172,7 @@ export const AmountInput = ({
   rate,
   ammCash,
   updateAmountError = () => {},
+  isBuy = true,
 }: AmountInputProps) => {
   const { isLogged } = useAppStatusStore();
   const currencyName = chosenCash;
@@ -202,7 +204,7 @@ export const AmountInput = ({
     >
       <span>amount</span>
       <span onClick={setMax}>
-        {isLogged && `balance: ${formatCash(maxValue, ammCash).full}`}
+        {isLogged && `balance: ${isBuy ? formatCash(maxValue, ammCash).full : formatSimpleShares(maxValue).formatted}`}
       </span>
       <div
         className={classNames(Styles.AmountInputDropdown, {
@@ -627,6 +629,7 @@ const TradingForm = ({
               ? `1 ${amm?.cash?.name} = ${formatSimpleShares(breakdown?.ratePerCash).full}`
               : null
           }
+          isBuy={orderType === BUY}
         />
         <InfoNumbers infoNumbers={formatBreakdown(isBuy, breakdown, ammCash)} />
         {isLogged && !isApprovedTrade && (

--- a/packages/augur-simplified/src/modules/modal/modal-add-liquidity.tsx
+++ b/packages/augur-simplified/src/modules/modal/modal-add-liquidity.tsx
@@ -39,6 +39,7 @@ import { MultiButtonSelection } from '../common/selection';
 import classNames from 'classnames';
 import {
   AmmOutcome,
+  LiquidityBreakdown,
   MarketInfo,
 } from '../types';
 import {
@@ -75,7 +76,7 @@ const TRADING_FEE_OPTIONS = [
   },
 ];
 
-const defaultAddLiquidityBreakdown = {
+const defaultAddLiquidityBreakdown: LiquidityBreakdown = {
   yesShares: '0',
   noShares: '0',
   lpTokens: '0',
@@ -609,13 +610,13 @@ const ModalAddLiquidity = ({
               )}
               <AmountInput
                 updateInitialAmount={(amount) => updateAmount(amount)}
-                initialAmount={amount}
+                initialAmount={''}
                 maxValue={userMaxAmount}
                 showCurrencyDropdown={!currency}
                 chosenCash={modalType === REMOVE ? SHARES : chosenCash}
                 updateCash={updateCash}
                 updateAmountError={() => null}
-                ammCash={amm?.cash}
+                ammCash={cash}
               />
             </>
           )}

--- a/packages/augur-simplified/src/modules/types.ts
+++ b/packages/augur-simplified/src/modules/types.ts
@@ -1148,6 +1148,7 @@ export interface LiquidityBreakdown {
   yesShares: string;
   noShares: string;
   cashAmount: string;
+  lpTokens?: string;
 }
 export interface AddLiquidityBreakdown extends LiquidityBreakdown {
   lpTokens: string;

--- a/packages/augur-simplified/src/utils/format-number.ts
+++ b/packages/augur-simplified/src/utils/format-number.ts
@@ -11,6 +11,7 @@ import {
   GWEI_CONVERSION,
   SCALAR,
   TEN,
+  USDC,
   ZERO,
 } from '../modules/constants';
 import addCommas from './add-commas-to-number';
@@ -32,7 +33,7 @@ export function formatCash(num: NumStrBigNumber, cash: Cash, opts: FormattedNumb
   return formatNumber(num, {
     decimals: cash.displayDecimals,
     decimalsRounded: cash.displayDecimals,
-    denomination: v => cash.usdPrice === "1" ? `$${v}` : `${v} ${cash.name}`,
+    denomination: v => cash.name === USDC ? `$${v}` : `${v} ${cash.name}`,
     positiveSign: false,
     zeroStyled: false,
     blankZero: false,


### PR DESCRIPTION
clean up on add liquidity when user clicks on 'Create this market in ...' from market page, need to pass in cash not amm?.cash, and can not rely on USDC being 1 usd"
![Screen Shot 2021-01-20 at 20 15 28](https://user-images.githubusercontent.com/3970376/105271164-a8150200-5b5c-11eb-9cb5-edd49f7631dc.png)


![Screen Shot 2021-01-20 at 20 10 35](https://user-images.githubusercontent.com/3970376/105271205-b7944b00-5b5c-11eb-89ee-b5ae824aefbc.png)
