### PR TITLE
multicall collection needs a unique key, needed to add share token address.

### DIFF
--- a/packages/augur-simplified/src/utils/contract-calls.ts
+++ b/packages/augur-simplified/src/utils/contract-calls.ts
@@ -555,7 +555,7 @@ export const getUserBalances = async (
         (k, shareToken) => {
           // TODO: might need to change when scalars come in
           const outcomeShareBalances = [0, 1, 2].map((outcome) => ({
-            reference: `${marketId}-${outcome}`,
+            reference: `${shareToken}-${marketId}-${outcome}`,
             contractAddress: shareToken,
             abi: ParaShareToken.ABI,
             calls: [


### PR DESCRIPTION
contract calls were getting overridden because key wasn't unique in collection

<https://github.com/AugurProject/augur/issues/10338> 