### PR TITLE
check approval every-time, don't relay on local state

### DIFF
--- a/packages/augur-simplified/src/modules/common/buttons.tsx
+++ b/packages/augur-simplified/src/modules/common/buttons.tsx
@@ -149,14 +149,18 @@ export const DirectionButton = ({
   </button>
 );
 
-const {
+export const {
   ADD_LIQUIDITY,
   REMOVE_LIQUIDITY,
   ENTER_POSITION,
   EXIT_POSITION,
 } = ApprovalAction;
 
-const { UNKNOWN, PENDING, APPROVED } = ApprovalState;
+export const {
+  UNKNOWN,
+  PENDING,
+  APPROVED,
+} = ApprovalState;
 
 export const ApprovalButton = ({
   amm,
@@ -172,10 +176,9 @@ export const ApprovalButton = ({
 
   const {
     loginAccount,
-    approvals,
     paraConfig,
     transactions,
-    actions: { addTransaction, setApprovals, updateTransaction },
+    actions: { addTransaction, updateTransaction }
   } = useAppStatusStore();
 
   const marketCashType = cash?.name;
@@ -332,64 +335,12 @@ export const ApprovalButton = ({
 
     if (isApproved !== APPROVED && loginAccount?.account) {
       checkIfApproved();
-    } else {
-      if (
-        approvals &&
-        ((actionType === ENTER_POSITION &&
-          !approvals?.trade?.enter[marketCashType]) ||
-          (actionType === EXIT_POSITION &&
-            !approvals?.trade?.exit[marketCashType]) ||
-          (actionType === ADD_LIQUIDITY &&
-            !approvals?.liquidity?.add[marketCashType]) ||
-          (actionType === REMOVE_LIQUIDITY &&
-            !approvals?.liquidity?.remove[marketCashType]))
-      ) {
-        let newState = approvals;
-        switch (actionType) {
-          case ENTER_POSITION: {
-            newState.trade.enter[marketCashType] = true;
-            break;
-          }
-          case EXIT_POSITION: {
-            newState.trade.exit[marketCashType] = true;
-            break;
-          }
-          case ADD_LIQUIDITY: {
-            newState.liquidity.add[marketCashType] = true;
-            break;
-          }
-          case REMOVE_LIQUIDITY: {
-            newState.liquidity.remove[marketCashType] = true;
-            break;
-          }
-          default: {
-            break;
-          }
-        }
-        isMounted && setApprovals(newState);
-      }
     }
     return () => {
       isMounted = false;
-    };
-  }, [
-    setApprovals,
-    loginAccount,
-    isApproved,
-    actionType,
-    amm,
-    paraConfig,
-    tokenAddress,
-    approvals,
-    transactions,
-    AMMFactory,
-    WethWrapperForAMMExchange,
-    cash?.address,
-    isETH,
-    marketCashType,
-    shareToken,
-    updateTransaction,
-  ]);
+    }
+  }, [loginAccount, isApproved, actionType, amm, paraConfig, tokenAddress, transactions, AMMFactory, WethWrapperForAMMExchange, cash?.address, isETH, marketCashType, shareToken, updateTransaction]);
+
 
   if (!loginAccount || isApproved === APPROVED) {
     return null;

--- a/packages/augur-simplified/src/modules/stores/app-status-hooks.ts
+++ b/packages/augur-simplified/src/modules/stores/app-status-hooks.ts
@@ -16,7 +16,6 @@ import {
 
 const {
   SET_SHOW_TRADING_FORM,
-  SET_APPROVALS,
   SET_IS_MOBILE,
   SET_SIDEBAR,
   SET_LOGIN_ACCOUNT,
@@ -34,7 +33,6 @@ const {
 } = APP_STATUS_ACTIONS;
 
 const {
-  APPROVALS,
   IS_MOBILE,
   SIDEBAR_TYPE,
   GRAPH_DATA,
@@ -137,10 +135,6 @@ export function AppStatusReducer(state, action) {
   const now = new Date().getTime();
 
   switch (action.type) {
-    case SET_APPROVALS: {
-      updatedState[APPROVALS] = action.approvals;
-      break;
-    }
     case SET_IS_MOBILE: {
       updatedState[IS_MOBILE] = action[IS_MOBILE];
       break;
@@ -161,28 +155,6 @@ export function AppStatusReducer(state, action) {
       updatedState[IS_LOGGED] = false;
       updatedState[TRANSACTIONS] = [];
       updatedState[LOGIN_ACCOUNT] = null;
-      updatedState[APPROVALS] = {
-        trade: {
-          enter: {
-            USDC: false,
-            ETH: false,
-          },
-          exit: {
-            USDC: false,
-            ETH: false,
-          },
-        },
-        liquidity: {
-          add: {
-            USDC: false,
-            ETH: false
-          },
-          remove: {
-            USDC: false,
-            ETH: false
-          },
-        },
-      };
       updatedState[USER_INFO] = DEFAULT_APP_STATUS_STATE.userInfo
       break;
     }
@@ -324,7 +296,6 @@ export const useAppStatus = (defaultState = MOCK_APP_STATUS_STATE) => {
         dispatch({ type: SET_SHOW_TRADING_FORM, showTradingForm }),
       setSidebar: (sidebarType) => dispatch({ type: SET_SIDEBAR, sidebarType }),
       setIsMobile: (isMobile) => dispatch({ type: SET_IS_MOBILE, isMobile }),
-      setApprovals: (approvals) => dispatch({ type: SET_APPROVALS, approvals }),
       updateLoginAccount: (account) =>
         dispatch({ type: SET_LOGIN_ACCOUNT, account }),
       updateUserBalances: (userBalances: UserBalances) =>

--- a/packages/augur-simplified/src/modules/stores/constants.ts
+++ b/packages/augur-simplified/src/modules/stores/constants.ts
@@ -10,7 +10,6 @@ import { AppStatusState } from '../types';
 
 export const STUBBED_APP_STATUS_ACTIONS = {
   setIsMobile: isMobile => {},
-  setApprovals: approvals => {},
   setSidebar: sidebarType => {},
   setShowTradingForm: showTradingForm => {},
   updateGraphHeartbeat: (processed, graphData, blocknumber) => {},
@@ -30,28 +29,6 @@ export const STUBBED_APP_STATUS_ACTIONS = {
 export const DEFAULT_APP_STATUS_STATE: AppStatusState = {
   isMobile: false,
   blocknumber: null,
-  approvals: {
-    trade: {
-      enter: {
-        USDC: false,
-        ETH: false,
-      },
-      exit: {
-        USDC: false,
-        ETH: false,
-      },
-    },
-    liquidity: {
-      add: {
-        USDC: false,
-        ETH: false
-      },
-      remove: {
-        USDC: false,
-        ETH: false
-      },
-    },
-  },
   sidebarType: null,
   loginAccount: null,
   isLogged: false,
@@ -100,7 +77,6 @@ export const DEFAULT_APP_STATUS_STATE: AppStatusState = {
 };
 
 export const APP_STATE_KEYS = {
-  APPROVALS: 'approvals',
   IS_MOBILE: 'isMobile',
   SIDEBAR_TYPE: 'sidebarType',
   LOGIN_ACCOUNT: 'loginAccount',
@@ -120,7 +96,6 @@ export const APP_STATE_KEYS = {
 };
 
 export const APP_STATUS_ACTIONS = {
-  SET_APPROVALS: 'SET_APPROVALS',
   SET_IS_MOBILE: 'SET_IS_MOBILE',
   SET_SIDEBAR: 'SET_SIDEBAR',
   UPDATE_GRAPH_DATA: 'UPDATE_GRAPH_DATA',

--- a/packages/augur-simplified/src/modules/types.ts
+++ b/packages/augur-simplified/src/modules/types.ts
@@ -1105,28 +1105,6 @@ export interface Settings {
   showInvalidMarkets: boolean;
 }
 export interface AppStatusState {
-  approvals: {
-    liquidity: {
-      add: {
-        USDC: boolean;
-        ETH: boolean;
-      };
-      remove: {
-        USDC: boolean;
-        ETH: boolean;
-      };
-    };
-    trade: {
-      enter: {
-        USDC: boolean;
-        ETH: boolean;
-      };
-      exit: {
-        USDC: boolean;
-        ETH: boolean;
-      };
-    };
-  };
   processed: ProcessedData;
   graphData: GraphData;
   loginAccount: LoginAccount;


### PR DESCRIPTION
fixes #10377 

- remove approval from appStatus
- always check approvals since approvals can be revoked 
- fixes bugs we had related to button not disapearing afater approval