### PR TITLE
calculate winnings based on share balances instead of using usd value

### DIFF
--- a/packages/augur-simplified/src/modules/apollo/queries.ts
+++ b/packages/augur-simplified/src/modules/apollo/queries.ts
@@ -152,6 +152,7 @@ export const GET_MARKETS = blockNumber => {
         lpTokens
         noShareCashValue
         yesShareCashValue
+        netShares
       }
       removeLiquidity {
         id

--- a/packages/augur-simplified/src/modules/types.ts
+++ b/packages/augur-simplified/src/modules/types.ts
@@ -132,6 +132,7 @@ export interface AmmTransaction {
   yesShareCashValue?: string;
   noShareCashValue?: string;
   cashValue?: string; // for add/remove liquidity
+  netShares?: string; // only for add liquidity
 }
 
 export interface Trade {

--- a/packages/augur-simplified/src/utils/contract-calls.ts
+++ b/packages/augur-simplified/src/utils/contract-calls.ts
@@ -712,7 +712,8 @@ const populateClaimableWinnings = (finalizedMarkets: MarketInfos = {}, finalized
       if (userShares && new BN(userShares?.rawBalance).gt(0)) {
         // for yesNo and categoricals user would get 1 cash for each share
         // TODO: figure out scalars when the time comes
-        const claimableBalance = String(new BN(userShares.maxUsdValue).minus(new BN(userShares.initCostUsd)).toFixed(4));
+        const maxValue = Math.ceil(Number(userShares.balance));
+        const claimableBalance = (new BN(maxValue).minus(new BN(userShares.balance))).toFixed(4);
         marketShares[amm.id].claimableWinnings = {
           claimableBalance,
           sharetoken: amm.cash.shareToken,

--- a/packages/augur-simplified/src/utils/process-data.ts
+++ b/packages/augur-simplified/src/utils/process-data.ts
@@ -88,6 +88,7 @@ interface GraphAddLiquidity extends GraphTransaction {
   lpTokens: string;
   yesShareCashValue: string;
   noShareCashValue: string;
+  netShares: string;
 }
 
 interface GraphRemoveLiquidity extends GraphTransaction {
@@ -464,6 +465,12 @@ const shapeAddLiquidityTransactions = (
         new BN(cash.decimals)
       )
     );
+    const netShares = String(
+      convertOnChainSharesToDisplayShareAmount(
+        new BN(e.netShares),
+        new BN(cash.decimals)
+      )
+    );
     return {
       ...e,
       tx_type: TransactionTypes.ADD_LIQUIDITY,
@@ -474,6 +481,7 @@ const shapeAddLiquidityTransactions = (
       cashValueUsd,
       value: cashValueUsd,
       lpTokens,
+      netShares
     };
   });
 };


### PR DESCRIPTION
claim winnings was in USD value for ETH and USDC, needed to be in cash.

![Screen Shot 2021-02-03 at 13 24 40](https://user-images.githubusercontent.com/3970376/106798871-32ad3500-6624-11eb-8115-1bd17771f23f.png)


<https://github.com/AugurProject/augur/issues/10504>