### PR TITLE
update-formatDai-and-movementlabel

### DIFF
--- a/packages/augur-simplified/src/modules/common/labels.tsx
+++ b/packages/augur-simplified/src/modules/common/labels.tsx
@@ -466,7 +466,7 @@ export const MovementLabel = ({ value, numberValue }: MovementLabelProps) => {
   const textColorStyle = getTextColorStyles(numberValue);
 
   const handlePlusMinus: Function = (label: string): string => {
-    if (numberValue > 0) {
+    if (numberValue >= 0.01) {
       return '+'.concat(label);
     }
     return label;

--- a/packages/augur-simplified/src/utils/format-number.ts
+++ b/packages/augur-simplified/src/utils/format-number.ts
@@ -208,12 +208,13 @@ export function formatBestPrice(
     decimalsRounded: decimals,
     denomination: v => {
       const isNegative = Number(v) < 0;
+      const formattedNegative = createBigNumber(createBigNumber(v).toFixed(2)).lt(0);
       const val = isNegative
         ? createBigNumber(v)
           .abs()
           .toFixed(2)
         : v;
-      return `${isNegative ? '-' : ''}${val}`;
+      return `${formattedNegative ? '-' : ''}${val}`;
     },
     positiveSign: false,
     zeroStyled: false,


### PR DESCRIPTION
updated the logic for formatDai denomination to only add a - sign if the formatted value would be less than 0.00. updated movement label logic to only add a + sign if the value is greater than or equal to 0.01 instead of greater than 0 to prevent display of `+$0.00` for example if the value was a positive fraction of a penny.

https://github.com/AugurProject/augur/issues/10565