### PR TITLE
fix-bad-input

### DIFF
--- a/packages/augur-simplified/src/modules/common/inputs.styles.less
+++ b/packages/augur-simplified/src/modules/common/inputs.styles.less
@@ -150,12 +150,6 @@
     color: var(--simple-primary-text);
   }
 
-  &.showCurrencyDropdown {
-    > input {
-      margin-right: @size-80;
-    }
-  }
-
   &.Error {
     border: @size-1 solid var(--simple-failed);
   }


### PR DESCRIPTION
removed margin on amount input with currency dropdown as it was unintentionally shortening the input display.