### PR TITLE
fix provider error on wallet switch

### DIFF
--- a/packages/augur-simplified/src/modules/common/top-nav.tsx
+++ b/packages/augur-simplified/src/modules/common/top-nav.tsx
@@ -262,14 +262,6 @@ export const TopNav = () => {
       ) {
         logout();
         updateLoginAccount(activeWeb3);
-
-        // TEMPORARY WORKAROUND - MM provider broken on account change
-        const isMetaMask = activeWeb3?.library?.provider?.isMetaMask;
-        if (isMetaMask) {
-          // When we detect a MM account chanage we call updateLoginAccount in order to update the lastUser localStorage
-          // key with the users new selected account and refresh the page to reload the provider using autologin
-          window.location.reload();
-        }
       } else {
         updateLoginAccount(activeWeb3);
       }

--- a/packages/augur-simplified/src/modules/stores/user-hooks.ts
+++ b/packages/augur-simplified/src/modules/stores/user-hooks.ts
@@ -3,6 +3,7 @@ import { useReducer } from 'react';
 import { windowRef } from '../../utils/window-ref';
 import { USER_ACTIONS, USER_KEYS, DEFAULT_USER_STATE } from './constants';
 import { UserBalances, TransactionDetails } from '../types';
+import { augurSdkLite } from '../../utils/augurlitesdk';
 
 const {
   ADD_TRANSACTION,
@@ -52,6 +53,7 @@ export function UserReducer(state, action) {
 
   switch (action.type) {
     case LOGOUT: {
+      augurSdkLite.destroy();
       window.localStorage.setItem('lastUser', null);
       updatedState = { ...DEFAULT_USER_STATE };
       break;

--- a/packages/augur-simplified/src/modules/stores/utils.ts
+++ b/packages/augur-simplified/src/modules/stores/utils.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { APPROVED } from '../common/buttons';
 import {
   checkAllowance,
@@ -77,6 +77,7 @@ export function useCanExitCashPosition(shareToken) {
     transactions,
     actions: { updateTransaction },
   } = useUserStore();
+  const approvedAccount = useRef(null);
   const [canExitPosition, setCanExitPosition] = useState(false);
   const {
     addresses: { WethWrapperForAMMExchange },
@@ -91,8 +92,9 @@ export function useCanExitCashPosition(shareToken) {
         updateTransaction
       );
       setCanExitPosition(Boolean(approvalCheck));
+      if (Boolean(approvalCheck)) approvedAccount.current = loginAccount.account;
     };
-    if (!!account && !!shareToken) {
+    if (!!account && !!shareToken && account !== approvedAccount.current) {
       checkCanCashExit();
     }
   }, [
@@ -113,6 +115,7 @@ export function useCanEnterCashPosition({ name, address }: Cash) {
     transactions,
     actions: { updateTransaction },
   } = useUserStore();
+  const approvedAccount = useRef(null);
   const [canEnterPosition, setCanEnterPosition] = useState(name === ETH);
   const {
     addresses: { AMMFactory },
@@ -126,9 +129,10 @@ export function useCanEnterCashPosition({ name, address }: Cash) {
         transactions,
         updateTransaction
       );
-      setCanEnterPosition(approvalCheck === APPROVED);
+      setCanEnterPosition(approvalCheck === APPROVED || name === ETH);
+      if (approvalCheck === APPROVED || name === ETH) approvedAccount.current = loginAccount.account;
     };
-    if (!!account && !!address) {
+    if (!!account && !!address && account !== approvedAccount.current) {
       checkCanCashEnter();
     }
   }, [

--- a/packages/augur-simplified/src/modules/stores/utils.ts
+++ b/packages/augur-simplified/src/modules/stores/utils.ts
@@ -92,7 +92,7 @@ export function useCanExitCashPosition(shareToken) {
       );
       setCanExitPosition(Boolean(approvalCheck));
     };
-    if (!!account && !canExitPosition && !!shareToken) {
+    if (!!account && !!shareToken) {
       checkCanCashExit();
     }
   }, [
@@ -128,7 +128,7 @@ export function useCanEnterCashPosition({ name, address }: Cash) {
       );
       setCanEnterPosition(approvalCheck === APPROVED);
     };
-    if (!!account && !canEnterPosition && !!address) {
+    if (!!account && !!address) {
       checkCanCashEnter();
     }
   }, [


### PR DESCRIPTION

- fixes issue where switching between two accounts (MM / Portis) would result in the SDK still using the first wallet provider

- also updated `useCanExitCashPosition/useCanEnterCashPosition` to always check for approval -- switching from a wallet that is `APPROVED` to a wallet that is `NOT APPROVED` would always return true since we don't reset the hook state between wallet switching.