### PR TITLE
Prevents safari from stretching market cards when there's 1 row

### DIFF
--- a/packages/augur-simplified/src/modules/markets/markets-view.styles.less
+++ b/packages/augur-simplified/src/modules/markets/markets-view.styles.less
@@ -44,6 +44,7 @@
     display: grid;
     grid-gap: @size-24;
     grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(3, 0fr);
     flex: 1;
     margin-bottom: @size-40;
     margin-top: @size-24;


### PR DESCRIPTION
#10680 