### PR TITLE
added amount of liquidity will go to invalid pool in add liquidity mo…

### DIFF
--- a/packages/augur-simplified/src/modules/constants.ts
+++ b/packages/augur-simplified/src/modules/constants.ts
@@ -49,6 +49,7 @@ export const TRILLION = BILLION.times(THOUSAND);
 export const DAYS_IN_YEAR = createBigNumber(365);
 export const SEC_IN_DAY = createBigNumber(86400);
 export const PORTION_OF_INVALID_POOL_SELL = createBigNumber(0.5);
+export const PORTION_OF_CASH_INVALID_POOL = createBigNumber(0.1);
 
 // # Asset Types
 export const ETH = 'ETH';

--- a/packages/augur-simplified/src/modules/modal/modal-add-liquidity.tsx
+++ b/packages/augur-simplified/src/modules/modal/modal-add-liquidity.tsx
@@ -23,6 +23,7 @@ import {
   ONE,
   ERROR_AMOUNT,
   ETH,
+  PORTION_OF_CASH_INVALID_POOL,
 } from '../constants';
 import {
   InfoNumbers,
@@ -390,7 +391,7 @@ const ModalAddLiquidity = ({
     },
   ];
 
-  const invalidCashAmount = formatCash(0, cash?.name).full;
+  const invalidCashAmount = formatCash(createBigNumber(amount === '' ? "0" : amount).times(PORTION_OF_CASH_INVALID_POOL), cash?.name).full;
 
   const confirmAction = async () => {
     const properties = checkConvertLiquidityProperties(
@@ -604,7 +605,7 @@ const ModalAddLiquidity = ({
         ],
       },
       footerText:
-        "By adding initial liquidity you'll earn your set trading fee percentage of all trades on this market proportional to your share of the pool. Fees are added to the pool, accrue in real time and can be claimed by withdrawing your liquidity.",
+        `By adding initial liquidity you'll earn your set trading fee percentage of all trades on this market proportional to your share of the pool. Fees are added to the pool, accrue in real time and can be claimed by withdrawing your liquidity. ${invalidCashAmount} will be added to the invalid balancer pool.`,
       breakdown: addCreateBreakdown,
       approvalButtonText: `approve ${chosenCash}`,
       confirmOverview: {


### PR DESCRIPTION
…dal footer
<https://github.com/AugurProject/augur/issues/10751> 
10% of what the user is adding to liquidity will go to invalid pool

default view
![image](https://user-images.githubusercontent.com/3970376/109835923-45a62b80-7c09-11eb-8799-1e1af516825f.png)


user fills in amount
![image](https://user-images.githubusercontent.com/3970376/109835989-59519200-7c09-11eb-8925-afcfe48c1024.png)
