### PR TITLE
winning-for-finalized-only

### DIFF
--- a/packages/augur-comps/src/components/market-card/market-card.tsx
+++ b/packages/augur-comps/src/components/market-card/market-card.tsx
@@ -81,9 +81,11 @@ export const outcomesToDisplay = (
 const OutcomesTable = ({
   amm,
   marketOutcomes,
+  reportingState,
 }: {
   amm: AmmExchange;
   marketOutcomes: MarketOutcome[];
+  reportingState: string;
 }) => (
   <div
     className={classNames(Styles.OutcomesTable, {
@@ -92,7 +94,7 @@ const OutcomesTable = ({
   >
     {outcomesToDisplay(amm.ammOutcomes, marketOutcomes).map((outcome) => {
       const isWinner =
-        outcome.isFinalNumerator && outcome.payoutNumerator !== '0';
+        outcome.isFinalNumerator && outcome.payoutNumerator !== '0' && reportingState === MARKET_STATUS.FINALIZED;
       return (
         <div
           key={`${outcome.name}-${amm?.marketId}-${outcome.id}`}
@@ -178,7 +180,7 @@ export const MarketCardView = ({
               value={formatDai(market.amm?.volumeTotalUSD).full}
             />
             <ValueLabel label="APY" value={formattedApy} />
-            <OutcomesTable amm={amm} marketOutcomes={outcomes} />
+            <OutcomesTable amm={amm} marketOutcomes={outcomes} reportingState={reportingState} />
           </MarketLink>
         )}
       </div>

--- a/packages/augur-simplified/src/modules/market/market-view.tsx
+++ b/packages/augur-simplified/src/modules/market/market-view.tsx
@@ -34,6 +34,7 @@ import { AmmOutcome, MarketOutcome } from '../types';
 import { MARKETS_LIST_HEAD_TAGS } from '../seo-config';
 const { ConfirmedCheck } = Icons;
 const {
+  MARKET_STATUS,
   USDC,
   YES_NO,
   BUY,
@@ -193,9 +194,10 @@ const MarketView = ({ defaultMarket = null }) => {
           <CurrencyLabel name={amm?.cash?.name} />
         </div>
         <h1>{market.description}</h1>
-        {winningOutcomes.length > 0 && (
-          <WinningOutcomeLabel winningOutcome={winningOutcomes[0]} />
-        )}
+        {reportingState === MARKET_STATUS.FINALIZED &&
+          winningOutcomes.length > 0 && (
+            <WinningOutcomeLabel winningOutcome={winningOutcomes[0]} />
+          )}
         <ul className={Styles.StatsRow}>
           <li>
             <span>24hr Volume</span>


### PR DESCRIPTION
updated winning outcome label on market view and on market cards (in comps) to only show on finalized/resolved markets.

https://github.com/AugurProject/augur/issues/10846