### PR TITLE
fix-auto-outcome-flip

### DIFF
--- a/packages/augur-simplified/src/modules/market/trading-form.tsx
+++ b/packages/augur-simplified/src/modules/market/trading-form.tsx
@@ -200,20 +200,7 @@ const TradingForm = ({
   });
   const canEnterPosition = useCanEnterCashPosition(ammCash);
   const isApprovedTrade = isBuy ? canEnterPosition : canExitPosition;
-
   const hasLiquidity = amm.liquidity !== '0';
-
-  useEffect(() => {
-    let isMounted = true;
-    if (initialSelectedOutcome.id !== selectedOutcomeId && isMounted) {
-      setSelectedOutcome(initialSelectedOutcome);
-      setAmount('');
-    }
-    return () => {
-      isMounted = false;
-    };
-  }, [initialSelectedOutcome]);
-
   const approvalAction = !isApprovedTrade
     ? isBuy
       ? ApprovalAction.ENTER_POSITION


### PR DESCRIPTION
fixed an issue that was causing the trading form to force the user to switch back to YES after selecting NO