### PR TITLE
consolidate-required-hooks

### DIFF
--- a/packages/augur-comps/src/index.tsx
+++ b/packages/augur-comps/src/index.tsx
@@ -43,7 +43,6 @@ import * as _StoreConstants from './stores/constants';
 import * as _ProcessData from './stores/process-data';
 import { useLocalStorage } from './stores/local-storage';
 import {
-  useGraphHeartbeat,
   useCanExitCashPosition,
   useCanEnterCashPosition,
   useUserBalances,
@@ -77,7 +76,6 @@ export const Stores = {
     useAppStatusStore,
     useUserStore,
     useGraphDataStore,
-    useGraphHeartbeat,
     useCanExitCashPosition,
     useCanEnterCashPosition,
     useUserBalances,
@@ -152,7 +150,6 @@ export {
   useAppStatusStore,
   AppStatusStore,
   useLocalStorage,
-  useGraphHeartbeat,
   useUserStore,
   UserStore,
   useCanExitCashPosition,

--- a/packages/augur-comps/src/stores/app-status.tsx
+++ b/packages/augur-comps/src/stores/app-status.tsx
@@ -1,7 +1,17 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { DEFAULT_APP_STATUS_STATE, STUBBED_APP_STATUS_ACTIONS } from './constants';
 import { useAppStatus } from './app-status-hooks';
 import { useUserStore } from './user';
+import { windowRef } from '../utils/window-ref';
+
+function checkIsMobile(setIsMobile) {
+  const isMobile =
+    (
+      windowRef.getComputedStyle(document.body).getPropertyValue('--is-mobile') ||
+      ''
+    ).indexOf('true') !== -1;
+  setIsMobile(isMobile);
+}
 
 export const AppStatusContext = React.createContext({
   ...DEFAULT_APP_STATUS_STATE,
@@ -32,6 +42,15 @@ export const AppStatusProvider = ({ children }) => {
   const readableState = { ...state };
   delete readableState.actions;
   AppStatusStore.get = () => readableState;
+
+  useEffect(() => {
+    const handleResize = () => checkIsMobile(state.actions.setIsMobile);
+    windowRef.addEventListener('resize', handleResize);
+    handleResize();
+    return () => {
+      windowRef.removeEventListener('resize', handleResize);
+    };
+  }, []);
 
   return (
     <AppStatusContext.Provider value={state}>

--- a/packages/augur-comps/src/stores/graph-data.tsx
+++ b/packages/augur-comps/src/stores/graph-data.tsx
@@ -3,6 +3,8 @@ import {
   DEFAULT_GRAPH_DATA_STATE,
   STUBBED_GRAPH_DATA_ACTIONS,
 } from './constants';
+import { ApolloProvider } from 'react-apollo';
+import * as GraphClient from '../apollo/client';
 import { useGraphData } from './graph-data-hooks';
 import { processGraphMarkets } from './process-data';
 import { NETWORK_BLOCK_REFRESH_TIME, PARA_CONFIG } from './constants';
@@ -20,7 +22,7 @@ export const GraphDataStore = {
   actions: STUBBED_GRAPH_DATA_ACTIONS,
 };
 
-export const GraphDataProvider = ({ children }) => {
+export const GraphDataProvider = ({ children, client = GraphClient.client }) => {
   const state = useGraphData();
   const { loginAccount } = useUserStore();
   const library = loginAccount?.library ? loginAccount.library : null;
@@ -78,9 +80,11 @@ export const GraphDataProvider = ({ children }) => {
   }, [library]);
 
   return (
-    <GraphDataContext.Provider value={state}>
-      {children}
-    </GraphDataContext.Provider>
+    <ApolloProvider client={client}>
+      <GraphDataContext.Provider value={state}>
+        {children}
+      </GraphDataContext.Provider>
+    </ApolloProvider>
   );
 };
 

--- a/packages/augur-comps/src/stores/graph-data.tsx
+++ b/packages/augur-comps/src/stores/graph-data.tsx
@@ -21,7 +21,7 @@ export const GraphDataStore = {
   get: () => ({ ...DEFAULT_GRAPH_DATA_STATE }),
   actions: STUBBED_GRAPH_DATA_ACTIONS,
 };
-
+// default to GraphClient.client if no client is passed...
 export const GraphDataProvider = ({ children, client = GraphClient.client }) => {
   const state = useGraphData();
   const { loginAccount } = useUserStore();
@@ -41,7 +41,8 @@ export const GraphDataProvider = ({ children, client = GraphClient.client }) => 
   const readableState = { ...state };
   delete readableState.actions;
   GraphDataStore.get = () => readableState;
-  
+  // useEffect is here to keep data fresh, fetch on mount then use network 
+  // interval map to determine update cadence.
   useEffect(() => {
     let isMounted = true;
     // get data immediately, then setup interval

--- a/packages/augur-comps/src/stores/utils.ts
+++ b/packages/augur-comps/src/stores/utils.ts
@@ -4,16 +4,13 @@ import {
   isERC1155ContractApproved,
 } from './use-approval-callback';
 import { Cash, MarketInfo, TransactionDetails } from '../utils/types';
-import { NETWORK_BLOCK_REFRESH_TIME, PARA_CONFIG } from './constants';
+import { PARA_CONFIG } from './constants';
 import { ApprovalState, ETH, TX_STATUS } from '../utils/constants';
 import { useAppStatusStore } from './app-status';
 import { useUserStore } from './user';
 import { useGraphDataStore } from './graph-data';
-import { processGraphMarkets } from './process-data';
-import { getMarketsData } from '../apollo/client';
 import { augurSdkLite } from '../utils/augurlitesdk';
 import { getUserBalances } from '../utils/contract-calls';
-import { Web3Provider } from '@ethersproject/providers';
 const { APPROVED } = ApprovalState;
 
 const isAsync = (obj) =>
@@ -175,52 +172,6 @@ export function useCanEnterCashPosition({ name, address }: Cash) {
   ]);
 
   return canEnterPosition;
-}
-
-export function useGraphHeartbeat(library?: Web3Provider) {
-  const {
-    ammExchanges,
-    cashes,
-    markets,
-    blocknumber,
-    actions: { updateGraphHeartbeat },
-  } = useGraphDataStore();
-  useEffect(() => {
-    let isMounted = true;
-    // get data immediately, then setup interval
-    getMarketsData(async (graphData, block, errors) => {
-      isMounted && !!errors
-        ? updateGraphHeartbeat(
-            { ammExchanges, cashes, markets },
-            blocknumber,
-            errors
-          )
-        : updateGraphHeartbeat(
-            await processGraphMarkets(graphData, library),
-            block,
-            errors
-          );
-    });
-    const intervalId = setInterval(() => {
-      getMarketsData(async (graphData, block, errors) => {
-        isMounted && !!errors
-          ? updateGraphHeartbeat(
-              { ammExchanges, cashes, markets },
-              blocknumber,
-              errors
-            )
-          : updateGraphHeartbeat(
-              await processGraphMarkets(graphData, library),
-              block,
-              errors
-            );
-      });
-    }, NETWORK_BLOCK_REFRESH_TIME[PARA_CONFIG.networkId] || NETWORK_BLOCK_REFRESH_TIME[1]);
-    return () => {
-      isMounted = false;
-      clearInterval(intervalId);
-    };
-  }, [library]);
 }
 
 export function useUserBalances() {

--- a/packages/augur-migration/src/modules/App.tsx
+++ b/packages/augur-migration/src/modules/App.tsx
@@ -25,29 +25,6 @@ const {
   AppStatus: { AppStatusProvider, useAppStatusStore },
 } = Stores;
 
-function checkIsMobile(setIsMobile) {
-  const isMobile =
-    (
-      window.getComputedStyle(document.body).getPropertyValue('--is-mobile') ||
-      ''
-    ).indexOf('true') !== -1;
-  setIsMobile(isMobile);
-}
-
-function useHandleResize() {
-  const {
-    actions: { setIsMobile },
-  } = useAppStatusStore();
-  useEffect(() => {
-    const handleResize = () => checkIsMobile(setIsMobile);
-    window.addEventListener('resize', handleResize);
-    handleResize();
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, []);
-}
-
 const AppBody = () => {
   const { isMobile, modal } = useAppStatusStore();
   const {
@@ -59,7 +36,6 @@ const AppBody = () => {
   useUserBalances();
   useFinalizeUserTransactions();
   useUpdateApprovals();
-  useHandleResize();
   useRepMigrated();
 
   const { networkId } = PARA_CONFIG;

--- a/packages/augur-simplified/src/modules/App.tsx
+++ b/packages/augur-simplified/src/modules/App.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import { ApolloProvider } from 'react-apollo';
 import { useLocation } from 'react-router';
 import { HashRouter } from 'react-router-dom';
 import Styles from './App.styles.less';
@@ -16,7 +15,6 @@ import {
   useAppStatusStore,
   useFinalizeUserTransactions,
   useUserBalances,
-  GraphClient,
   PathUtils,
   Constants,
 } from '@augurproject/augur-comps';
@@ -92,17 +90,15 @@ function App() {
   return (
     <HashRouter hashType="hashbang">
       <ConnectAccountProvider>
-        <ApolloProvider client={GraphClient.client}>
-          <GraphDataProvider>
-            <UserProvider>
-              <AppStatusProvider>
-                <SimplifiedProvider>
-                  <AppBody />
-                </SimplifiedProvider>
-              </AppStatusProvider>
-            </UserProvider>
-          </GraphDataProvider>
-        </ApolloProvider>
+        <GraphDataProvider>
+          <UserProvider>
+            <AppStatusProvider>
+              <SimplifiedProvider>
+                <AppBody />
+              </SimplifiedProvider>
+            </AppStatusProvider>
+          </UserProvider>
+        </GraphDataProvider>
       </ConnectAccountProvider>
     </HashRouter>
   );

--- a/packages/augur-simplified/src/modules/App.tsx
+++ b/packages/augur-simplified/src/modules/App.tsx
@@ -21,29 +21,6 @@ import {
 const { MARKETS } = Constants;
 const { parsePath } = PathUtils;
 
-function checkIsMobile(setIsMobile) {
-  const isMobile =
-    (
-      window.getComputedStyle(document.body).getPropertyValue('--is-mobile') ||
-      ''
-    ).indexOf('true') !== -1;
-  setIsMobile(isMobile);
-}
-
-function useHandleResize() {
-  const {
-    actions: { setIsMobile },
-  } = useAppStatusStore();
-  useEffect(() => {
-    const handleResize = () => checkIsMobile(setIsMobile);
-    window.addEventListener('resize', handleResize);
-    handleResize();
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, []);
-}
-
 const AppBody = () => {
   const { isMobile, modal } = useAppStatusStore();
   const { sidebarType, showTradingForm } = useSimplifiedStore();
@@ -54,7 +31,6 @@ const AppBody = () => {
 
   useUserBalances();
   useFinalizeUserTransactions();
-  useHandleResize();
   usePageView();
 
   useEffect(() => {

--- a/packages/augur-simplified/src/modules/App.tsx
+++ b/packages/augur-simplified/src/modules/App.tsx
@@ -13,9 +13,7 @@ import ModalView from './modal/modal-view';
 import { usePageView } from '../utils/tracker';
 import {
   Stores,
-  useUserStore,
   useAppStatusStore,
-  useGraphHeartbeat,
   useFinalizeUserTransactions,
   useUserBalances,
   GraphClient,
@@ -51,16 +49,13 @@ function useHandleResize() {
 const AppBody = () => {
   const { isMobile, modal } = useAppStatusStore();
   const { sidebarType, showTradingForm } = useSimplifiedStore();
-  const { loginAccount } = useUserStore();
   const modalShowing = Object.keys(modal).length !== 0;
   const location = useLocation();
   const path = parsePath(location.pathname)[0];
   const sidebarOut = sidebarType && isMobile;
 
-  useGraphHeartbeat(loginAccount ? loginAccount.library : null);
   useUserBalances();
   useFinalizeUserTransactions();
-
   useHandleResize();
   usePageView();
 


### PR DESCRIPTION
Consolidate required hooks

GraphData and AppStatus shouldn't have any extra hooks to implement. just drop in the provider and graph will auto-fetch/sync, appStatus will auto track isMobile (assuming we still setup the class that adds the data to the document body under a certain media query, see shared.less) 

Will most likely follow suit with User hooks which need another hard look to determine approval tracking/transaction tracking.