### PR TITLE
fix-approval-hook

### DIFF
--- a/packages/augur-comps/src/stores/utils.ts
+++ b/packages/augur-comps/src/stores/utils.ts
@@ -319,7 +319,7 @@ export function useApprovalStatus({
       if (forceCheck.current) forceCheck.current = false;
     };
 
-    if ((forceCheck || isApproved !== APPROVED) && account) {
+    if ((forceCheck.current || isApproved !== APPROVED) && account) {
       checkIfApproved();
     }
     return () => {

--- a/packages/augur-simplified/src/modules/common/labels.tsx
+++ b/packages/augur-simplified/src/modules/common/labels.tsx
@@ -15,12 +15,12 @@ import {
   LabelComps,
 } from '@augurproject/augur-comps';
 const { CREATE, USDC, ETH, MODAL_ADD_LIQUIDITY, MARKET, ADD } = Constants;
-const { ValueLabel, IconLabel } = LabelComps;
+const { ValueLabel } = LabelComps;
 const {
   PathUtils: { parsePath },
   Formatter: { formatCash },
 } = Utils;
-const { USDCIcon, EthIcon, PlusIcon, UsdIcon } = Icons;
+const { USDCIcon, EthIcon, PlusIcon } = Icons;
 
 const handleValue = (value, cashName = USDC) =>
   formatCash(value, cashName, {


### PR DESCRIPTION
fixed an oversight that allowed for the useApproval hook to use other approval states for the current approval option. now correctly calls again whenever we change inputs that may require a new check.